### PR TITLE
add truecolour option to MTTS bitmask

### DIFF
--- a/src/TelnetProcessor.cpp
+++ b/src/TelnetProcessor.cpp
@@ -1631,6 +1631,10 @@ void TelnetProcessor::sendTerminalType()
 	     32 "OSC COLOR PALETTE" Client supports the OSC color palette.
 	     64 "SCREEN READER"     Client is using a screen reader.
 	    128 "PROXY"             Client is a proxy allowing different users to connect from the same IP address.
+	    256 "TRUECOLOR"         Client supports truecolor codes using semicolon notation.
+	    512 "MNES"              Client supports the Mud New Environment Standard for information exchange.
+	   1024 "MSLP"              Client supports the Mud Server Link Protocol for clickable link handling.
+	   2048 "SSL"               Client supports SSL for data encryption, preferably TLS 1.3 or higher.
 
   */
 
@@ -1648,10 +1652,16 @@ void TelnetProcessor::sendTerminalType()
 		break;
 
 	case 2:
-		if (m_utf8)
-			strTemp = QByteArray("MTTS 13");
-		else
-			strTemp = QByteArray("MTTS 9");
+		{
+			unsigned mttsBitmask = 0;
+			mttsBitmask |= 1; // ANSI
+			mttsBitmask |= 8; // 256 colors
+			mttsBitmask |= 256; // truecolor
+			if (m_utf8)
+				mttsBitmask |= 4;
+
+			strTemp = QByteArray("MTTS ") + QByteArray::number(mttsBitmask);
+		}
 		break;
 	default:
 		break;

--- a/tests/integration/tst_TelnetProcessor_Encoding.cpp
+++ b/tests/integration/tst_TelnetProcessor_Encoding.cpp
@@ -105,7 +105,7 @@ class tst_TelnetProcessor_Encoding : public QObject
 
 			processor.processBytes(bytes({IAC, SB, TELOPT_TERMINAL_TYPE, TTYPE_SEND, IAC, SE}));
 			QCOMPARE(processor.takeOutboundData(),
-			         bytes({IAC, SB, TELOPT_TERMINAL_TYPE, TTYPE_IS, 'M', 'T', 'T', 'S', ' ', '1', '3', IAC, SE}));
+			         bytes({IAC, SB, TELOPT_TERMINAL_TYPE, TTYPE_IS, 'M', 'T', 'T', 'S', ' ', '2', '6', '9', IAC, SE}));
 		}
 	// NOLINTEND(readability-convert-member-functions-to-static)
 };


### PR DESCRIPTION
## Summary

MTTS bitmask was missing truecolour bit

## Scope

- [x] Bug fix

## Compatibility impact

No compatability impact.

## Validation

Tested bitmask manually with local CS build
Unit test updated

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

