### PR TITLE
Expose send_keep_alives to world preferences and match MUSHclient semantics.

### DIFF
--- a/src/WorldSocket.cpp
+++ b/src/WorldSocket.cpp
@@ -15,8 +15,8 @@
 #include <QNetworkProxy>
 #include <QTcpSocket>
 #if defined(Q_OS_WIN)
-#include <mstcpip.h>
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #elif defined(Q_OS_UNIX)
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -25,6 +25,25 @@
 
 namespace
 {
+#if defined(Q_OS_WIN)
+#ifndef SIO_KEEPALIVE_VALS
+#define SIO_KEEPALIVE_VALS _WSAIOW(IOC_VENDOR, 4)
+#endif
+
+	/**
+	 * @brief Windows keepalive tuning payload used with `SIO_KEEPALIVE_VALS`.
+	 *
+	 * Defined locally to avoid toolchain/header-order sensitivity between MSVC
+	 * and MinGW while keeping WinSock API-compatible field layout.
+	 */
+	struct WinTcpKeepAlive
+	{
+			u_long onoff;
+			u_long keepalivetime;
+			u_long keepaliveinterval;
+	};
+#endif
+
 	void applyMushclientKeepAliveSettings(QTcpSocket *socket, const bool enabled)
 	{
 		if (!socket)
@@ -39,7 +58,7 @@ namespace
 			return;
 
 #if defined(Q_OS_WIN)
-		tcp_keepalive keepaliveData{};
+		WinTcpKeepAlive keepaliveData{};
 		keepaliveData.onoff             = 1;
 		keepaliveData.keepalivetime     = 120000; // 2 minutes
 		keepaliveData.keepaliveinterval = 6000;   // 6 seconds

--- a/src/WorldSocket.cpp
+++ b/src/WorldSocket.cpp
@@ -14,6 +14,54 @@
 #include <QMetaObject>
 #include <QNetworkProxy>
 #include <QTcpSocket>
+#if defined(Q_OS_WIN)
+#include <mstcpip.h>
+#include <winsock2.h>
+#elif defined(Q_OS_UNIX)
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+namespace
+{
+	void applyMushclientKeepAliveSettings(QTcpSocket *socket, const bool enabled)
+	{
+		if (!socket)
+			return;
+
+		socket->setSocketOption(QAbstractSocket::KeepAliveOption, enabled ? 1 : 0);
+		if (!enabled)
+			return;
+
+		const qintptr descriptor = socket->socketDescriptor();
+		if (descriptor < 0)
+			return;
+
+#if defined(Q_OS_WIN)
+		tcp_keepalive keepaliveData{};
+		keepaliveData.onoff             = 1;
+		keepaliveData.keepalivetime     = 120000; // 2 minutes
+		keepaliveData.keepaliveinterval = 6000;   // 6 seconds
+		DWORD bytesReturned             = 0;
+		(void)WSAIoctl(static_cast<SOCKET>(descriptor), SIO_KEEPALIVE_VALS, &keepaliveData,
+		               static_cast<DWORD>(sizeof(keepaliveData)), nullptr, 0, &bytesReturned, nullptr,
+		               nullptr);
+#elif defined(Q_OS_UNIX)
+		const int     fd              = static_cast<int>(descriptor);
+		constexpr int idleSeconds     = 120;
+		constexpr int intervalSeconds = 6;
+#if defined(TCP_KEEPIDLE)
+		(void)setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idleSeconds, sizeof(idleSeconds));
+#elif defined(TCP_KEEPALIVE)
+		(void)setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &idleSeconds, sizeof(idleSeconds));
+#endif
+#if defined(TCP_KEEPINTVL)
+		(void)setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intervalSeconds, sizeof(intervalSeconds));
+#endif
+#endif
+	}
+} // namespace
 
 WorldSocket::WorldSocket(QObject *parent) : WorldSocketService(parent)
 {
@@ -40,7 +88,7 @@ void WorldSocket::setKeepAliveEnabled(bool enabled)
 {
 	m_keepAliveEnabled = enabled;
 	if (m_socket && m_socket->state() == QAbstractSocket::ConnectedState)
-		m_socket->setSocketOption(QAbstractSocket::KeepAliveOption, enabled ? 1 : 0);
+		applyMushclientKeepAliveSettings(m_socket, enabled);
 }
 
 void WorldSocket::setProxySettings(int proxyType, const QString &server, quint16 port,
@@ -91,7 +139,7 @@ bool WorldSocket::connectToHost(const QString &host, quint16 port)
 
 	if (m_socket->state() != QAbstractSocket::UnconnectedState)
 		m_socket->abort();
-	m_socket->setSocketOption(QAbstractSocket::KeepAliveOption, m_keepAliveEnabled ? 1 : 0);
+	applyMushclientKeepAliveSettings(m_socket, m_keepAliveEnabled);
 	m_socket->connectToHost(host, port);
 	return true;
 }
@@ -174,7 +222,7 @@ bool WorldSocket::adoptConnectedSocketDescriptor(const qintptr descriptor, QStri
 			*errorMessage = m_socket->errorString();
 		return false;
 	}
-	m_socket->setSocketOption(QAbstractSocket::KeepAliveOption, m_keepAliveEnabled ? 1 : 0);
+	applyMushclientKeepAliveSettings(m_socket, m_keepAliveEnabled);
 	return true;
 }
 
