### PR TITLE
Hotfix for Win11's styling problem. Spinboxes are layout aware now.

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -10,10 +10,10 @@
 #define QMUD_VERSION_H
 
 // Used for detecting version changes.
-inline constexpr int  kThisVersion = 1050;
+inline constexpr int  kThisVersion = 1051;
 
 // Used to display the version number.
-inline constexpr char kVersionString[] = "10.50";
+inline constexpr char kVersionString[] = "10.51";
 
 // CI builds append "-ci" to the runtime display version (AppController::m_version).
 // kVersionString itself remains the canonical numeric version.

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1274,7 +1274,7 @@ WorldView::WorldView(QWidget *parent) : QWidget(parent)
 	splitter->addWidget(m_input);
 	splitter->setStretchFactor(0, 1);
 	splitter->setStretchFactor(1, 0);
-	applyDefaultInputHeight(true);
+	applyDefaultInputHeight(false);
 
 	layout->addWidget(splitter);
 
@@ -8148,6 +8148,8 @@ void WorldView::resizeEvent(QResizeEvent *event)
 	QWidget::resizeEvent(event);
 	updateWrapMargin();
 	updateInputWrap();
+	if (!m_defaultInputHeightApplied)
+		applyDefaultInputHeight(true);
 	if (m_scrollbackSplitActive && m_outputSplitter)
 	{
 		const QList<int> sizes = m_outputSplitter->sizes();
@@ -8817,10 +8819,15 @@ void WorldView::applyDefaultInputHeight(bool setSplitterSizes)
 
 	if (setSplitterSizes && m_splitter)
 	{
-		const int total = m_splitter->size().height();
-		if (total > 0)
+		if (!isVisible())
 		{
-			const int outputSize = qMax(0, total - singleLine);
+			m_input->setMaximumHeight(QWIDGETSIZE_MAX);
+			return;
+		}
+		const int total = m_splitter->size().height();
+		if (total > singleLine)
+		{
+			const int outputSize = total - singleLine;
 			m_splitter->setSizes(QList<int>() << outputSize << singleLine);
 			m_input->setMaximumHeight(QWIDGETSIZE_MAX);
 			m_defaultInputHeightApplied = true;

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -66,6 +66,8 @@
 #include <QSpinBox>
 #include <QStackedWidget>
 #include <QStyleOptionGroupBox>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QStyleOptionSpinBox>
 #include <QTableWidget>
 #include <QTemporaryFile>
 #include <QTextCursor>
@@ -156,6 +158,30 @@ static QString canonicalSavePath(const QString &fileName, const QString &extensi
 	if (const QString suffix = QFileInfo(output).suffix().toLower(); suffix != extensionLower)
 		output = QMudFileExtensions::replaceOrAppendExtension(output, extensionLower);
 	return output;
+}
+
+static void configureSpinBoxWidthForRange(QSpinBox *spin)
+{
+	if (!spin)
+		return;
+
+	const auto makeDisplayText = [spin](const int value)
+	{ return spin->prefix() + spin->locale().toString(value) + spin->suffix(); };
+	const QString minText = makeDisplayText(spin->minimum());
+	const QString maxText = makeDisplayText(spin->maximum());
+	const int     textWidth =
+	    qMax(spin->fontMetrics().horizontalAdvance(minText), spin->fontMetrics().horizontalAdvance(maxText));
+
+	QStyleOptionSpinBox option;
+	option.initFrom(spin);
+	option.subControls = QStyle::SC_All;
+	const QRect editField =
+	    spin->style()->subControlRect(QStyle::CC_SpinBox, &option, QStyle::SC_SpinBoxEditField, spin);
+	const int chromeWidth = qMax(0, spin->sizeHint().width() - editField.width());
+	const int targetWidth = qMax(spin->minimumSizeHint().width(), chromeWidth + textWidth + 12);
+
+	spin->setMinimumWidth(targetWidth);
+	spin->setMaximumWidth(targetWidth);
 }
 
 class GradientHeader : public QWidget
@@ -5217,11 +5243,11 @@ void WorldPreferencesDialog::buildUi()
 	auto *outputBufferLayout = new QGridLayout(outputBufferBox);
 	m_maxLines               = new QSpinBox(outputBufferBox);
 	m_maxLines->setRange(200, 500000);
-	m_maxLines->setMaximumWidth(90);
+	configureSpinBoxWidthForRange(m_maxLines);
 	m_wrapOutput = new QCheckBox(QStringLiteral("Wrap output at column number"), outputBufferBox);
 	m_wrapColumn = new QSpinBox(outputBufferBox);
 	m_wrapColumn->setRange(20, 500);
-	m_wrapColumn->setMaximumWidth(90);
+	configureSpinBoxWidthForRange(m_wrapColumn);
 	auto *adjustWidthButton = new QPushButton(QStringLiteral("Adjust width to size"), outputBufferBox);
 	auto *adjustSizeButton  = new QPushButton(QStringLiteral("Adjust size to width"), outputBufferBox);
 	outputBufferLayout->addWidget(new QLabel(QStringLiteral("Number of lines in output"), outputBufferBox), 0,
@@ -5421,7 +5447,7 @@ void WorldPreferencesDialog::buildUi()
 	m_speedWalkFiller = new QLineEdit(speedWalkBox);
 	m_speedWalkDelay  = new QSpinBox(speedWalkBox);
 	m_speedWalkDelay->setRange(0, 30000);
-	m_speedWalkDelay->setMaximumWidth(60);
+	configureSpinBoxWidthForRange(m_speedWalkDelay);
 	auto *fillerLabel = new QLabel(QStringLiteral("Filler:"), speedWalkBox);
 	fillerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	auto *delayLabel = new QLabel(QStringLiteral("Delay:"), speedWalkBox);
@@ -5493,10 +5519,10 @@ void WorldPreferencesDialog::buildUi()
 	m_autoResizeCommandWindow = new QCheckBox(QStringLiteral("Auto-resize command window"), commandResizeBox);
 	m_autoResizeMinimumLines  = new QSpinBox(commandResizeBox);
 	m_autoResizeMinimumLines->setRange(1, 100);
-	m_autoResizeMinimumLines->setMaximumWidth(60);
+	configureSpinBoxWidthForRange(m_autoResizeMinimumLines);
 	m_autoResizeMaximumLines = new QSpinBox(commandResizeBox);
 	m_autoResizeMaximumLines->setRange(1, 100);
-	m_autoResizeMaximumLines->setMaximumWidth(60);
+	configureSpinBoxWidthForRange(m_autoResizeMaximumLines);
 	commandResizeLayout->addWidget(m_autoResizeCommandWindow, 0, 0, 1, 4);
 	commandResizeLayout->addWidget(new QLabel(QStringLiteral("Min lines:"), commandResizeBox), 1, 0);
 	commandResizeLayout->addWidget(m_autoResizeMinimumLines, 1, 1);
@@ -5511,7 +5537,7 @@ void WorldPreferencesDialog::buildUi()
 	m_enableSpamPrevention = new QCheckBox(QStringLiteral("Enable Spam Prevention"), spamBox);
 	m_spamLineCount        = new QSpinBox(spamBox);
 	m_spamLineCount->setRange(5, 500);
-	m_spamLineCount->setMaximumWidth(60);
+	configureSpinBoxWidthForRange(m_spamLineCount);
 	m_spamMessage        = new QLineEdit(spamBox);
 	auto *spamEveryLabel = new QLabel(QStringLiteral("Every"), spamBox);
 	spamEveryLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
@@ -5555,7 +5581,7 @@ void WorldPreferencesDialog::buildUi()
 	historyKeepLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	m_historyLines = new QSpinBox(historyBox);
 	m_historyLines->setRange(20, 5000);
-	m_historyLines->setMaximumWidth(70);
+	configureSpinBoxWidthForRange(m_historyLines);
 	historyLayout->addWidget(historyKeepLabel, 0, 0);
 	historyLayout->addWidget(m_historyLines, 0, 1);
 	historyLayout->addWidget(new QLabel(QStringLiteral("lines."), historyBox), 0, 2);

--- a/tests/gui/tst_Dialog_WorldPreferences.cpp
+++ b/tests/gui/tst_Dialog_WorldPreferences.cpp
@@ -160,7 +160,6 @@ class tst_Dialog_WorldPreferences : public QObject
 				if (commandName == QStringLiteral("ConfigurePaste"))
 					return pasteAlias;
 				return false;
-				// NOLINTEND(readability-convert-member-functions-to-static)
 			};
 
 			QCOMPARE(QMudWorldPreferencesRouting::isPreferencesCommand(cmdName, matcher), expectedRecognized);
@@ -168,7 +167,73 @@ class tst_Dialog_WorldPreferences : public QObject
 			             QMudWorldPreferencesRouting::initialPageForCommand(cmdName, lastPage, matcher)),
 			         expectedPage);
 		}
