### PR TITLE
Fix module() compatibility for Lua 5.2+, add return _M

### DIFF
--- a/skeleton/lua/InfoBox.lua
+++ b/skeleton/lua/InfoBox.lua
@@ -45,7 +45,9 @@ local fontProps = {"fontID", "fontName", "fontSize", "fontBold", "fontItalic", "
 local commas, CheckStyle, DoFade, PrintText
 local matteHilight, matteShadow, Bar, ansiCodes, ansiColors, _Doc
 
-module(...)
+local _M = {}
+_M._NAME = "InfoBox"
+_ENV = _M
 
 setmetatable ( _M, {__index = world, class = "module"})           -- find all the MushClient Functions
 
@@ -1676,3 +1678,6 @@ function Doc (self, topic)
         end end
         print("\n\nSyntax: ".. GetInfo(36) .. _NAME .. ':Doc("topic")\n')
 end end
+
+
+return _M


### PR DESCRIPTION
`module(...)` was removed in Lua 5.2.  The replacements I've made here are standard:

https://www.lua.org/manual/5.2/manual.html#8

(8.2 in particular)

See also:
http://lua-users.org/wiki/LuaModuleFunctionCritiqued

Which discusses why `module` was removed and what to do instead.