@@ -232,11 +280,11 @@ void WorldSocket::drainPendingReads()
 		return;
 	}
 
-	constexpr qsizetype kEmitChunkSize = 16 * 1024;
-	constexpr int kMaxChunksPerDrain = 4;
-	constexpr int kDrainBudgetMs     = 2;
-	int           emitted            = 0;
-	QElapsedTimer budget;
+	constexpr qsizetype kEmitChunkSize     = 16 * 1024;
+	constexpr int       kMaxChunksPerDrain = 4;
+	constexpr int       kDrainBudgetMs     = 2;
+	int                 emitted            = 0;
+	QElapsedTimer       budget;
 	budget.start();
 
 	while (!m_pendingInbound.isEmpty())
@@ -263,7 +311,7 @@ void WorldSocket::drainPendingReads()
 void WorldSocket::onConnected()
 {
 	if (m_socket)
-		m_socket->setSocketOption(QAbstractSocket::KeepAliveOption, m_keepAliveEnabled ? 1 : 0);
+		applyMushclientKeepAliveSettings(m_socket, m_keepAliveEnabled);
 	emit connected();
 }
 

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -1441,6 +1441,10 @@ void WorldPreferencesDialog::accept()
 			m_runtime->setWorldAttribute(QStringLiteral("convert_ga_to_newline"),
 			                             m_convertGaToNewline->isChecked() ? QStringLiteral("1")
 			                                                               : QStringLiteral("0"));
+		if (m_sendKeepAlives)
+			m_runtime->setWorldAttribute(QStringLiteral("send_keep_alives"), m_sendKeepAlives->isChecked()
+			                                                                     ? QStringLiteral("1")
+			                                                                     : QStringLiteral("0"));
 		if (m_persistOutputBuffer)
 			m_runtime->setWorldAttribute(QStringLiteral("persist_output_buffer"),
 			                             boolAttributeValue(m_persistOutputBuffer->isChecked()));
@@ -5517,6 +5521,7 @@ void WorldPreferencesDialog::buildUi()
 	m_autoCopyHtml = new QCheckBox(QStringLiteral("HTML"), outputOptionsWidget);
 	m_convertGaToNewline =
 	    new QCheckBox(QStringLiteral("Convert IAC EOR/GA to new line"), outputOptionsWidget);
+	m_sendKeepAlives = new QCheckBox(QStringLiteral("Send keep alives"), outputOptionsWidget);
 	m_persistOutputBuffer =
 	    new QCheckBox(QStringLiteral("Persist output buffer across reload/restart"), outputOptionsWidget);
 	outputOptionsLayout->addWidget(m_lineInformation);
@@ -5541,6 +5546,7 @@ void WorldPreferencesDialog::buildUi()
 	htmlLayout->addStretch();
 	outputOptionsLayout->addLayout(htmlLayout);
 	outputOptionsLayout->addWidget(m_convertGaToNewline);
+	outputOptionsLayout->addWidget(m_sendKeepAlives);
 	outputOptionsLayout->addWidget(m_persistOutputBuffer);
 	outputRight->addWidget(outputOptionsWidget);
 	if (m_copySelectionToClipboard && m_autoCopyHtml)
@@ -5548,14 +5554,12 @@ void WorldPreferencesDialog::buildUi()
 
 	auto *outputTelnetBox    = new QWidget(outputPage);
 	auto *outputTelnetLayout = new QGridLayout(outputTelnetBox);
