### PR TITLE
Command history dedup and tighten partial recall. Selection has priority on right click context menu. Tab autocompletion skips seen. Line tooltips now do not show up on empty space.  Announce tagged releases to discord.

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -1024,6 +1024,64 @@ jobs:
             release-assets/qmud-windows/*.zip
             release-assets/qmud-windows/*.exe
 
+      - name: Announce tagged release on Discord
+        env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          RELEASE_NOTES_PATH: ${{ steps.release_changelog.outputs.body_path }}
+        run: |
+          if [ -z "${DISCORD_RELEASE_WEBHOOK_URL}" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK_URL is not set." >&2
+            exit 1
+          fi
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          webhook = os.environ["DISCORD_RELEASE_WEBHOOK_URL"].strip()
+          notes_path = os.environ["RELEASE_NOTES_PATH"].strip()
+          repo = os.environ["GITHUB_REPOSITORY"]
+          tag = os.environ["GITHUB_REF_NAME"]
+          release_url = f"https://github.com/{repo}/releases/tag/{tag}"
+
+          def post_message(content: str) -> None:
+              payload = json.dumps({"content": content}).encode("utf-8")
+              request = urllib.request.Request(
+                  webhook,
+                  data=payload,
+                  headers={
+                      "Content-Type": "application/json",
+                      "User-Agent": "qmud-release-discord",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=20):
+                  pass
+
+          with open(notes_path, "r", encoding="utf-8") as fh:
+              notes = fh.read()
+          notes = notes.strip()
+          if not notes:
+              notes = "(No release notes.)"
+
+          combined_message = f"QMud {tag} released: {release_url}\n\n{notes}"
+
+          max_len = 2000
+          chunks = []
+          remaining = combined_message
+          while remaining:
+              if len(remaining) <= max_len:
+                  chunks.append(remaining)
+                  break
+              split_index = remaining.rfind("\n", 0, max_len)
+              if split_index <= 0:
+                  split_index = max_len
+              chunks.append(remaining[:split_index])
+              remaining = remaining[split_index:]
+
+          for chunk in chunks:
+              post_message(chunk)
+          PY
+
       - name: Cleanup workspace build directories
         if: always()
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif ()
 
 option(QMUD_ENABLE_LUA_SCRIPTING "Enable Lua scripting callbacks" ON)
 option(QMUD_ENABLE_TESTING "Enable QMud QtTest/CTest targets" ON)
-option(QMUD_ENABLE_GUI_TESTS "Enable GUI-focused QtTest suites" OFF)
+option(QMUD_ENABLE_GUI_TESTS "Enable GUI-focused QtTest suites" ON)
 option(QMUD_CI_BUILD "Mark runtime display version as CI build (-ci suffix)" OFF)
 option(QMUD_RELEASE_NATIVE_OPTIMIZATIONS "Tune Release builds for the local CPU (-march=native or /arch:AVX2)" OFF)
 set(QMUD_SYSTEM_LUA_MODULES_PREFIX "" CACHE PATH

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1614,8 +1614,9 @@ bool WorldView::showWorldContextMenuAtGlobalPos(const QPoint &globalPos)
 	QString              hint;
 	NativeOutputPosition hit;
 	(void)nativeOutputHitTest(source, sourcePos, hit, &href, &hint);
-	const QVector<QPair<QString, QString>> actions = parseMxpContextMenuActions(href, hint);
-	if (!actions.isEmpty())
+	const QVector<QPair<QString, QString>> actions      = parseMxpContextMenuActions(href, hint);
+	const bool                             hasSelection = hasOutputSelection();
+	if (!hasSelection && !actions.isEmpty())
 	{
 		menu = new QMenu(source);
 		for (int i = 0; i < actions.size(); ++i)
@@ -1633,12 +1634,12 @@ bool WorldView::showWorldContextMenuAtGlobalPos(const QPoint &globalPos)
 		menu = new QMenu(source);
 		if (QAction *copy = menu->addAction(QStringLiteral("Copy")); copy)
 		{
-			copy->setEnabled(hasOutputSelection());
+			copy->setEnabled(hasSelection);
 			connect(copy, &QAction::triggered, this, [this] { copySelection(); });
 		}
 		if (QAction *copyHtml = menu->addAction(QStringLiteral("Copy as HTML")); copyHtml)
 		{
-			copyHtml->setEnabled(hasOutputSelection());
+			copyHtml->setEnabled(hasSelection);
 			connect(copyHtml, &QAction::triggered, this, [this] { copySelectionAsHtml(); });
 		}
 	}

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -9544,10 +9544,12 @@ void WorldView::resetTabCompletionCycle()
 	m_tabCompletionCycleEndColumn   = -1;
 	m_tabCompletionCycleLastSource  = -2;
 	m_tabCompletionCycleActive      = false;
+	m_tabCompletionCycleSeenCompletions.clear();
 }
 
 bool WorldView::tabCompleteOneLine(int startColumn, int endColumn, const QString &targetWordLower,
-                                   const QString &line, bool insertSpace)
+                                   const QString &line, bool insertSpace, QString *appliedCompletion,
+                                   const QSet<QString> *skipCanonicalCompletions)
 {
 	if (!m_input || targetWordLower.isEmpty() || line.isEmpty())
 		return false;
@@ -9589,6 +9591,14 @@ bool WorldView::tabCompleteOneLine(int startColumn, int endColumn, const QString
 			QString replacement = line.mid(i, replacementLength);
 			if (m_lowerCaseTabCompletion)
 				replacement = replacement.toLower();
+			const QString canonicalCompletion = replacement.toCaseFolded();
+			if (skipCanonicalCompletions && skipCanonicalCompletions->contains(canonicalCompletion))
+			{
+				i = end;
+				continue;
+			}
+			if (appliedCompletion)
+				*appliedCompletion = replacement;
 			if (m_runtime)
 				m_runtime->firePluginTabComplete(replacement);
 			if (insertSpace)
@@ -9657,6 +9667,7 @@ bool WorldView::handleTabCompletionKeyPress()
 	}
 	else
 	{
+		m_tabCompletionCycleSeenCompletions.clear();
 		if (endColumn <= 0 || endColumn > currentText.size())
 		{
 			resetTabCompletionCycle();
@@ -9693,11 +9704,13 @@ bool WorldView::handleTabCompletionKeyPress()
 			insertSpace = true;
 	}
 
-	bool completionApplied = false;
-	int  matchedSource     = -2;
+	bool    completionApplied = false;
+	int     matchedSource     = -2;
+	QString matchedCompletion;
 
 	if (!continueCycle &&
-	    tabCompleteOneLine(startColumn, endColumn, targetWordLower, m_tabCompletionDefaults, insertSpace))
+	    tabCompleteOneLine(startColumn, endColumn, targetWordLower, m_tabCompletionDefaults, insertSpace,
+	                       &matchedCompletion, &m_tabCompletionCycleSeenCompletions))
 	{
 		completionApplied = true;
 		matchedSource     = -1;
@@ -9726,7 +9739,8 @@ bool WorldView::handleTabCompletionKeyPress()
 		{
 			if (++scanned > m_tabCompletionLines)
 				break;
-			if (!tabCompleteOneLine(startColumn, endColumn, targetWordLower, lines.at(i).text, insertSpace))
+			if (!tabCompleteOneLine(startColumn, endColumn, targetWordLower, lines.at(i).text, insertSpace,
+			                        &matchedCompletion, &m_tabCompletionCycleSeenCompletions))
 				continue;
 			completionApplied = true;
 			matchedSource     = i;
@@ -9740,7 +9754,9 @@ bool WorldView::handleTabCompletionKeyPress()
 		return false;
 	}
 
-	cursor                          = m_input->textCursor();
+	cursor = m_input->textCursor();
+	if (!matchedCompletion.isEmpty())
+		m_tabCompletionCycleSeenCompletions.insert(matchedCompletion.toCaseFolded());
 	m_tabCompletionCycleTargetLower = targetWordLower;
 	m_tabCompletionCycleStartColumn = startColumn;
 	m_tabCompletionCycleEndColumn   = cursor.position();

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -3597,13 +3597,16 @@ bool WorldView::nativeOutputInteractionActive() const
 
 bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &viewPos,
                                     NativeOutputPosition &position, QString *href, QString *hint,
-                                    const bool allowCacheBuild) const
+                                    const bool allowCacheBuild, const bool requireTextHit,
+                                    bool *const textHit) const
 {
 	position = {};
 	if (href)
 		href->clear();
 	if (hint)
 		hint->clear();
+	if (textHit)
+		*textHit = false;
 	if (!nativeOutputInteractionActive() || !view || !view->viewport())
 		return false;
 
@@ -3672,6 +3675,8 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	const NativeOutputRenderLine &line = lines.at(lineIndex);
 	if (line.text.isEmpty())
 	{
+		if (requireTextHit)
+			return false;
 		position = {lineIndex, 0};
 		return true;
 	}
@@ -3679,6 +3684,8 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	const QTextLayout *layout = nativeLayoutForLine(lineIndex);
 	if (!layout || layout->lineCount() <= 0)
 	{
+		if (requireTextHit)
+			return false;
 		position = {lineIndex, 0};
 		return true;
 	}
@@ -3689,6 +3696,8 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	QTextLine   targetRow = layout->lineAt(0);
 	if (!targetRow.isValid())
 	{
+		if (requireTextHit)
+			return false;
 		position = {lineIndex, 0};
 		return true;
 	}
@@ -3704,21 +3713,26 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 		}
 	}
 
-	const int   rowStartColumn = targetRow.textStart();
-	const int   rowEndColumn   = rowStartColumn + targetRow.textLength();
-	const qreal rowLeft        = targetRow.cursorToX(rowStartColumn);
-	const qreal rowRight       = targetRow.cursorToX(rowEndColumn);
-	const qreal minX           = qMin(rowLeft, rowRight);
-	const qreal maxX           = qMax(rowLeft, rowRight);
-	const bool  insideTextRow  = static_cast<qreal>(x) >= minX && static_cast<qreal>(x) < maxX;
+	const int   rowStartColumn  = targetRow.textStart();
+	const int   rowEndColumn    = rowStartColumn + targetRow.textLength();
+	const qreal rowLeft         = targetRow.cursorToX(rowStartColumn);
+	const qreal rowRight        = targetRow.cursorToX(rowEndColumn);
+	const qreal minX            = qMin(rowLeft, rowRight);
+	const qreal maxX            = qMax(rowLeft, rowRight);
+	const bool  insideTextRow   = static_cast<qreal>(x) >= minX && static_cast<qreal>(x) < maxX;
+	const bool  resolvedTextHit = insideTextRow && rowEndColumn > rowStartColumn;
+	if (textHit)
+		*textHit = resolvedTextHit;
+	if (requireTextHit && !resolvedTextHit)
+		return false;
 
-	int         column = targetRow.xToCursor(static_cast<qreal>(x), QTextLine::CursorBetweenCharacters);
-	column             = qBound(rowStartColumn, column, rowEndColumn);
-	position           = {lineIndex, column};
+	int column = targetRow.xToCursor(static_cast<qreal>(x), QTextLine::CursorBetweenCharacters);
+	column     = qBound(rowStartColumn, column, rowEndColumn);
+	position   = {lineIndex, column};
 
 	if (href || hint)
 	{
-		if (!insideTextRow || rowEndColumn <= rowStartColumn)
+		if (!resolvedTextHit)
 			return true;
 
 		const int textSize = sizeToInt(line.text.size());
@@ -3781,7 +3795,7 @@ bool WorldView::nativeOutputHitTestGlobal(const QPoint &globalPos, WrapTextBrows
 bool WorldView::nativeOutputHitTestForMouseEvent(const QWidget *watched, const QMouseEvent *event,
                                                  WrapTextBrowser *&view, QPoint &viewPos,
                                                  NativeOutputPosition &position, QString *href, QString *hint,
-                                                 const bool allowCacheBuild) const
+                                                 const bool allowCacheBuild, bool *const textHit) const
 {
 	view     = nullptr;
 	viewPos  = {};
@@ -3790,6 +3804,8 @@ bool WorldView::nativeOutputHitTestForMouseEvent(const QWidget *watched, const Q
 		href->clear();
 	if (hint)
 		hint->clear();
+	if (textHit)
+		*textHit = false;
 	if (!watched || !event || !nativeOutputInteractionActive())
 		return false;
 
@@ -3809,7 +3825,7 @@ bool WorldView::nativeOutputHitTestForMouseEvent(const QWidget *watched, const Q
 
 	if (!view->viewport()->rect().contains(viewPos))
 		return false;
-	return nativeOutputHitTest(view, viewPos, position, href, hint, allowCacheBuild);
+	return nativeOutputHitTest(view, viewPos, position, href, hint, allowCacheBuild, false, textHit);
 }
 
 void WorldView::applyResolvedOutputSelection(const bool hasSelection, const int startLine,
@@ -8007,7 +8023,7 @@ void WorldView::updateLineInformationTooltip(const QWidget *watched, const QMous
                                              const WrapTextBrowser      *precomputedView,
                                              const QPoint               *precomputedPosInView,
                                              const NativeOutputPosition *precomputedHit,
-                                             const bool                  allowCacheBuild)
+                                             const bool *precomputedTextHit, const bool allowCacheBuild)
 {
 	auto hideLineInfoTooltip = [this]
 	{
@@ -8027,10 +8043,19 @@ void WorldView::updateLineInformationTooltip(const QWidget *watched, const QMous
 
 	WrapTextBrowser     *view = nullptr;
 	NativeOutputPosition hit;
+	bool                 textHit = false;
 	if (precomputedView && precomputedPosInView && precomputedHit)
 	{
 		view = const_cast<WrapTextBrowser *>(precomputedView);
 		hit  = *precomputedHit;
+		if (precomputedTextHit)
+			textHit = *precomputedTextHit;
+		else if (!nativeOutputHitTest(view, *precomputedPosInView, hit, nullptr, nullptr, allowCacheBuild,
+		                              false, &textHit))
+		{
+			hideLineInfoTooltip();
+			return;
+		}
 	}
 	else
 	{
@@ -8048,11 +8073,16 @@ void WorldView::updateLineInformationTooltip(const QWidget *watched, const QMous
 			posInView = event->position().toPoint();
 		else
 			posInView = view->viewport()->mapFromGlobal(event->globalPosition().toPoint());
-		if (!nativeOutputHitTest(view, posInView, hit, nullptr, nullptr, allowCacheBuild))
+		if (!nativeOutputHitTest(view, posInView, hit, nullptr, nullptr, allowCacheBuild, false, &textHit))
 		{
 			hideLineInfoTooltip();
 			return;
 		}
+	}
+	if (!textHit)
+	{
+		hideLineInfoTooltip();
+		return;
 	}
 
 	const QVector<NativeOutputRenderLine> &renderLines = nativeOutputRenderLines();
@@ -8308,6 +8338,7 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 		WrapTextBrowser     *mouseMoveHitView      = nullptr;
 		QPoint               mouseMoveHitPosInView;
 		NativeOutputPosition mouseMoveHit;
+		bool                 mouseMoveTextHit = false;
 
 		if (event->type() == QEvent::MouseMove)
 		{
@@ -8316,7 +8347,7 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 				QString mouseMoveHref;
 				if (nativeOutputHitTestForMouseEvent(watchedWidget, mouseEvent, mouseMoveHitView,
 				                                     mouseMoveHitPosInView, mouseMoveHit, &mouseMoveHref,
-				                                     nullptr, false))
+				                                     nullptr, false, &mouseMoveTextHit))
 				{
 					hasMouseMoveNativeHit = true;
 					applyHoveredHyperlink(mouseMoveHref);
@@ -8391,7 +8422,8 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 				updateLineInformationTooltip(watchedWidget, mouseEvent,
 				                             hasMouseMoveNativeHit ? mouseMoveHitView : nullptr,
 				                             hasMouseMoveNativeHit ? &mouseMoveHitPosInView : nullptr,
-				                             hasMouseMoveNativeHit ? &mouseMoveHit : nullptr, false);
+				                             hasMouseMoveNativeHit ? &mouseMoveHit : nullptr,
+				                             hasMouseMoveNativeHit ? &mouseMoveTextHit : nullptr, false);
 			}
 		}
 

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -81,6 +81,16 @@ namespace
 		return static_cast<int>(qBound(kMin, value, kMax));
 	}
 
+	void appendDeduplicatedHistoryEntry(QVector<QString> &history, const QString &entry,
+	                                    const int historyLimit)
+	{
+		const auto newEnd = std::ranges::remove(history, entry).begin();
+		history.erase(newEnd, history.end());
+		history.append(entry);
+		if (historyLimit > 0 && history.size() > historyLimit)
+			history.remove(0, history.size() - historyLimit);
+	}
+
 	bool styleSpansEquivalent(const WorldRuntime::StyleSpan &lhs, const WorldRuntime::StyleSpan &rhs)
 	{
 		return lhs.length == rhs.length && lhs.fore == rhs.fore && lhs.back == rhs.back &&
@@ -8833,9 +8843,7 @@ void WorldView::addToHistory(const QString &text)
 	if (text == m_lastCommand)
 		return;
 
-	m_history.append(text);
-	if (m_history.size() > m_historyLimit)
-		m_history.remove(0, m_history.size() - m_historyLimit);
+	appendDeduplicatedHistoryEntry(m_history, text, m_historyLimit);
 	m_lastCommand = text;
 }
 
@@ -9408,7 +9416,7 @@ void WorldView::recallPartialHistory(int direction)
 	if (m_inputChanged)
 	{
 		m_partialCommand = m_input->toPlainText();
-		m_partialIndex   = (direction < 0) ? sizeToInt(m_history.size()) : -1;
+		m_partialIndex   = sizeToInt(m_history.size());
 	}
 
 	if (m_partialCommand.isEmpty())
@@ -9417,13 +9425,12 @@ void WorldView::recallPartialHistory(int direction)
 		return;
 	}
 
-	const qsizetype partialLen = m_partialCommand.size();
-	const auto      findMatch  = [&](const bool requireBoundaryAfterPrefix) -> int
+	const auto findMatch = [&](const int step) -> int
 	{
 		int index = m_partialIndex;
 		while (true)
 		{
-			index += (direction < 0) ? -1 : 1;
+			index += step;
 			if (index < 0 || index >= m_history.size())
 				return -1;
 
@@ -9432,21 +9439,12 @@ void WorldView::recallPartialHistory(int direction)
 				continue;
 			if (candidate.compare(m_partialCommand, Qt::CaseInsensitive) == 0)
 				continue;
-
-			if (!requireBoundaryAfterPrefix)
-				return index;
-
-			if (candidate.size() == partialLen)
-				return index;
-			const QChar nextChar = candidate.at(partialLen);
-			if (nextChar.isSpace())
-				return index;
+			return index;
 		}
 	};
 
-	int index = findMatch(true);
-	if (index < 0)
-		index = findMatch(false);
+	const bool preferNewest = (direction < 0) || (m_partialIndex >= m_history.size());
+	int        index        = preferNewest ? findMatch(-1) : findMatch(1);
 	if (index < 0)
 	{
 		if (confirmReplaceTyping(QString()))

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -642,10 +642,13 @@ class WorldView : public QWidget
 		 * @param targetWordLower Lowercased target word.
 		 * @param line Source line text.
 		 * @param insertSpace Insert trailing space after completion when `true`.
+		 * @param appliedCompletion Receives inserted completion token when non-null.
+		 * @param skipCanonicalCompletions Canonical completion tokens to skip when non-null.
 		 * @return `true` when completion changed the line.
 		 */
 		bool tabCompleteOneLine(int startColumn, int endColumn, const QString &targetWordLower,
-		                        const QString &line, bool insertSpace);
+		                        const QString &line, bool insertSpace, QString *appliedCompletion,
+		                        const QSet<QString> *skipCanonicalCompletions);
 		/**
 		 * @brief Applies default command-input height policy.
 		 * @param setSplitterSizes Apply splitter sizing when `true`.
@@ -1455,6 +1458,7 @@ class WorldView : public QWidget
 		int                                          m_tabCompletionCycleEndColumn{-1};
 		int                                          m_tabCompletionCycleLastSource{-2};
 		bool                                         m_tabCompletionCycleActive{false};
+		QSet<QString>                                m_tabCompletionCycleSeenCompletions;
 		int                                          m_fadeOutputBufferAfterSeconds{0};
 		int                                          m_fadeOutputOpacityPercent{100};
 		int                                          m_fadeOutputSeconds{1};

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -1009,11 +1009,14 @@ class WorldView : public QWidget
 		 * @param href Optional hyperlink href at hit point.
 		 * @param hint Optional hyperlink hint at hit point.
 		 * @param allowCacheBuild `true` to rebuild layout caches on demand, `false` to query only when cache is ready.
+		 * @param requireTextHit `true` to require the point to fall inside rendered text glyph bounds.
+		 * @param textHit Optional output set to `true` when the point is over rendered text glyph bounds.
 		 * @return `true` when hit maps inside the rendered output surface.
 		 */
 		[[nodiscard]] bool nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &viewPos,
 		                                       NativeOutputPosition &position, QString *href = nullptr,
