### PR TITLE
Turn SmoothPixMapTransform on for all paintMiniWindows() context. Up/Down arrows navigate command input when history traversal is disabled.

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -10000,6 +10000,7 @@ void InputTextEdit::keyPressEvent(QKeyEvent *event)
 	if (m_view && (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down))
 	{
 		const int direction = (event->key() == Qt::Key_Up) ? -1 : 1;
+		bool      handled   = false;
 		if (event->modifiers() == Qt::NoModifier)
 		{
 			if (m_view->m_arrowsChangeHistory)
@@ -10009,13 +10010,19 @@ void InputTextEdit::keyPressEvent(QKeyEvent *event)
 					m_view->recallPartialHistory(direction);
 				else
 					m_view->recallHistory(direction);
+				handled = true;
 			}
-			return;
 		}
-		if (event->modifiers() == Qt::AltModifier)
+		else if (event->modifiers() == Qt::AltModifier)
 		{
 			if (m_view->m_altArrowRecallsPartial || m_view->m_arrowRecallsPartial)
+			{
 				m_view->recallPartialHistory(direction);
+				handled = true;
+			}
+		}
+		if (handled)
+		{
 			return;
 		}
 	}

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -6628,6 +6628,10 @@ void WorldView::paintMiniWindows(QPainter *painter, bool underneath, const QRect
 
 	painter->save();
 	painter->setClipRect(clippedUpdateRect);
+	painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+
+	const auto drawImageToRect = [painter](const QRect &targetRect, const QImage &image)
+	{ painter->drawImage(targetRect, image); };
 
 	if (underneath)
 	{
@@ -6685,7 +6689,7 @@ void WorldView::paintMiniWindows(QPainter *painter, bool underneath, const QRect
 			{
 				const QRect rect = positionImageRect(image.size(), clientSize, ownerSize, mode);
 				if (rect.intersects(clippedUpdateRect))
-					painter->drawImage(rect, image);
+					drawImageToRect(rect, image);
 			}
 		}
 	}
@@ -6703,7 +6707,7 @@ void WorldView::paintMiniWindows(QPainter *painter, bool underneath, const QRect
 			{
 				const QRect rect = positionImageRect(image.size(), clientSize, ownerSize, mode);
 				if (rect.intersects(clippedUpdateRect))
-					painter->drawImage(rect, image);
+					drawImageToRect(rect, image);
 			}
 		}
 	}
@@ -6748,7 +6752,7 @@ void WorldView::paintMiniWindows(QPainter *painter, bool underneath, const QRect
 			    window->position <= 3)
 			{
 				if (window->rect.intersects(clippedUpdateRect))
-					painter->drawImage(window->rect, image);
+					drawImageToRect(window->rect, image);
 			}
 			else
 			{
@@ -6756,10 +6760,7 @@ void WorldView::paintMiniWindows(QPainter *painter, bool underneath, const QRect
 				{
 					if (!window->rect.intersects(clippedUpdateRect))
 						continue;
-					const bool smooth = painter->testRenderHint(QPainter::SmoothPixmapTransform);
-					painter->setRenderHint(QPainter::SmoothPixmapTransform, false);
-					painter->drawImage(window->rect, image);
-					painter->setRenderHint(QPainter::SmoothPixmapTransform, smooth);
+					drawImageToRect(window->rect, image);
 				}
 				else
 				{

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -4767,6 +4767,45 @@ class tst_WorldView_Basic : public QObject
 			resetTestState();
 		}
 
+		void arrowKeysNavigateInputCursorWhenHistoryTraversalDisabled()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("arrows_change_history"), QStringLiteral("0"));
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(760, 460);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("north"));
+			view.addToHistoryForced(QStringLiteral("south"));
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			input->setFocus();
+			view.setInputText(QStringLiteral("line1\nline2"), true);
+
+			QTextCursor cursor = input->textCursor();
+			cursor.movePosition(QTextCursor::End);
+			input->setTextCursor(cursor);
+			QCoreApplication::processEvents();
+
+			QCOMPARE(view.inputText(), QStringLiteral("line1\nline2"));
+			QCOMPARE(input->textCursor().blockNumber(), 1);
+
+			QTest::keyClick(input, Qt::Key_Up);
+			QCOMPARE(view.inputText(), QStringLiteral("line1\nline2"));
+			QCOMPARE(input->textCursor().blockNumber(), 0);
+
+			QTest::keyClick(input, Qt::Key_Down);
+			QCOMPARE(view.inputText(), QStringLiteral("line1\nline2"));
+			QCOMPARE(input->textCursor().blockNumber(), 1);
+
+			resetTestState();
+		}
+
 		void partialHistoryRecallUsesPrefixAndNewestFirst()
 		{
 			resetTestState();


### PR DESCRIPTION
## Summary

- Turn SmoothPixMapTransform on for all paintMiniWindows() context.
- Up/Down arrows navigate command input when history traversal is disabled. Fixes #82

## Scope

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- N/A

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