-	auto *telnetLabel        = new QLabel(QStringLiteral("Telnet"), outputTelnetBox);
 	auto *terminalTypeLabel  = new QLabel(QStringLiteral("Terminal Type:"), outputTelnetBox);
 	terminalTypeLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	m_terminalIdentification = new QLineEdit(outputTelnetBox);
 	m_terminalIdentification->setMaxLength(20);
-	outputTelnetLayout->addWidget(telnetLabel, 0, 0, 1, 2, Qt::AlignRight);
-	outputTelnetLayout->addWidget(terminalTypeLabel, 1, 0);
-	outputTelnetLayout->addWidget(m_terminalIdentification, 1, 1);
+	outputTelnetLayout->addWidget(terminalTypeLabel, 0, 0);
+	outputTelnetLayout->addWidget(m_terminalIdentification, 0, 1);
 	outputTelnetLayout->setColumnStretch(1, 1);
 	outputRight->addStretch();
 	outputRight->addWidget(outputTelnetBox);
@@ -9345,6 +9349,8 @@ void WorldPreferencesDialog::populateOutput()
 	if (m_convertGaToNewline)
 		m_convertGaToNewline->setChecked(
 		    qmudIsEnabledFlag(attrs.value(QStringLiteral("convert_ga_to_newline"))));
+	if (m_sendKeepAlives)
+		m_sendKeepAlives->setChecked(qmudIsEnabledFlag(attrs.value(QStringLiteral("send_keep_alives"))));
 	if (m_persistOutputBuffer)
 		m_persistOutputBuffer->setChecked(
 		    qmudIsEnabledFlag(attrs.value(QStringLiteral("persist_output_buffer"))));

--- a/src/dialogs/WorldPreferencesDialog.h
+++ b/src/dialogs/WorldPreferencesDialog.h
@@ -556,6 +556,7 @@ class WorldPreferencesDialog : public QDialog
 		QCheckBox                    *m_utf8{nullptr};
 		QCheckBox                    *m_carriageReturnClearsLine{nullptr};
 		QCheckBox                    *m_convertGaToNewline{nullptr};
+		QCheckBox                    *m_sendKeepAlives{nullptr};
 		QCheckBox                    *m_persistOutputBuffer{nullptr};
 		QSpinBox                     *m_fadeOutputBufferAfterSeconds{nullptr};
 		QSpinBox                     *m_fadeOutputOpacityPercent{nullptr};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -384,6 +384,18 @@ qmud_add_qtest(tst_ReloadRecoveryUtils
         TIMEOUT
         20)
 
+qmud_add_qtest(tst_WorldSocket_KeepAlive
+        SOURCES
+        integration/tst_WorldSocket_KeepAlive.cpp
+        "${CMAKE_SOURCE_DIR}/src/WorldSocketService.h"
+        "${CMAKE_SOURCE_DIR}/src/WorldSocket.cpp"
+        LIBRARIES
+        Qt6::Network
+        LABELS
+        integration
+        TIMEOUT
+        20)
+
 qmud_add_qtest(tst_WorldDocument_Load
         SOURCES
         integration/tst_WorldDocument_Load.cpp

--- a/tests/integration/tst_WorldSocket_KeepAlive.cpp
+++ b/tests/integration/tst_WorldSocket_KeepAlive.cpp
@@ -135,7 +135,7 @@ class tst_WorldSocket_KeepAlive : public QObject
 		// NOLINTEND(readability-convert-member-functions-to-static)
 };
 
-QTEST_APPLESS_MAIN(tst_WorldSocket_KeepAlive)
+QTEST_GUILESS_MAIN(tst_WorldSocket_KeepAlive)
 
 #if __has_include("tst_WorldSocket_KeepAlive.moc")
 #include "tst_WorldSocket_KeepAlive.moc"

--- a/tests/integration/tst_WorldSocket_KeepAlive.cpp
+++ b/tests/integration/tst_WorldSocket_KeepAlive.cpp
@@ -6,6 +6,7 @@
  * Role: Integration coverage for world socket keepalive behavior and OS-level tuning.
  */
 
+#include "WorldOptions.h"
 #include "WorldSocket.h"
 
 #include <QTcpServer>
@@ -70,6 +71,7 @@ class tst_WorldSocket_KeepAlive : public QObject
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldSocket socket;
+			socket.setProxySettings(eProxyServerNone, QString(), 0, QString(), QString());
 			socket.setKeepAliveEnabled(true);
 
 			QSignalSpy connectedSpy(&socket, &WorldSocket::connected);