+
+		void spinBoxesUseRangeBasedWidthPolicy()
+		{
+			const QString sourcePath =
+			    QDir(QStringLiteral(QMUD_TEST_SOURCE_DIR))
+			        .filePath(QStringLiteral("src/dialogs/WorldPreferencesDialog.cpp"));
+			QFile sourceFile(sourcePath);
+			QVERIFY2(sourceFile.open(QIODevice::ReadOnly | QIODevice::Text),
+			         qPrintable(QStringLiteral("Failed to open %1").arg(sourcePath)));
+			const QString sourceText = QString::fromUtf8(sourceFile.readAll());
+
+			auto          firstMatchLine = [&sourceText](const QString &pattern) -> int
+			{
+				const QRegularExpression      regex(pattern);
+				const QRegularExpressionMatch match = regex.match(sourceText);
+				if (!match.hasMatch())
+					return -1;
+				return static_cast<int>(sourceText.left(match.capturedStart()).count(QLatin1Char('\n'))) + 1;
+			};
+
+			QVERIFY2(firstMatchLine(QStringLiteral(
+			             "\\bconfigureSpinBoxWidthForRange\\s*\\(\\s*QSpinBox\\s*\\*\\s*\\w+\\s*\\)")) > 0,
+			         "Expected range-based spin-box width helper was not found.");
+			QVERIFY2(firstMatchLine(QStringLiteral("\\bQStyleOptionSpinBox\\b")) > 0,
+			         "Expected style-aware spin-box width calculation was not found.");
+
+			const QStringList spinNames = {QStringLiteral("m_maxLines"),
+			                               QStringLiteral("m_wrapColumn"),
+			                               QStringLiteral("m_speedWalkDelay"),
+			                               QStringLiteral("m_autoResizeMinimumLines"),
+			                               QStringLiteral("m_autoResizeMaximumLines"),
+			                               QStringLiteral("m_spamLineCount"),
+			                               QStringLiteral("m_historyLines")};
+
+			for (const QString &spinName : spinNames)
+			{
+				const QString escaped = QRegularExpression::escape(spinName);
+				const int     createLine =
+				    firstMatchLine(QStringLiteral("\\b%1\\s*=\\s*new\\s+QSpinBox\\s*\\(").arg(escaped));
+				const int setRangeLine =
+				    firstMatchLine(QStringLiteral("\\b%1\\s*->\\s*setRange\\s*\\(").arg(escaped));
+				const int configureLine = firstMatchLine(
+				    QStringLiteral("\\bconfigureSpinBoxWidthForRange\\s*\\(\\s*%1\\s*\\)\\s*;").arg(escaped));
+
+				QVERIFY2(createLine > 0,
+				         qPrintable(QStringLiteral("No QSpinBox construction found for %1").arg(spinName)));
+				QVERIFY2(setRangeLine > 0,
+				         qPrintable(QStringLiteral("No setRange(...) call found for %1").arg(spinName)));
+				QVERIFY2(configureLine > 0,
+				         qPrintable(QStringLiteral("No configureSpinBoxWidthForRange(...) call found for %1")
+				                        .arg(spinName)));
+				QVERIFY2(setRangeLine > createLine,
+				         qPrintable(
+				             QStringLiteral("Expected setRange(...) after %1 construction.").arg(spinName)));
+				QVERIFY2(configureLine > setRangeLine,
+				         qPrintable(
+				             QStringLiteral("Expected configureSpinBoxWidthForRange(%1) after setRange(...).")
+				                 .arg(spinName)));
+
+				const QRegularExpression fixedWidthPattern(
+				    QStringLiteral("\\b%1\\s*->\\s*set(?:Maximum|Minimum|Fixed)Width\\s*\\(").arg(escaped));
+				QVERIFY2(!fixedWidthPattern.match(sourceText).hasMatch(),
+				         qPrintable(QStringLiteral("Unexpected fixed-width policy for %1").arg(spinName)));
+			}
+		}
 };
