### PR TITLE
Fix version parsing for CI rolling release.

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -286,7 +286,7 @@ jobs:
       - name: Resolve base version from Version.h
         id: version
         run: |
-          BASE_VERSION="$(sed -n 's/.*kVersionString\\[\\] = \"\\([^\"]*\\)\".*/\\1/p' src/Version.h | head -n 1)"
+          BASE_VERSION="$(awk -F'\"' '/kVersionString\\[\\][[:space:]]*=/ { print $2; exit }' src/Version.h)"
           if [ -z "$BASE_VERSION" ]; then
             echo "Failed to resolve kVersionString from src/Version.h" >&2
             exit 1


### PR DESCRIPTION
## Summary

CI rolling release pipeline was failing to parse the version string from the header. Switched to a more robust method.

## Scope

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

None.

## Validation

None do to the nature of the change.

## Checklist

- [-] I verified behavior manually or with tests.
- [-] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