@@ -102,6 +104,7 @@ class tst_WorldSocket_KeepAlive : public QObject
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldSocket socket;
+			socket.setProxySettings(eProxyServerNone, QString(), 0, QString(), QString());
 			socket.setKeepAliveEnabled(true);
 
 			QSignalSpy connectedSpy(&socket, &WorldSocket::connected);

--- a/tests/integration/tst_WorldSocket_KeepAlive.cpp
+++ b/tests/integration/tst_WorldSocket_KeepAlive.cpp
@@ -1,0 +1,142 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_WorldSocket_KeepAlive.cpp
+ * Role: Integration coverage for world socket keepalive behavior and OS-level tuning.
+ */
+
+#include "WorldSocket.h"
+
+#include <QTcpServer>
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#if defined(Q_OS_WIN)
+#include <winsock2.h>
+#elif defined(Q_OS_UNIX)
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+namespace
+{
+	/**
+	 * @brief Reads an integer socket option value from a native descriptor.
+	 * @param descriptor Native socket descriptor.
+	 * @param level Socket option protocol level.
+	 * @param option Socket option name.
+	 * @param value Receives option value on success.
+	 * @return `true` when option read succeeds.
+	 */
+	bool readSocketIntOption(const qintptr descriptor, const int level, const int option, int &value)
+	{
+#if defined(Q_OS_WIN)
+		int  size = sizeof(value);
+		auto rc   = ::getsockopt(static_cast<SOCKET>(descriptor), level, option,
+		                         reinterpret_cast<char *>(&value), &size);
+		return rc == 0 && size == static_cast<int>(sizeof(value));
+#elif defined(Q_OS_UNIX)
+		socklen_t size = sizeof(value);
+		auto      rc   = ::getsockopt(static_cast<int>(descriptor), level, option, &value, &size);
+		return rc == 0 && size == static_cast<socklen_t>(sizeof(value));
+#else
+		Q_UNUSED(descriptor);
+		Q_UNUSED(level);
+		Q_UNUSED(option);
+		Q_UNUSED(value);
+		return false;
+#endif
+	}
+} // namespace
+
+/**
+ * @brief QTest fixture covering `WorldSocket` keepalive behavior.
+ */
+class tst_WorldSocket_KeepAlive : public QObject
+{
+		Q_OBJECT
+
+		// NOLINTBEGIN(readability-convert-member-functions-to-static)
+	private slots:
+		/**
+		 * @brief Verifies keepalive enable/disable updates the live socket option.
+		 */
+		void togglesKeepAliveOnConnectedSocket()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::AnyIPv4, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldSocket socket;
+			socket.setKeepAliveEnabled(true);
+
+			QSignalSpy connectedSpy(&socket, &WorldSocket::connected);
+			QVERIFY(socket.connectToHost(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QVERIFY(server.waitForNewConnection(5000));
+
+			const qintptr descriptor = socket.nativeSocketDescriptor();
+			QVERIFY(descriptor >= 0);
+
+			int keepAliveValue = 0;
+			QVERIFY(readSocketIntOption(descriptor, SOL_SOCKET, SO_KEEPALIVE, keepAliveValue));
+			QCOMPARE(keepAliveValue, 1);
+
+			socket.setKeepAliveEnabled(false);
+			keepAliveValue = 1;
+			QVERIFY(readSocketIntOption(descriptor, SOL_SOCKET, SO_KEEPALIVE, keepAliveValue));
+			QCOMPARE(keepAliveValue, 0);
+
+			socket.abortSocket();
+		}
+
+		/**
+		 * @brief Verifies MUSHclient-parity keepalive timings where platform supports querying them.
+		 */
+		void appliesMushclientParityKeepAliveTimings()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::AnyIPv4, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldSocket socket;
+			socket.setKeepAliveEnabled(true);
+
+			QSignalSpy connectedSpy(&socket, &WorldSocket::connected);
+			QVERIFY(socket.connectToHost(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QVERIFY(server.waitForNewConnection(5000));
+
+			const qintptr descriptor = socket.nativeSocketDescriptor();
+			QVERIFY(descriptor >= 0);
+
+#if defined(TCP_KEEPIDLE)
+			int idleSeconds = 0;
+			QVERIFY(readSocketIntOption(descriptor, IPPROTO_TCP, TCP_KEEPIDLE, idleSeconds));
+			QCOMPARE(idleSeconds, 120);
+#elif defined(TCP_KEEPALIVE)
+			int idleSeconds = 0;
+			QVERIFY(readSocketIntOption(descriptor, IPPROTO_TCP, TCP_KEEPALIVE, idleSeconds));
+			QCOMPARE(idleSeconds, 120);
+#else
+			QSKIP("TCP keepalive idle tuning option is not available on this platform.");
+#endif
+
+#if defined(TCP_KEEPINTVL)
+			int intervalSeconds = 0;
+			QVERIFY(readSocketIntOption(descriptor, IPPROTO_TCP, TCP_KEEPINTVL, intervalSeconds));
+			QCOMPARE(intervalSeconds, 6);
+#endif
+
+			socket.abortSocket();
+		}
+		// NOLINTEND(readability-convert-member-functions-to-static)
+};
+
+QTEST_APPLESS_MAIN(tst_WorldSocket_KeepAlive)
+
+#if __has_include("tst_WorldSocket_KeepAlive.moc")
+#include "tst_WorldSocket_KeepAlive.moc"
+#endif

--- a/tests/integration/tst_WorldSocket_KeepAlive.cpp
+++ b/tests/integration/tst_WorldSocket_KeepAlive.cpp
@@ -67,17 +67,22 @@ class tst_WorldSocket_KeepAlive : public QObject
 		void togglesKeepAliveOnConnectedSocket()
 		{
 			QTcpServer server;
-			if (!server.listen(QHostAddress::AnyIPv4, 0))
+			if (!server.listen(QHostAddress::LocalHost, 0))
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldSocket socket;
 			socket.setProxySettings(eProxyServerNone, QString(), 0, QString(), QString());
 			socket.setKeepAliveEnabled(true);
 
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
 			QSignalSpy connectedSpy(&socket, &WorldSocket::connected);
 			QVERIFY(socket.connectToHost(QStringLiteral("127.0.0.1"), server.serverPort()));
 			QVERIFY(connectedSpy.wait(5000));
-			QVERIFY(server.waitForNewConnection(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QVERIFY(server.hasPendingConnections());
+			if (QTcpSocket *accepted = server.nextPendingConnection())
+				accepted->deleteLater();
 
 			const qintptr descriptor = socket.nativeSocketDescriptor();
 			QVERIFY(descriptor >= 0);
@@ -100,17 +105,22 @@ class tst_WorldSocket_KeepAlive : public QObject
 		void appliesMushclientParityKeepAliveTimings()
 		{
 			QTcpServer server;
-			if (!server.listen(QHostAddress::AnyIPv4, 0))
+			if (!server.listen(QHostAddress::LocalHost, 0))
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldSocket socket;
 			socket.setProxySettings(eProxyServerNone, QString(), 0, QString(), QString());
 			socket.setKeepAliveEnabled(true);
 
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
 			QSignalSpy connectedSpy(&socket, &WorldSocket::connected);
 			QVERIFY(socket.connectToHost(QStringLiteral("127.0.0.1"), server.serverPort()));
 			QVERIFY(connectedSpy.wait(5000));
-			QVERIFY(server.waitForNewConnection(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QVERIFY(server.hasPendingConnections());
+			if (QTcpSocket *accepted = server.nextPendingConnection())
+				accepted->deleteLater();
 
 			const qintptr descriptor = socket.nativeSocketDescriptor();
 			QVERIFY(descriptor >= 0);

--- a/tests/unit/tst_WorldOptions.cpp
+++ b/tests/unit/tst_WorldOptions.cpp
@@ -60,6 +60,16 @@ class tst_WorldOptions : public QObject
 			QCOMPARE(opt->maxValue, 0LL);
 		}
 
+		void sendKeepAlivesOptionIsBooleanAndDefaultOff()
+		{
+			const WorldNumericOption *opt =
+			    QMudWorldOptions::findWorldNumericOption(QStringLiteral("send_keep_alives"));
+			QVERIFY(opt != nullptr);
+			QCOMPARE(opt->defaultValue, 0LL);
+			QCOMPARE(opt->minValue, 0LL);
+			QCOMPARE(opt->maxValue, 0LL);
+		}
+
 		void findUnknownReturnsNull()
 		{
 			QCOMPARE(QMudWorldOptions::findWorldNumericOption(QStringLiteral("not_an_option")),


### PR DESCRIPTION
## Summary

- Expose send_keep_alives to world preferences and match MUSHclient semantics.

## Scope

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

Increase MUSHclient compatibility.

## Validation

Tests, manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