-		                                       QString *hint = nullptr, bool allowCacheBuild = true) const;
+		                                       QString *hint = nullptr, bool allowCacheBuild = true,
+		                                       bool requireTextHit = false, bool *textHit = nullptr) const;
 		/**
 		 * @brief Resolves native-output hit-test information for a mouse event source widget.
 		 * @param watched Event source widget from the installed event filter.
@@ -1024,13 +1027,15 @@ class WorldView : public QWidget
 		 * @param href Optional hyperlink href at hit point.
 		 * @param hint Optional hyperlink hint at hit point.
 		 * @param allowCacheBuild `true` to rebuild layout caches on demand, `false` to query only when cache is ready.
+		 * @param textHit Optional output set to `true` when the event point is over rendered text glyph bounds.
 		 * @return `true` when event position maps to native output text.
 		 */
 		[[nodiscard]] bool nativeOutputHitTestForMouseEvent(const QWidget *watched, const QMouseEvent *event,
 		                                                    WrapTextBrowser *&view, QPoint &viewPos,
 		                                                    NativeOutputPosition &position,
 		                                                    QString *href = nullptr, QString *hint = nullptr,
-		                                                    bool allowCacheBuild = true) const;
+		                                                    bool  allowCacheBuild = true,
+		                                                    bool *textHit         = nullptr) const;
 		/**
 		 * @brief Hit-tests a global point against visible native output panes.
 		 * @param globalPos Global screen coordinate.
@@ -1250,12 +1255,14 @@ class WorldView : public QWidget
 		 * @param precomputedView Optional resolved output view for the hit-test.
 		 * @param precomputedPosInView Optional viewport-local position for @p precomputedView.
 		 * @param precomputedHit Optional precomputed native-output hit position.
+		 * @param precomputedTextHit Optional precomputed text-hit state for @p precomputedHit.
 		 * @param allowCacheBuild `true` to rebuild layout caches on demand, `false` to query only when cache is ready.
 		 */
 		void                 updateLineInformationTooltip(const QWidget *watched, const QMouseEvent *event,
 		                                                  const WrapTextBrowser      *precomputedView = nullptr,
 		                                                  const QPoint               *precomputedPosInView = nullptr,
 		                                                  const NativeOutputPosition *precomputedHit = nullptr,
+		                                                  const bool                 *precomputedTextHit = nullptr,
 		                                                  bool                        allowCacheBuild = true);
 		/**
 		 * @brief Computes line fade opacity for timestamp.

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -108,7 +108,7 @@ class WorldView : public QWidget
 		 */
 		void                        addHyperlinkToHistory(const QString &text);
 		/**
-		 * @brief Adds history entry bypassing duplicate checks.
+		 * @brief Adds history entry bypassing no-echo filtering.
 		 * @param text Command text to append.
 		 */
 		void                        addToHistoryForced(const QString &text);

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -4681,7 +4681,7 @@ class tst_WorldView_Basic : public QObject
 			resetTestState();
 		}
 