+// NOLINTEND(readability-convert-member-functions-to-static)
 
 QTEST_APPLESS_MAIN(tst_Dialog_WorldPreferences)
 

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -2735,6 +2735,35 @@ class tst_WorldView_Basic : public QObject
 			resetTestState();
 		}
 
+		void defaultInputSplitterSizingRepairsPoisonedPreShowState()
+		{
+			resetTestState();
+
+			WorldView view;
+			view.resize(420, 420);
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			auto *inputSplitter = qobject_cast<QSplitter *>(input->parentWidget());
+			QVERIFY(inputSplitter);
+
+			inputSplitter->setSizes(QList<int>() << 0 << 1000);
+
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			QCoreApplication::processEvents();
+
+			QTRY_VERIFY(inputSplitter->sizes().size() >= 2);
+			const QList<int> sizes = inputSplitter->sizes();
+			QVERIFY2(sizes.at(0) > 0, "Output pane should recover from poisoned pre-show splitter sizes.");
+			QVERIFY2(sizes.at(1) > 0, "Input pane should keep a positive height after startup sizing.");
+			QVERIFY2(qAbs(sizes.at(1) - input->height()) <= 2,
+			         "Startup default input sizing should synchronize splitter/input heights.");
+
+			resetTestState();
+		}
+
 		void enablingAutoResizeCompactsInputPaneWithoutBottomDeadSpace()
 		{
 			resetTestState();


### PR DESCRIPTION
## Summary

- Hotfix for Win11's styling problem. Fixes #80 
- Spinboxes are layout aware now.
- Bump version to v10.51.

## Scope

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- N/A.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