-		void partialHistoryRecallPrefersCommandTokenBoundary()
+		void partialHistoryRecallUsesPrefixAndNewestFirst()
 		{
 			resetTestState();
 			g_worldAttrs.insert(QStringLiteral("arrows_change_history"), QStringLiteral("1"));
@@ -4693,21 +4693,105 @@ class tst_WorldView_Basic : public QObject
 			view.show();
 			view.setRuntimeObserver(fakeRuntimePointer());
 			view.applyRuntimeSettings();
-			view.addToHistoryForced(QStringLiteral("ff test"));
-			view.addToHistoryForced(QStringLiteral("ffl test"));
+			view.addToHistoryForced(QStringLiteral("hitman"));
+			view.addToHistoryForced(QStringLiteral("hit man"));
+			view.addToHistoryForced(QStringLiteral("hit123"));
+			view.addToHistoryForced(QStringLiteral("hit 321"));
 			QCoreApplication::processEvents();
 
 			QPlainTextEdit *input = view.inputEditor();
 			QVERIFY(input);
 			input->setFocus();
-			view.setInputText(QStringLiteral("ff"), true);
+			view.setInputText(QStringLiteral("hit"), true);
 			QCoreApplication::processEvents();
 
 			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
-			QCOMPARE(view.inputText(), QStringLiteral("ff test"));
+			QCOMPARE(view.inputText(), QStringLiteral("hit 321"));
 
-			QTest::keyClick(input, Qt::Key_Down, Qt::AltModifier);
-			QCOMPARE(view.inputText(), QStringLiteral("ffl test"));
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hit123"));
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hit man"));
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hitman"));
+
+			view.setInputText(QStringLiteral("hit "), true);
+			QCoreApplication::processEvents();
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hit 321"));
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hit man"));
+
+			resetTestState();
+		}
+
+		void partialHistoryRecallReseedsAfterManualEdit()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("arrows_change_history"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("arrow_recalls_partial"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(760, 460);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("hitman"));
+			view.addToHistoryForced(QStringLiteral("hit man"));
+			view.addToHistoryForced(QStringLiteral("hit123"));
+			view.addToHistoryForced(QStringLiteral("hit 321"));
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			input->setFocus();
+			view.setInputText(QStringLiteral("hit"), true);
+			QCoreApplication::processEvents();
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hit 321"));
+
+			QTest::keyClick(input, Qt::Key_A, Qt::ControlModifier);
+			QTest::keyClicks(input, QStringLiteral("hit "));
+			QCoreApplication::processEvents();
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hit 321"));
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCOMPARE(view.inputText(), QStringLiteral("hit man"));
+
+			resetTestState();
+		}
+
+		void commandHistoryKeepsOnlyNewestDuplicateEntry()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(760, 460);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+
+			view.addToHistoryForced(QStringLiteral("look"));
+			view.addToHistoryForced(QStringLiteral("north"));
+			view.addToHistoryForced(QStringLiteral("look"));
+			view.addToHistoryForced(QStringLiteral("south"));
+			view.addToHistoryForced(QStringLiteral("look"));
+
+			QCOMPARE(view.commandHistoryList(),
+			         (QStringList{QStringLiteral("north"), QStringLiteral("south"), QStringLiteral("look")}));
+
+			view.addToHistoryForced(QStringLiteral("look"));
+			QCOMPARE(view.commandHistoryList(),
+			         (QStringList{QStringLiteral("north"), QStringLiteral("south"), QStringLiteral("look")}));
 
 			resetTestState();
 		}

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -362,20 +362,28 @@ namespace
 		return {-1, -1};
 	}
 
-	QPoint findLineInformationPoint(const WorldView &view, const QTextBrowser &browser)
+	QPoint findLineInformationPoint(const QTextBrowser &browser)
 	{
 		if (!browser.viewport())
 			return {-1, -1};
 
-		auto         *nativeCanvas = view.findChild<QWidget *>(QStringLiteral("worldOutputNativeCanvas"));
+		QWidget *root = browser.window();
+		auto    *nativeCanvas =
+            root ? root->findChild<QWidget *>(QStringLiteral("worldOutputNativeCanvas")) : nullptr;
 		QElapsedTimer readyTimer;
 		readyTimer.start();
-		while (readyTimer.elapsed() < 500)
+		constexpr qint64 kMaxReadyWaitMs       = 500;
+		constexpr qint64 kMissingCanvasGraceMs = 50;
+		while (readyTimer.elapsed() < kMaxReadyWaitMs)
 		{
-			const bool ready = nativeCanvas && nativeCanvas->isVisible() && view.isVisible() &&
-			                   browser.viewport()->isVisible() && browser.viewport()->width() > 1 &&
-			                   browser.viewport()->height() > 1;
-			if (ready)
+			if (!nativeCanvas && root)
+				nativeCanvas = root->findChild<QWidget *>(QStringLiteral("worldOutputNativeCanvas"));
+
+			const bool viewReady = root && root->isVisible() && browser.viewport()->isVisible() &&
+			                       browser.viewport()->width() > 1 && browser.viewport()->height() > 1;
+			if (viewReady && nativeCanvas && nativeCanvas->isVisible())
+				break;
+			if (viewReady && !nativeCanvas && readyTimer.elapsed() >= kMissingCanvasGraceMs)
 				break;
 			QCoreApplication::processEvents();
 			QTest::qWait(1);
@@ -384,14 +392,31 @@ namespace
 		const QRect area = browser.viewport()->rect();
 		const int   probeBottom =
 		    qMin(area.bottom(), area.top() + qMax(24, QFontMetrics(browser.font()).height() * 6));
+		const int probeRight = qMin(area.right(), area.left() + 320);
+
+		auto      probePoint = [&browser](const QPoint &point)
+		{
+			QToolTip::hideText();
+			QCoreApplication::processEvents();
+			QTest::mouseMove(browser.viewport(), point);
+			QCoreApplication::processEvents();
+			QCoreApplication::processEvents();
+			return QToolTip::text().contains(QStringLiteral("Line "));
+		};
+
+		const int lineHeight = qMax(1, QFontMetrics(browser.font()).height());
+		const int candidateY = qMin(probeBottom, area.top() + (lineHeight / 2));
+		for (int x = area.left() + 2; x <= probeRight; x += 12)
+		{
+			if (probePoint({x, candidateY}))
+				return {x, candidateY};
+		}
 
 		for (int y = area.top(); y <= probeBottom; y += 4)
 		{
-			for (int x = area.left(); x <= area.right(); x += 4)
+			for (int x = area.left(); x <= probeRight; x += 4)
 			{
-				QTest::mouseDClick(browser.viewport(), Qt::LeftButton, Qt::NoModifier, {x, y});
-				QCoreApplication::processEvents();
-				if (view.hasOutputSelection())
+				if (probePoint({x, y}))
 					return {x, y};
 			}
 		}
@@ -4712,7 +4737,7 @@ class tst_WorldView_Basic : public QObject
 
 			QTextBrowser *browser = findVisibleOutputBrowser(view);
 			QVERIFY(browser);
-			const QPoint point = findLineInformationPoint(view, *browser);
+			const QPoint point = findLineInformationPoint(*browser);
 			QVERIFY2(point.x() >= 0 && point.y() >= 0,
 			         "Expected line-information tooltip probe point in rendered output.");
 			QTest::mouseMove(browser->viewport(), point);
@@ -4720,6 +4745,49 @@ class tst_WorldView_Basic : public QObject
 			QTRY_VERIFY(QToolTip::text().contains(QStringLiteral("Line 1, ")));
 			QTRY_VERIFY(QToolTip::text().contains(QStringLiteral("(unknown time)")));
 			QToolTip::hideText();
+
+			resetTestState();
+		}
+
+		void lineInformationTooltipDoesNotShowOnBlankAreaOfRenderedLine()
+		{
+			resetTestState();
+			QToolTip::hideText();
+			g_worldAttrs.insert(QStringLiteral("line_information"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("tool_tip_start_time"), QStringLiteral("0"));
+			g_worldAttrs.insert(QStringLiteral("tool_tip_visible_time"), QStringLiteral("5000"));
+
+			WorldRuntime::LineEntry entry;
+			entry.text       = QStringLiteral("tip");
+			entry.flags      = WorldRuntime::LineOutput;
+			entry.hardReturn = true;
+			entry.lineNumber = 1;
+			g_runtimeLines.push_back(entry);
+
+			WorldView view;
+			view.resize(760, 460);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.rebuildOutputFromLines(g_runtimeLines);
+			QCoreApplication::processEvents();
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			const QPoint textPoint = findLineInformationPoint(*browser);
+			QVERIFY2(textPoint.x() >= 0 && textPoint.y() >= 0,
+			         "Expected line-information tooltip probe point in rendered output.");
+
+			QTest::mouseMove(browser->viewport(), textPoint);
+			QTRY_VERIFY(QToolTip::text().contains(QStringLiteral("Line 1, ")));
+
+			const QRect  viewportRect = browser->viewport()->rect();
+			const int    blankX = qBound(viewportRect.left(), viewportRect.right() - 2, viewportRect.right());
+			const QPoint blankPoint(blankX, textPoint.y());
+			QVERIFY(blankPoint.x() > textPoint.x());
+
+			QTest::mouseMove(browser->viewport(), blankPoint);
+			QTRY_VERIFY(QToolTip::text().isEmpty());
 
 			resetTestState();
 		}

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -4285,6 +4285,62 @@ class tst_WorldView_Basic : public QObject
 			resetTestState();
 		}
 
+		void tabCompletionSkipsDuplicateMatchesWithinCycleAndResetsAfterTyping()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("tab_completion_space"), QStringLiteral("0"));
+
+			WorldRuntime::LineEntry older;
+			older.text       = QStringLiteral("stamina");
+			older.flags      = WorldRuntime::LineOutput;
+			older.hardReturn = true;
+			g_runtimeLines.push_back(older);
+
+			WorldRuntime::LineEntry middle;
+			middle.text       = QStringLiteral("starch");
+			middle.flags      = WorldRuntime::LineOutput;
+			middle.hardReturn = true;
+			g_runtimeLines.push_back(middle);
+
+			WorldRuntime::LineEntry newer;
+			newer.text       = QStringLiteral("starch");
+			newer.flags      = WorldRuntime::LineOutput;
+			newer.hardReturn = true;
+			g_runtimeLines.push_back(newer);
+
+			WorldView view;
+			view.resize(860, 520);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			input->setFocus();
+
+			view.setInputText(QStringLiteral("sta"), true);
+			QTextCursor cursor = input->textCursor();
+			cursor.movePosition(QTextCursor::End);
+			input->setTextCursor(cursor);
+
+			QTest::keyClick(input, Qt::Key_Tab);
+			QCOMPARE(view.inputText(), QStringLiteral("starch"));
+
+			QTest::keyClick(input, Qt::Key_Tab);
+			QCOMPARE(view.inputText(), QStringLiteral("stamina"));
+
+			QTest::keyClick(input, Qt::Key_A, Qt::ControlModifier);
+			QTest::keyClicks(input, QStringLiteral("sta"));
+			cursor = input->textCursor();
+			cursor.movePosition(QTextCursor::End);
+			input->setTextCursor(cursor);
+
+			QTest::keyClick(input, Qt::Key_Tab);
+			QCOMPARE(view.inputText(), QStringLiteral("starch"));
+
+			resetTestState();
+		}
+
 		void outputFindNoMatchReturnsWithoutHanging()
 		{
 			resetTestState();

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -23,6 +23,7 @@
 #include <QElapsedTimer>
 #include <QImage>
 #include <QInputMethodEvent>
+#include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPlainTextEdit>
@@ -5121,6 +5122,90 @@ class tst_WorldView_Basic : public QObject
 			const QString emittedHref =
 			    QUrl::fromPercentEncoding(activatedSpy.at(0).at(0).toString().toUtf8());
 			QCOMPARE(emittedHref, span.action);
+			resetTestState();
+		}
+
+		void rightClickOnLinkPrefersSelectionMenuWhenOutputSelectionExists() const
+		{
+			resetTestState();
+
+			WorldView view;
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.resize(720, 420);
+			view.show();
+			QCoreApplication::processEvents();
+
+			WorldRuntime::StyleSpan span;
+			span.length     = QStringLiteral("assistant").size();
+			span.actionType = WorldRuntime::ActionSend;
+			span.action     = QStringLiteral("examine assistant|consider assistant|attack assistant");
+			span.hint       = QStringLiteral("Right mouse click to act|Examine assistant|Consider assistant|"
+			                                       "Attack assistant");
+			view.appendOutputTextStyled(QStringLiteral("assistant"), {span}, true);
+			QCoreApplication::processEvents();
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			const QPoint anchorPoint = findHyperlinkPoint(view, *browser, span.action);
+			QVERIFY(anchorPoint.x() >= 0 && anchorPoint.y() >= 0);
+			const QPoint globalAnchorPos = browser->viewport()->mapToGlobal(anchorPoint);
+
+			struct MenuCaptureFilter final : QObject
+			{
+					explicit MenuCaptureFilter(QStringList *capturedActions, bool *captured)
+					    : m_capturedActions(capturedActions), m_captured(captured)
+					{
+					}
+
+					bool eventFilter(QObject *watched, QEvent *event) override
+					{
+						if (!m_capturedActions || !m_captured || *m_captured || event->type() != QEvent::Show)
+							return QObject::eventFilter(watched, event);
+						auto *menu = qobject_cast<QMenu *>(watched);
+						if (!menu)
+							return QObject::eventFilter(watched, event);
+
+						const QList<QAction *> actions = menu->actions();
+						m_capturedActions->reserve(actions.size());
+						for (QAction *action : actions)
+						{
+							if (action)
+								m_capturedActions->push_back(action->text());
+						}
+						*m_captured = true;
+						QMetaObject::invokeMethod(menu, &QMenu::close, Qt::QueuedConnection);
+						return QObject::eventFilter(watched, event);
+					}
+
+				private:
+					QStringList *m_capturedActions{nullptr};
+					bool        *m_captured{nullptr};
+			};
+
+			auto captureWorldMenuActions = [&view](const QPoint &globalPos) -> QStringList
+			{
+				QStringList       capturedActions;
+				bool              captured = false;
+				MenuCaptureFilter filter(&capturedActions, &captured);
+				qApp->installEventFilter(&filter);
+				const bool shown = view.showWorldContextMenuAtGlobalPos(globalPos);
+				qApp->removeEventFilter(&filter);
+				if (!shown || !captured)
+					return {};
+				return capturedActions;
+			};
+
+			const QStringList linkMenuActions = captureWorldMenuActions(globalAnchorPos);
+			QCOMPARE(linkMenuActions,
+			         (QStringList{QStringLiteral("Examine assistant"), QStringLiteral("Consider assistant"),
+			                      QStringLiteral("Attack assistant")}));
+
+			view.selectOutputRange(0, 0, 3);
+			QTRY_VERIFY(view.hasOutputSelection());
+			const QStringList selectionMenuActions = captureWorldMenuActions(globalAnchorPos);
+			QCOMPARE(selectionMenuActions,
+			         (QStringList{QStringLiteral("Copy"), QStringLiteral("Copy as HTML")}));
+
 			resetTestState();
 		}
 


### PR DESCRIPTION
## Summary

- Command history dedup and tighten partial recall.
- Selection has priority on right click context menu.
- Tab autocompletion skips seen.
- Line tooltips now do not show up on empty space. 
- Announce tagged releases to discord.

## Scope

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- N/A.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

