### PR TITLE
Implement QAccessible interface for the native renderer. Finalize path contract. Fix ColourNote()/ColourTell() failing when additional arguments are not a full group or 3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ set(QMUD_SOURCES
         helpers/WorldCommandProcessorUtils.cpp
         helpers/LuaExecutionUtils.cpp
         helpers/AccessibleTextUtils.cpp
+        helpers/PluginPathUtils.cpp
         helpers/OutputWrapUtils.cpp
         helpers/GuiSystemUtils.cpp
         NameGeneration.cpp
@@ -256,6 +257,7 @@ set(QMUD_HEADERS
         helpers/MainFrameMdiUtils.h
         helpers/LuaExecutionUtils.h
         helpers/AccessibleTextUtils.h
+        helpers/PluginPathUtils.h
         helpers/OutputWrapUtils.h
         TabActivationHistory.h
         AppController.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ set(QMUD_SOURCES
         helpers/HyperlinkActionUtils.cpp
         helpers/WorldCommandProcessorUtils.cpp
         helpers/LuaExecutionUtils.cpp
+        helpers/AccessibleTextUtils.cpp
         helpers/OutputWrapUtils.cpp
         helpers/GuiSystemUtils.cpp
         NameGeneration.cpp
@@ -254,6 +255,7 @@ set(QMUD_HEADERS
         helpers/MainFrameActionUtils.h
         helpers/MainFrameMdiUtils.h
         helpers/LuaExecutionUtils.h
+        helpers/AccessibleTextUtils.h
         helpers/OutputWrapUtils.h
         TabActivationHistory.h
         AppController.h

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -52,6 +52,7 @@
 #include "dialogs/WelcomeDialog.h"
 #include "dialogs/WelcomeUpgradeDialog.h"
 #include "dialogs/WorldPreferencesDialog.h"
+#include "helpers/PluginPathUtils.h"
 #include "helpers/WorldEditUtils.h"
 #include "scripting/ScriptingErrors.h"
 
@@ -1253,6 +1254,7 @@ namespace
 	}
 
 	QString absolutePathFromBase(const QString &baseDir, const QString &path);
+	QString dotRelativeStoragePath(const QString &qmudHome, const QString &value, bool trailingSlash);
 
 	QString canonicalAbsolutePath(const QString &path, const QString &workingDir)
 	{
@@ -1277,16 +1279,7 @@ namespace
 		if (path.trimmed().isEmpty())
 			return {};
 		const QString absolute = canonicalAbsolutePath(path, workingDir);
-		const QString baseDir  = QDir::cleanPath(workingDir);
-		if (QString relative = normalizePathString(QDir(baseDir).relativeFilePath(absolute));
-		    !relative.isEmpty() && relative != QStringLiteral("..") &&
-		    !relative.startsWith(QStringLiteral("../")) && !QDir::isAbsolutePath(relative))
-		{
-			if (relative.startsWith(QStringLiteral("./")) || relative.startsWith(QStringLiteral("../")))
-				return relative;
-			return QStringLiteral("./") + relative;
-		}
-		return normalizePathString(absolute);
+		return dotRelativeStoragePath(workingDir, absolute, false);
 	}
 
 	QString keyLeafName(const QString &key)
@@ -1325,11 +1318,7 @@ namespace
 
 	QString pathForRuntime(const QString &input)
 	{
-#ifdef Q_OS_WIN
-		return QDir::toNativeSeparators(input);
-#else
 		return normalizePathString(input);
-#endif
 	}
 
 	QString pathListForRuntime(const QString &input)
@@ -1450,19 +1439,53 @@ namespace
 #endif
 	}
 
-	QString normalizeStoredGlobalStringValue(const QString &key, const QString &value)
+	bool isDirectoryStorageKey(const QString &key)
+	{
+		const QString leaf = keyLeafName(key);
+		return leaf.contains(QStringLiteral("Directory"), Qt::CaseInsensitive);
+	}
+
+	QString dotRelativeStoragePath(const QString &qmudHome, const QString &value, const bool trailingSlash)
+	{
+		const QString normalized = QMudFileExtensions::canonicalizePathExtension(normalizePathString(value));
+		if (normalized.trimmed().isEmpty())
+			return {};
+		QString relative = QMudPluginPathUtils::qmudHomeRelativePath(qmudHome, normalized, trailingSlash);
+		if (relative.isEmpty())
+			return {};
+		if (relative == QLatin1String("."))
+			relative = QStringLiteral("./");
+		if (!relative.startsWith(QStringLiteral("./")) && !relative.startsWith(QStringLiteral("../")))
+			relative.prepend(QStringLiteral("./"));
+		return relative;
+	}
+
+	QString normalizeStoredGlobalStringValue(const QString &key, const QString &value,
+	                                         const QString &qmudHome)
 	{
 		QString adjusted = normalizeLegacyPortableDirectory(key, value);
 		if (isPathListKey(key))
-			return normalizePathList(adjusted);
+		{
+			const QStringList items = splitSerializedPathList(adjusted);
+			QStringList       normalizedItems;
+			normalizedItems.reserve(items.size());
+			for (const QString &item : items)
+			{
+				if (const QString normalized = dotRelativeStoragePath(qmudHome, item, false);
+				    !normalized.isEmpty())
+					normalizedItems.push_back(normalized);
+			}
+			return normalizedItems.join(QLatin1Char('*'));
+		}
 		if (shouldNormalizePathKey(key))
-			return QMudFileExtensions::canonicalizePathExtension(normalizePathString(adjusted));
+			return dotRelativeStoragePath(qmudHome, adjusted, isDirectoryStorageKey(key));
 		return adjusted;
 	}
 
-	QString normalizeRuntimeGlobalStringValue(const QString &key, const QString &value)
+	QString normalizeRuntimeGlobalStringValue(const QString &key, const QString &value,
+	                                          const QString &qmudHome)
 	{
-		QString stored = normalizeStoredGlobalStringValue(key, value);
+		QString stored = normalizeStoredGlobalStringValue(key, value, qmudHome);
 		if (isPathListKey(key))
 			return pathListForRuntime(stored);
 		if (shouldNormalizePathKey(key))
@@ -1950,32 +1973,32 @@ static const struct
 
     // option name                              default
 
-    {"AsciiArtFont",                  "fonts\\standard.flf"       },
-    {"DefaultAliasesFile",            ""                          },
-    {"DefaultColoursFile",            ""                          },
-    {"DefaultInputFont",              "DejaVu Sans Mono"          },
-    {"DefaultLogFileDirectory",       ".\\logs\\"                 },
-    {"DefaultMacrosFile",             ""                          },
-    {"DefaultNameGenerationFile",     "names/names.txt"           },
-    {"DefaultOutputFont",             "DejaVu Sans Mono"          },
-    {"DefaultTimersFile",             ""                          },
-    {"DefaultTriggersFile",           ""                          },
-    {"DefaultWorldFileDirectory",     ".\\worlds\\"               },
-    {"NotepadQuoteString",            "> "                        },
-    {"PluginList",                    ""                          },
-    {"PluginsDirectory",              R"(.\worlds\plugins\)"      },
-    {"StateFilesDirectory",           R"(.\worlds\plugins\state\)"}, // however see below
-    {"PrinterFont",                   "Courier"                   },
-    {"TrayIconFileName",              ""                          },
-    {"WordDelimiters",                ".,()[]\"\'"                },
-    {"WordDelimitersDblClick",        ".,()[]\"\'"                },
-    {"WorldList",                     ""                          },
-    {"LuaScript",                     ""                          },
-    {"Locale",                        "EN"                        },
-    {"FixedPitchFont",                "DejaVu Sans Mono"          },
-    {"SkipUpdateNotificationVersion", ""                          },
+    {"AsciiArtFont",                  "fonts/standard.flf"     },
+    {"DefaultAliasesFile",            ""                       },
+    {"DefaultColoursFile",            ""                       },
+    {"DefaultInputFont",              "DejaVu Sans Mono"       },
+    {"DefaultLogFileDirectory",       "./logs/"                },
+    {"DefaultMacrosFile",             ""                       },
+    {"DefaultNameGenerationFile",     "names/names.txt"        },
+    {"DefaultOutputFont",             "DejaVu Sans Mono"       },
+    {"DefaultTimersFile",             ""                       },
+    {"DefaultTriggersFile",           ""                       },
+    {"DefaultWorldFileDirectory",     "./worlds/"              },
+    {"NotepadQuoteString",            "> "                     },
+    {"PluginList",                    ""                       },
+    {"PluginsDirectory",              "./worlds/plugins/"      },
+    {"StateFilesDirectory",           "./worlds/plugins/state/"}, // however see below
+    {"PrinterFont",                   "Courier"                },
+    {"TrayIconFileName",              ""                       },
+    {"WordDelimiters",                ".,()[]\"\'"             },
+    {"WordDelimitersDblClick",        ".,()[]\"\'"             },
+    {"WorldList",                     ""                       },
+    {"LuaScript",                     ""                       },
+    {"Locale",                        "EN"                     },
+    {"FixedPitchFont",                "DejaVu Sans Mono"       },
+    {"SkipUpdateNotificationVersion", ""                       },
 
-    {nullptr,                         nullptr                     }  // end of table marker
+    {nullptr,                         nullptr                  }  // end of table marker
 }; // end of table
 
 namespace
@@ -2070,9 +2093,8 @@ namespace
 	QString storagePathFromAbsolute(const QString &baseDir, const QString &sourcePath,
 	                                const QString &absolutePath)
 	{
-		if (QFileInfo(sourcePath).isAbsolute())
-			return normalizePathString(absolutePath);
-		return archiveRelativePathFor(baseDir, absolutePath);
+		Q_UNUSED(sourcePath);
+		return dotRelativeStoragePath(baseDir, absolutePath, false);
 	}
 
 	QString remapLegacyWindowsWorldPathToBase(const QString &baseDir, const QString &path)
@@ -3707,9 +3729,9 @@ void AppController::setGlobalOptionString(const QString &name, const QString &va
 	};
 
 	const auto key         = findKey(lookupName);
-	const auto storedValue = normalizeStoredGlobalStringValue(key, value);
+	const auto storedValue = normalizeStoredGlobalStringValue(key, value, m_workingDir);
 	{
-		const auto   runtimeValue = normalizeRuntimeGlobalStringValue(key, storedValue);
+		const auto   runtimeValue = normalizeRuntimeGlobalStringValue(key, storedValue, m_workingDir);
 		QMutexLocker locker(&m_globalPrefsMutex);
 		m_globalStringPrefs.insert(key, runtimeValue);
 	}
@@ -3921,7 +3943,7 @@ bool AppController::initialize()
 #endif
 
 	m_fixedPitchFont   = QStringLiteral("DejaVu Sans Mono");
-	m_pluginsDirectory = QStringLiteral(".\\\\worlds\\\\plugins\\\\");
+	m_pluginsDirectory = QStringLiteral("./worlds/plugins/");
 
 	// open SQLite database for preferences
 	if (!openPreferencesDatabase())
@@ -4442,8 +4464,9 @@ bool AppController::openWorldForReloadRecovery(const ReloadWorldState &worldStat
 	bool                          opened                     = false;
 	const int                     previousActivationOverride = m_nextNewWorldActivationOverride;
 	m_nextNewWorldActivationOverride                         = activateWindow ? 1 : 0;
-	if (!worldState.worldFilePath.trimmed().isEmpty() && QFileInfo::exists(worldState.worldFilePath))
-		opened = openDocumentFile(worldState.worldFilePath);
+	const QString worldFilePath = dotRelativeStoragePath(m_workingDir, worldState.worldFilePath, false);
+	if (!worldFilePath.trimmed().isEmpty() && QFileInfo::exists(makeAbsolutePath(worldFilePath)))
+		opened = openDocumentFile(worldFilePath);
 	if (!opened)
 		opened = openDocumentFile(QString());
 	m_nextNewWorldActivationOverride = previousActivationOverride;
@@ -4485,8 +4508,8 @@ bool AppController::openWorldForReloadRecovery(const ReloadWorldState &worldStat
 		worldRuntime->setWorldAttribute(QStringLiteral("site"), worldState.host.trimmed());
 	if (worldState.port > 0)
 		worldRuntime->setWorldAttribute(QStringLiteral("port"), QString::number(worldState.port));
-	if (!worldState.worldFilePath.trimmed().isEmpty() && worldRuntime->worldFilePath().trimmed().isEmpty())
-		worldRuntime->setWorldFilePath(worldState.worldFilePath);
+	if (!worldFilePath.trimmed().isEmpty() && worldRuntime->worldFilePath().trimmed().isEmpty())
+		worldRuntime->setWorldFilePath(worldFilePath);
 	worldRuntime->setWorldAttribute(QStringLiteral("utf_8"),
 	                                worldState.utf8Enabled ? QStringLiteral("1") : QStringLiteral("0"));
 
@@ -8432,7 +8455,7 @@ int AppController::populateDatabase() const
 		    key == QStringLiteral("FixedPitchFont"))
 			strDefault = m_fixedPitchFont;
 
-		QString strValue = normalizeStoredGlobalStringValue(key, strDefault);
+		QString strValue = normalizeStoredGlobalStringValue(key, strDefault, m_workingDir);
 
 		strValue.replace('\'', QStringLiteral("''")); // fix up quotes
 
@@ -8559,7 +8582,7 @@ void AppController::loadGlobalsFromDatabase()
 		if (key == QStringLiteral("LuaScript"))
 			dbValue = migrateLegacyLuaScriptTipText(dbValue);
 
-		QString storedValue = normalizeStoredGlobalStringValue(key, dbValue);
+		QString storedValue = normalizeStoredGlobalStringValue(key, dbValue, m_workingDir);
 		if (key.compare(QStringLiteral("WorldList"), Qt::CaseInsensitive) == 0)
 		{
 			bool          worldListChanged = false;
@@ -8581,7 +8604,7 @@ void AppController::loadGlobalsFromDatabase()
 			ensurePrefsSnapshot();
 			(void)dbWriteString(QStringLiteral("prefs"), key, storedValue);
 		}
-		const QString runtimeValue = normalizeRuntimeGlobalStringValue(key, storedValue);
+		const QString runtimeValue = normalizeRuntimeGlobalStringValue(key, storedValue, m_workingDir);
 		{
 			QMutexLocker locker(&m_globalPrefsMutex);
 			m_globalStringPrefs.insert(key, runtimeValue);
@@ -8728,7 +8751,7 @@ int AppController::dbWriteString(const QString &section, const QString &entry, c
 
 	QString normalizedValue = value;
 	if (section.compare(QStringLiteral("prefs"), Qt::CaseInsensitive) == 0)
-		normalizedValue = normalizeStoredGlobalStringValue(entry, normalizedValue);
+		normalizedValue = normalizeStoredGlobalStringValue(entry, normalizedValue, m_workingDir);
 
 	const QString escapedEntry = escapeSql(entry);
 	const QString escapedValue = escapeSql(normalizedValue);
@@ -14526,7 +14549,7 @@ void AppController::handleReloadQmud()
 		world.worldId                       = attrs.value(QStringLiteral("id")).trimmed();
 		if (world.displayName.isEmpty())
 			world.displayName = attrs.value(QStringLiteral("name")).trimmed();
-		world.worldFilePath   = runtime->worldFilePath();
+		world.worldFilePath   = dotRelativeStoragePath(m_workingDir, runtime->worldFilePath(), false);
 		world.host            = attrs.value(QStringLiteral("site")).trimmed();
 		world.port            = attrs.value(QStringLiteral("port")).toUShort();
 		world.utf8Enabled     = isEnabledFlag(attrs.value(QStringLiteral("utf_8")));

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -12102,14 +12102,16 @@ static int luaColourOutput(lua_State *L, const bool noteLastSegment)
 		return 0;
 
 	QVector<ColourOutputSegment> segments;
-	const int                    top = lua_gettop(L);
-	for (int index = 1; index <= top; index += 3)
+	const int                    top                  = lua_gettop(L);
+	const int                    completeSegmentCount = top / 3;
+	for (int segmentIndex = 0; segmentIndex < completeSegmentCount; ++segmentIndex)
 	{
+		const int     index      = segmentIndex * 3 + 1;
 		const QString textColour = QString::fromUtf8(luaL_optstring(L, index, ""));
 		const QString backColour = QString::fromUtf8(luaL_optstring(L, index + 1, ""));
 		const QString text       = QString::fromUtf8(luaL_checkstring(L, index + 2));
 		segments.push_back({text, WorldView::parseColor(textColour), WorldView::parseColor(backColour),
-		                    noteLastSegment && index + 2 >= top});
+		                    noteLastSegment && segmentIndex + 1 == completeSegmentCount});
 	}
 
 	for (const ColourOutputSegment &segment : segments)

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -39,6 +39,7 @@
 #include "dialogs/SpellCheckDialog.h"
 #include "helpers/LuaExecutionUtils.h"
 #include "helpers/MiniWindowUtils.h"
+#include "helpers/PluginPathUtils.h"
 #include "helpers/WorldCommandProcessorUtils.h"
 #include "scripting/ScriptingErrors.h"
 
@@ -143,13 +144,17 @@ constexpr int kStyleInverse = INVERSE;
 constexpr int kStyleInverse = 0x0008;
 #endif
 // Keep legacy ShowWindow-compatible values returned by GetInfo(238).
-constexpr int kWindowShowNormal    = 1;
-constexpr int kWindowShowMaximized = 3;
-constexpr int kWindowMinimize      = 6;
-constexpr int kWindowRestore       = 9;
-constexpr int kAnsiBold            = 1;
-constexpr int kAnsiTextRed         = 31;
-constexpr int kAnsiTextCyan        = 36;
+constexpr int  kWindowShowNormal    = 1;
+constexpr int  kWindowShowMaximized = 3;
+constexpr int  kWindowMinimize      = 6;
+constexpr int  kWindowRestore       = 9;
+constexpr int  kAnsiBold            = 1;
+constexpr int  kAnsiTextRed         = 31;
+constexpr int  kAnsiTextCyan        = 36;
+
+static QString qmudHomeForLuaFileApi(const LuaCallbackEngine *engine);
+static bool    resolveLuaFileApiPath(const LuaCallbackEngine *engine, const QString &rawPath,
+                                     QString *resolvedPath, QString *error);
 
 #ifdef TRIGGER_MATCH_TEXT
 constexpr int kTriggerMatchText = TRIGGER_MATCH_TEXT;
@@ -9820,12 +9825,8 @@ void LuaCallbackEngine::setPluginInfo(const QString &id, const QString &name, co
 	{
 		normalizedDirectory += '/';
 	}
-#ifdef Q_OS_WIN
-	m_pluginDirectory = QDir::toNativeSeparators(normalizedDirectory);
-#else
 	normalizedDirectory.replace(QLatin1Char('\\'), QLatin1Char('/'));
 	m_pluginDirectory = normalizedDirectory;
-#endif
 }
 
 QString LuaCallbackEngine::pluginId() const
@@ -10601,12 +10602,18 @@ static int luaAddFont(lua_State *L)
 			lua_pushnumber(L, eBadParameter);
 			return 1;
 		}
-		if (!QFileInfo::exists(trimmedPath))
+		QString absolutePath;
+		QString pathError;
+		if (!resolveLuaFileApiPath(engine, trimmedPath, &absolutePath, &pathError))
 		{
 			lua_pushnumber(L, eFileNotFound);
 			return 1;
 		}
-		const QString absolutePath = QFileInfo(trimmedPath).absoluteFilePath();
+		if (!QFileInfo::exists(absolutePath))
+		{
+			lua_pushnumber(L, eFileNotFound);
+			return 1;
+		}
 		if (callbackScopeSyncBridgeForbidden())
 		{
 			const int results = enqueueRuntimeThreadAsyncStatusResult(
@@ -11821,12 +11828,19 @@ static int luaChatSendFile(lua_State *L)
 			lua_pushnumber(L, eFileNotFound);
 			return 1;
 		}
-		const QFileInfo fileInfo(path);
-		QFile           file(path);
+		QString resolvedPath;
+		QString pathError;
+		if (!resolveLuaFileApiPath(engine, path, &resolvedPath, &pathError))
+		{
+			lua_pushnumber(L, eFileNotFound);
+			return 1;
+		}
+		const QFileInfo fileInfo(resolvedPath);
+		QFile           file(resolvedPath);
 		if (!file.open(QIODevice::ReadOnly))
 		{
 			appendCallbackChatNoteOutputLine(engine, runtime, 14,
-			                                 QStringLiteral("File %1 cannot be opened.").arg(path));
+			                                 QStringLiteral("File %1 cannot be opened.").arg(resolvedPath));
 			lua_pushnumber(L, eFileNotFound);
 			return 1;
 		}
@@ -11838,14 +11852,15 @@ static int luaChatSendFile(lua_State *L)
 		    blockSize > 0 ? (fileSize + blockSize - 1) / blockSize : static_cast<qlonglong>(0);
 		const int results = enqueueRuntimeThreadAsyncOkStatusResult(
 		    L, engine, runtime, QStringLiteral("ChatSendFile"), eChatIDNotFound,
-		    [id, path](WorldRuntime &targetRuntime) -> int { return targetRuntime.chatSendFile(id, path); });
+		    [id, resolvedPath](WorldRuntime &targetRuntime) -> int
+		    { return targetRuntime.chatSendFile(id, resolvedPath); });
 		if (lua_tointeger(L, -results) != eOK)
 			return results;
-		setCallbackChatFileTransferSnapshot(engine, id, true, true, fileInfo.fileName(), path, fileSize,
-		                                    fileBlocks, 0, QDateTime::currentDateTime());
+		setCallbackChatFileTransferSnapshot(engine, id, true, true, fileInfo.fileName(), resolvedPath,
+		                                    fileSize, fileBlocks, 0, QDateTime::currentDateTime());
 		appendCallbackChatNoteOutputLine(engine, runtime, 14,
 		                                 QStringLiteral("Initiated transfer of file %1, %2 bytes (%3 Kb).")
-		                                     .arg(path)
+		                                     .arg(resolvedPath)
 		                                     .arg(fileSize)
 		                                     .arg(static_cast<double>(fileSize) / 1024.0, 0, 'f', 1));
 		return results;
@@ -19845,7 +19860,14 @@ static int luaReadNamesFile(lua_State *L)
 		return 1;
 	}
 	const QString fileName = QString::fromUtf8(luaL_checkstring(L, 1));
-	lua_pushnumber(L, WorldRuntime::readNamesFile(fileName));
+	QString       resolvedFileName;
+	QString       pathError;
+	if (!resolveLuaFileApiPath(engine, fileName, &resolvedFileName, &pathError))
+	{
+		lua_pushnumber(L, 0);
+		return 1;
+	}
+	lua_pushnumber(L, WorldRuntime::readNamesFile(resolvedFileName));
 	return 1;
 }
 
@@ -20312,7 +20334,14 @@ static int luaSaveNotepad(lua_State *L)
 		lua_pushnumber(L, 0);
 		return 1;
 	}
-	if (!replace && QFileInfo::exists(fileName))
+	QString resolvedFileName;
+	QString pathError;
+	if (!resolveLuaFileApiPath(engine, fileName, &resolvedFileName, &pathError))
+	{
+		lua_pushnumber(L, 0);
+		return 1;
+	}
+	if (!replace && QFileInfo::exists(resolvedFileName))
 	{
 		lua_pushnumber(L, 0);
 		return 1;
@@ -20326,7 +20355,7 @@ static int luaSaveNotepad(lua_State *L)
 		const bool                 queued =
 		    app && QMetaObject::invokeMethod(
 		               app.data(),
-		               [runtimeGuard, title, worldId, fileName, callbackPluginId, requestId]
+		               [runtimeGuard, title, worldId, resolvedFileName, callbackPluginId, requestId]
 		               {
 			               WorldRuntime *targetRuntime = runtimeGuard.data();
 			               if (!targetRuntime)
@@ -20336,7 +20365,7 @@ static int luaSaveNotepad(lua_State *L)
 			               if (TextChildWindow *text = findNotepadWindow(title, targetRuntime, worldId);
 			                   text && text->editor())
 			               {
-				               ok = text->saveToFile(fileName, &error);
+				               ok = text->saveToFile(resolvedFileName, &error);
 			               }
 			               emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
 			                                     QStringLiteral("SaveNotepad"), ok, ok ? 0 : -1, error);
@@ -20351,13 +20380,13 @@ static int luaSaveNotepad(lua_State *L)
 		return 1;
 	}
 	const bool ok = runOnMainWindowThread(
-	    [title, runtime, worldId, fileName](MainWindow *) -> bool
+	    [title, runtime, worldId, resolvedFileName](MainWindow *) -> bool
 	    {
 		    TextChildWindow *text = findNotepadWindow(title, runtime, worldId);
 		    if (!text || !text->editor())
 			    return false;
 		    QString error;
-		    return text->saveToFile(fileName, &error);
+		    return text->saveToFile(resolvedFileName, &error);
 	    },
 	    false, true);
 	lua_pushnumber(L, ok ? 1 : 0);
@@ -20500,13 +20529,25 @@ static int luaSetBackgroundImage(lua_State *L)
 			lua_pushnumber(L, eBadParameter);
 			return 1;
 		}
-		QString storedName;
-		if (const int validationResult = WorldRuntime::loadWorldImageFile(fileName, nullptr, &storedName);
+		QString resolvedFileName;
+		QString pathError;
+		if (!fileName.trimmed().isEmpty() &&
+		    !resolveLuaFileApiPath(engine, fileName, &resolvedFileName, &pathError))
+		{
+			lua_pushnumber(L, eFileNotFound);
+			return 1;
+		}
+		const QString imageFileName = fileName.trimmed().isEmpty() ? QString() : resolvedFileName;
+		if (const int validationResult = WorldRuntime::loadWorldImageFile(imageFileName, nullptr, nullptr);
 		    validationResult != eOK)
 		{
 			lua_pushnumber(L, validationResult);
 			return 1;
 		}
+		const QString storedName =
+		    imageFileName.isEmpty() ? QString()
+		                            : QMudPluginPathUtils::qmudHomeRelativePath(qmudHomeForLuaFileApi(engine),
+		                                                                        imageFileName, false);
 		if (callbackScopeSyncBridgeForbidden())
 		{
 			return enqueueRuntimeThreadAsyncStatusResult(
@@ -20689,13 +20730,25 @@ static int luaSetForegroundImage(lua_State *L)
 			lua_pushnumber(L, eBadParameter);
 			return 1;
 		}
-		QString storedName;
-		if (const int validationResult = WorldRuntime::loadWorldImageFile(fileName, nullptr, &storedName);
+		QString resolvedFileName;
+		QString pathError;
+		if (!fileName.trimmed().isEmpty() &&
+		    !resolveLuaFileApiPath(engine, fileName, &resolvedFileName, &pathError))
+		{
+			lua_pushnumber(L, eFileNotFound);
+			return 1;
+		}
+		const QString imageFileName = fileName.trimmed().isEmpty() ? QString() : resolvedFileName;
+		if (const int validationResult = WorldRuntime::loadWorldImageFile(imageFileName, nullptr, nullptr);
 		    validationResult != eOK)
 		{
 			lua_pushnumber(L, validationResult);
 			return 1;
 		}
+		const QString storedName =
+		    imageFileName.isEmpty() ? QString()
+		                            : QMudPluginPathUtils::qmudHomeRelativePath(qmudHomeForLuaFileApi(engine),
+		                                                                        imageFileName, false);
 		if (callbackScopeSyncBridgeForbidden())
 		{
 			return enqueueRuntimeThreadAsyncStatusResult(
@@ -22265,6 +22318,49 @@ static int luaGetStatusTime(lua_State *L)
 	return 1;
 }
 
+static QString qmudHomeForLuaFileApi(const LuaCallbackEngine *engine)
+{
+	const WorldRuntime *runtime = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
+	return QMudPluginPathUtils::normalizeSeparators(runtime ? runtime->startupDirectory() : QString());
+}
+
+static bool resolveLuaFileApiPath(const LuaCallbackEngine *engine, const QString &rawPath,
+                                  QString *resolvedPath, QString *error)
+{
+	if ((engine ? engine->worldRuntimeForBridgedCall() : nullptr) == nullptr)
+	{
+		if (error)
+			*error = QStringLiteral("Lua file path API has no attached world runtime");
+		return false;
+	}
+	return QMudPluginPathUtils::resolveInsideQmudHome(qmudHomeForLuaFileApi(engine), rawPath, resolvedPath,
+	                                                  error);
+}
+
+static int luaResolveFilePathForApi(lua_State *L)
+{
+	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
+	const QString rawPath = QString::fromUtf8(luaL_checkstring(L, 1));
+	QString       resolved;
+	QString       error;
+	if (!resolveLuaFileApiPath(engine, rawPath, &resolved, &error))
+		return luaL_error(L, "QMud file path rejected: %s", qPrintable(error));
+	lua_pushstring(L, resolved.toUtf8().constData());
+	return 1;
+}
+
+static QString qmudHomeRelativePathForGetInfo(const LuaCallbackEngine *engine, const QString &path,
+                                              const bool trailingSlash)
+{
+	return QMudPluginPathUtils::qmudHomeRelativePath(qmudHomeForLuaFileApi(engine), path, trailingSlash);
+}
+
+static void pushLuaString(lua_State *L, const QString &value)
+{
+	const QByteArray bytes = value.toLocal8Bit();
+	lua_pushlstring(L, bytes.constData(), bytes.size());
+}
+
 static int luaGetInfo(lua_State *L)
 {
 	auto *engine = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
@@ -22315,10 +22411,12 @@ static int luaGetInfo(lua_State *L)
 		lua_pushstring(L, getAttr(QStringLiteral("notes")).toLocal8Bit().constData());
 		return 1;
 	case 9:
-		lua_pushstring(L, getAttr(QStringLiteral("new_activity_sound")).toLocal8Bit().constData());
+		pushLuaString(
+		    L, qmudHomeRelativePathForGetInfo(engine, getAttr(QStringLiteral("new_activity_sound")), false));
 		return 1;
 	case 10:
-		lua_pushstring(L, getAttr(QStringLiteral("script_editor")).toLocal8Bit().constData());
+		pushLuaString(
+		    L, qmudHomeRelativePathForGetInfo(engine, getAttr(QStringLiteral("script_editor")), false));
 		return 1;
 	case 11:
 		lua_pushstring(L, getMulti(QStringLiteral("log_file_preamble")).toLocal8Bit().constData());
@@ -22393,7 +22491,8 @@ static int luaGetInfo(lua_State *L)
 		lua_pushstring(L, getAttr(QStringLiteral("on_world_lose_focus")).toLocal8Bit().constData());
 		return 1;
 	case 35:
-		lua_pushstring(L, getAttr(QStringLiteral("script_filename")).toLocal8Bit().constData());
+		pushLuaString(
+		    L, qmudHomeRelativePathForGetInfo(engine, getAttr(QStringLiteral("script_filename")), false));
 		return 1;
 	case 36:
 		lua_pushstring(L, getAttr(QStringLiteral("script_prefix")).toLocal8Bit().constData());
@@ -22408,7 +22507,8 @@ static int luaGetInfo(lua_State *L)
 		lua_pushstring(L, getAttr(QStringLiteral("tab_completion_defaults")).toLocal8Bit().constData());
 		return 1;
 	case 40:
-		lua_pushstring(L, getAttr(QStringLiteral("auto_log_file_name")).toLocal8Bit().constData());
+		pushLuaString(
+		    L, qmudHomeRelativePathForGetInfo(engine, getAttr(QStringLiteral("auto_log_file_name")), false));
 		return 1;
 	case 41:
 		lua_pushstring(L, getAttr(QStringLiteral("recall_line_preamble")).toLocal8Bit().constData());
@@ -22438,7 +22538,8 @@ static int luaGetInfo(lua_State *L)
 		lua_pushstring(L, getAttr(QStringLiteral("on_mxp_set_variable")).toLocal8Bit().constData());
 		return 1;
 	case 50:
-		lua_pushstring(L, getAttr(QStringLiteral("beep_sound")).toLocal8Bit().constData());
+		pushLuaString(L,
+		              qmudHomeRelativePathForGetInfo(engine, getAttr(QStringLiteral("beep_sound")), false));
 		return 1;
 	case 51:
 	{
@@ -22448,7 +22549,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.logFileName.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.logFileName, false));
 		return 1;
 	}
 	case 52:
@@ -22481,7 +22582,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.worldFilePath.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.worldFilePath, false));
 		return 1;
 	}
 	case 55:
@@ -22496,7 +22597,7 @@ static int luaGetInfo(lua_State *L)
 		return 1;
 	}
 	case 56:
-		lua_pushstring(L, QCoreApplication::applicationFilePath().toLocal8Bit().constData());
+		pushLuaString(L, QMudPluginPathUtils::normalizeSeparators(QCoreApplication::applicationFilePath()));
 		return 1;
 	case 57:
 	{
@@ -22506,7 +22607,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.defaultWorldDirectory.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.defaultWorldDirectory, true));
 		return 1;
 	}
 	case 58:
@@ -22517,11 +22618,11 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.defaultLogDirectory.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.defaultLogDirectory, true));
 		return 1;
 	}
 	case 59:
-		lua_pushstring(L, QCoreApplication::applicationDirPath().toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, qmudHomeForLuaFileApi(engine), true));
 		return 1;
 	case 60:
 	{
@@ -22531,7 +22632,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.pluginsDirectory.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.pluginsDirectory, true));
 		return 1;
 	}
 	case 61:
@@ -22561,10 +22662,7 @@ static int luaGetInfo(lua_State *L)
 		return 1;
 	case 64:
 	{
-		QString cwd = QDir::currentPath();
-		if (const QChar sep = QDir::separator(); !cwd.endsWith(sep))
-			cwd += sep;
-		lua_pushstring(L, cwd.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, qmudHomeForLuaFileApi(engine), true));
 		return 1;
 	}
 	case 65:
@@ -22578,11 +22676,7 @@ static int luaGetInfo(lua_State *L)
 		QString                               base;
 		if (resolveRuntimeCountersSnapshotWithStringsForApi(engine, runtime, snapshot))
 			base = snapshot.startupDirectory;
-		if (base.isEmpty())
-			base = QCoreApplication::applicationDirPath();
-		if (!base.endsWith(QDir::separator()))
-			base.append(QDir::separator());
-		lua_pushstring(L, base.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, base, true));
 		return 1;
 	}
 	case 67:
@@ -22596,11 +22690,8 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		QFileInfo info(worldFilePath);
-		QString   worldDir = info.absolutePath();
-		if (const QChar sep = QDir::separator(); !worldDir.isEmpty() && !worldDir.endsWith(sep))
-			worldDir += sep;
-		lua_pushstring(L, worldDir.toLocal8Bit().constData());
+		const QString worldDir = QFileInfo(QMudPluginPathUtils::normalizeSeparators(worldFilePath)).path();
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, worldDir, true));
 		return 1;
 	}
 	case 68:
@@ -22611,7 +22702,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.startupDirectory.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.startupDirectory, true));
 		return 1;
 	}
 	case 69:
@@ -22622,7 +22713,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.translatorFile.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.translatorFile, false));
 		return 1;
 	}
 	case 70:
@@ -22661,10 +22752,8 @@ static int luaGetInfo(lua_State *L)
 			root = snapshot.startupDirectory;
 		if (root.isEmpty())
 			root = QCoreApplication::applicationDirPath();
-		QString sounds = QDir(root).filePath(QStringLiteral("sounds"));
-		if (const QChar sep = QDir::separator(); !sounds.endsWith(sep))
-			sounds += sep;
-		lua_pushstring(L, sounds.toLocal8Bit().constData());
+		const QString sounds = QDir(root).filePath(QStringLiteral("sounds"));
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, sounds, true));
 		return 1;
 	}
 	case 75:
@@ -22686,17 +22775,19 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.firstSpecialFontPath.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.firstSpecialFontPath, false));
 		return 1;
 	}
 	case 77:
 		lua_pushstring(L, "");
 		return 1;
 	case 78:
-		lua_pushstring(L, getAttr(QStringLiteral("foreground_image")).toLocal8Bit().constData());
+		pushLuaString(
+		    L, qmudHomeRelativePathForGetInfo(engine, getAttr(QStringLiteral("foreground_image")), false));
 		return 1;
 	case 79:
-		lua_pushstring(L, getAttr(QStringLiteral("background_image")).toLocal8Bit().constData());
+		pushLuaString(
+		    L, qmudHomeRelativePathForGetInfo(engine, getAttr(QStringLiteral("background_image")), false));
 		return 1;
 	case 81:
 	case 80:
@@ -22710,7 +22801,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.preferencesDatabaseName.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.preferencesDatabaseName, false));
 		return 1;
 	}
 	case 83:
@@ -22724,7 +22815,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.fileBrowsingDirectory.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.fileBrowsingDirectory, true));
 		return 1;
 	}
 	case 85:
@@ -22735,7 +22826,7 @@ static int luaGetInfo(lua_State *L)
 			lua_pushstring(L, "");
 			return 1;
 		}
-		lua_pushstring(L, snapshot.stateFilesDirectory.toLocal8Bit().constData());
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, snapshot.stateFilesDirectory, true));
 		return 1;
 	}
 	case 86:
@@ -24955,7 +25046,12 @@ static int luaUtilsHash(lua_State *L)
 
 static int luaUtilsReadDir(lua_State *L)
 {
-	const QString   pattern = QString::fromUtf8(luaL_checkstring(L, 1));
+	QString       error;
+	QString       pattern;
+	const QString rawPattern = QString::fromUtf8(luaL_checkstring(L, 1));
+	const auto   *engine     = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
+	if (!resolveLuaFileApiPath(engine, rawPattern, &pattern, &error))
+		return luaL_error(L, "QMud file path rejected: %s", qPrintable(error));
 	const QFileInfo patternInfo(pattern);
 	QDir            dir = patternInfo.dir();
 	if (!dir.exists())
@@ -25047,11 +25143,11 @@ static int luaUtilsInfo(lua_State *L)
 	if (const QString currentDir = slashPathWithTrailingSlash(QDir::currentPath()); !currentDir.isEmpty())
 	{
 		lua_pushstring(L, "current_directory");
-		lua_pushstring(L, currentDir.toUtf8().constData());
+		lua_pushstring(L, qmudHomeRelativePathForGetInfo(engine, currentDir, true).toUtf8().constData());
 		lua_rawset(L, -3);
 	}
 
-	const QString appDir = slashPathWithTrailingSlash(QCoreApplication::applicationDirPath());
+	const QString appDir = qmudHomeRelativePathForGetInfo(engine, qmudHomeForLuaFileApi(engine), true);
 	lua_pushstring(L, "app_directory");
 	lua_pushstring(L, appDir.toUtf8().constData());
 	lua_rawset(L, -3);
@@ -25068,16 +25164,16 @@ static int luaUtilsInfo(lua_State *L)
 		auto globalString = [app](const char *key) -> QString
 		{ return app->getGlobalOption(QString::fromLatin1(key)).toString(); };
 
-		setString("world_files_directory", slashPathWithTrailingSlash(app->makeAbsolutePath(
-		                                       globalString("DefaultWorldFileDirectory"))));
+		setString("world_files_directory",
+		          qmudHomeRelativePathForGetInfo(engine, globalString("DefaultWorldFileDirectory"), true));
 		setString("state_files_directory",
-		          slashPathWithTrailingSlash(app->makeAbsolutePath(globalString("StateFilesDirectory"))));
+		          qmudHomeRelativePathForGetInfo(engine, globalString("StateFilesDirectory"), true));
 		setString("log_files_directory",
-		          slashPathWithTrailingSlash(app->makeAbsolutePath(globalString("DefaultLogFileDirectory"))));
+		          qmudHomeRelativePathForGetInfo(engine, globalString("DefaultLogFileDirectory"), true));
 		setString("plugins_directory",
-		          slashPathWithTrailingSlash(app->makeAbsolutePath(globalString("PluginsDirectory"))));
+		          qmudHomeRelativePathForGetInfo(engine, globalString("PluginsDirectory"), true));
 		setString("startup_directory",
-		          slashPathWithTrailingSlash(QFileInfo(app->iniFilePath()).absolutePath()));
+		          qmudHomeRelativePathForGetInfo(engine, QFileInfo(app->iniFilePath()).absolutePath(), true));
 		setString("locale", globalString("Locale"));
 		setString("fixed_pitch_font", globalString("FixedPitchFont"));
 		lua_pushstring(L, "fixed_pitch_font_size");
@@ -25091,7 +25187,7 @@ static int luaUtilsInfo(lua_State *L)
 			if (resolveRuntimeCountersSnapshotWithStringsForApi(engine, runtime, snapshot))
 				translatorFile = snapshot.translatorFile;
 		}
-		setString("translator_file", QDir::fromNativeSeparators(translatorFile));
+		setString("translator_file", qmudHomeRelativePathForGetInfo(engine, translatorFile, false));
 	}
 
 	return 1;
@@ -25933,7 +26029,8 @@ static int luaUtilsFilePicker(lua_State *L)
 	auto         *engine           = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
 	WorldRuntime *runtime          = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
 
-	QString       initialDir = QDir::currentPath();
+	const QString qmudHome   = qmudHomeForLuaFileApi(engine);
+	QString       initialDir = qmudHome.isEmpty() ? QDir::currentPath() : qmudHome;
 	if (runtime)
 	{
 		const bool callbackForbidden =
@@ -25942,14 +26039,16 @@ static int luaUtilsFilePicker(lua_State *L)
 		if (resolveRuntimeCountersSnapshotWithStringsForApi(engine, runtime, snapshot))
 		{
 			if (!snapshot.fileBrowsingDirectory.isEmpty())
-				initialDir = snapshot.fileBrowsingDirectory;
+				static_cast<void>(QMudPluginPathUtils::resolveInsideQmudHome(
+				    qmudHome, snapshot.fileBrowsingDirectory, &initialDir));
 		}
 		else if (!callbackForbidden)
 		{
 			const QString runtimeDir = runOnRuntimeThread(
 			    runtime, [&]() -> QString { return runtime->fileBrowsingDirectory(); }, QString());
 			if (!runtimeDir.isEmpty())
-				initialDir = runtimeDir;
+				static_cast<void>(
+				    QMudPluginPathUtils::resolveInsideQmudHome(qmudHome, runtimeDir, &initialDir));
 		}
 	}
 
@@ -25959,13 +26058,13 @@ static int luaUtilsFilePicker(lua_State *L)
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
 		    engine, runtime,
-		    [title, defaultName, defaultExtension, filterString, saveDialog, initialDir, callbackPluginId,
-		     requestId](WorldRuntime &targetRuntime)
+		    [title, defaultName, defaultExtension, filterString, saveDialog, initialDir, qmudHome,
+		     callbackPluginId, requestId](WorldRuntime &targetRuntime)
 		    {
 			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
 			    const bool                   queued = enqueueOnMainThread(
 			        [runtimeGuard, title, defaultName, defaultExtension, filterString, saveDialog, initialDir,
-			         callbackPluginId, requestId]()
+			         qmudHome, callbackPluginId, requestId]()
 			        {
 				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
 				        if (!targetRuntimeOnMain)
@@ -25999,9 +26098,23 @@ static int luaUtilsFilePicker(lua_State *L)
 					        return;
 				        }
 
-				        const QString resolvedPath  = QDir::toNativeSeparators(selectedPath);
-				        const QString browseDir     = QFileInfo(selectedPath).absolutePath();
-				        const bool    runtimeQueued = QMetaObject::invokeMethod(
+				        const QString cleanedSelected =
+				            QDir::cleanPath(QMudPluginPathUtils::normalizeSeparators(selectedPath));
+				        const QString selectedContainer =
+				            saveDialog ? QFileInfo(cleanedSelected).absolutePath() : cleanedSelected;
+				        if (!QMudPluginPathUtils::pathIsWithinOrEqualTo(selectedContainer, qmudHome))
+				        {
+					        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+					                              QStringLiteral("FilePicker"), false, eCouldNotOpenFile,
+					                              QString());
+					        return;
+				        }
+
+				        const QString resolvedPath =
+				            QMudPluginPathUtils::qmudHomeRelativePath(qmudHome, cleanedSelected, false);
+				        const QString browseDir = QMudPluginPathUtils::qmudHomeRelativePath(
+				            qmudHome, QFileInfo(cleanedSelected).absolutePath(), true);
+				        const bool runtimeQueued = QMetaObject::invokeMethod(
 				            targetRuntimeOnMain,
 				            [runtimeGuard, callbackPluginId, requestId, resolvedPath, browseDir]
 				            {
@@ -26058,15 +26171,26 @@ static int luaUtilsFilePicker(lua_State *L)
 		return 1;
 	}
 
+	const QString cleanedSelected = QDir::cleanPath(QMudPluginPathUtils::normalizeSeparators(selectedPath));
+	const QString selectedContainer =
+	    saveDialog ? QFileInfo(cleanedSelected).absolutePath() : cleanedSelected;
+	if (!QMudPluginPathUtils::pathIsWithinOrEqualTo(selectedContainer, qmudHome))
+	{
+		lua_pushnil(L);
+		return 1;
+	}
+
 	if (runtime)
 	{
 		const QString absolutePath = QFileInfo(selectedPath).absolutePath();
 		enqueueRuntimeThreadDeferredMutationNoResult(
 		    engine, runtime, [absolutePath](WorldRuntime &targetRuntime)
 		    { targetRuntime.setFileBrowsingDirectory(absolutePath); });
-		setCallbackFileBrowsingDirectorySnapshot(engine, runtime, absolutePath);
+		setCallbackFileBrowsingDirectorySnapshot(
+		    engine, runtime, QMudPluginPathUtils::qmudHomeRelativePath(qmudHome, absolutePath, true));
 	}
-	const QByteArray bytes = QDir::toNativeSeparators(selectedPath).toUtf8();
+	const QString    resultPath = QMudPluginPathUtils::qmudHomeRelativePath(qmudHome, cleanedSelected, false);
+	const QByteArray bytes      = resultPath.toUtf8();
 	lua_pushlstring(L, bytes.constData(), bytes.size());
 	return 1;
 }
@@ -41364,7 +41488,16 @@ static int luaWindowLoadImage(lua_State *L)
 			lua_pushnumber(L, eBadParameter);
 			return 1;
 		}
-		if (!QFileInfo::exists(trimmed))
+		QString resolvedFileName;
+		QString pathError;
+		if (!resolveLuaFileApiPath(engine, trimmed, &resolvedFileName, &pathError))
+		{
+			enqueueRuntimeLoad();
+			removeShadowImage();
+			lua_pushnumber(L, eFileNotFound);
+			return 1;
+		}
+		if (!QFileInfo::exists(resolvedFileName))
 		{
 			enqueueRuntimeLoad();
 			removeShadowImage();
@@ -41372,7 +41505,7 @@ static int luaWindowLoadImage(lua_State *L)
 			return 1;
 		}
 		QImage image;
-		if (!image.load(trimmed))
+		if (!image.load(resolvedFileName))
 		{
 			enqueueRuntimeLoad();
 			removeShadowImage();
@@ -41380,7 +41513,7 @@ static int luaWindowLoadImage(lua_State *L)
 			return 1;
 		}
 		enqueueRuntimeLoad();
-		loadCallbackMiniWindowShadowImage(engine, name, imageId, filename);
+		loadCallbackMiniWindowShadowImage(engine, name, imageId, resolvedFileName);
 		cacheCallbackMiniWindowImageExists(engine, name, imageId, true);
 		clearCallbackMiniWindowImageHasAlphaCache(engine, name, imageId);
 		invalidateCallbackMiniWindowListCachesForWindow(engine, name);
@@ -42109,10 +42242,18 @@ static int luaWindowWrite(lua_State *L)
 			lua_pushnumber(L, eBadParameter);
 			return 1;
 		}
+		QString resolvedFileName;
+		QString pathError;
+		if (!resolveLuaFileApiPath(engine, trimmedFileName, &resolvedFileName, &pathError))
+		{
+			lua_pushnumber(L, eCouldNotOpenFile);
+			return 1;
+		}
 		if (const MiniWindow *shadow = callbackMiniWindowShadowConst(engine, name))
 		{
-			lua_pushnumber(
-			    L, MiniWindowUtils::saveWindowImage24Bit(*shadow, trimmedFileName) ? eOK : eCouldNotOpenFile);
+			lua_pushnumber(L, MiniWindowUtils::saveWindowImage24Bit(*shadow, resolvedFileName)
+			                      ? eOK
+			                      : eCouldNotOpenFile);
 			return 1;
 		}
 		if (callbackScopeSyncBridgeForbidden())
@@ -42148,7 +42289,7 @@ static int luaWindowWrite(lua_State *L)
 		snapshotWindow.height =
 		    qMax(1, static_cast<int>(std::ceil(snapshot.deviceIndependentSize().height())));
 		snapshotWindow.setBackingSurface(snapshot);
-		lua_pushnumber(L, MiniWindowUtils::saveWindowImage24Bit(snapshotWindow, trimmedFileName)
+		lua_pushnumber(L, MiniWindowUtils::saveWindowImage24Bit(snapshotWindow, resolvedFileName)
 		                      ? eOK
 		                      : eCouldNotOpenFile);
 		return 1;
@@ -42776,6 +42917,123 @@ static int luaWindowMenu(lua_State *L)
 }
 #endif
 
+static void installLuaFilePathCompat(lua_State *L, LuaCallbackEngine *engine)
+{
+	if (!L)
+		return;
+
+	lua_pushlightuserdata(L, engine);
+	lua_pushcclosure(L, luaResolveFilePathForApi, 1);
+	lua_setglobal(L, "__qmud_resolve_file_path");
+
+	static const auto *kFilePathCompatScript = R"lua(
+if not rawget(_G, "__qmud_file_path_compat_installed") then
+__qmud_file_path_compat_installed = true
+local qmud_resolve_file_path = __qmud_resolve_file_path
+
+local function qmud_resolve_string_path(path)
+  if type(path) ~= "string" then return path end
+  return qmud_resolve_file_path(path)
+end
+
+if type(io) == "table" then
+  local io_open = io.open
+  if type(io_open) == "function" then
+    io.open = function(filename, mode)
+      return io_open(qmud_resolve_string_path(filename), mode)
+    end
+  end
+
+  local io_lines = io.lines
+  if type(io_lines) == "function" then
+    io.lines = function(filename, ...)
+      if filename == nil then
+        return io_lines()
+      end
+      return io_lines(qmud_resolve_string_path(filename), ...)
+    end
+  end
+
+  local io_input = io.input
+  if type(io_input) == "function" then
+    io.input = function(file)
+      if file == nil then
+        return io_input()
+      end
+      return io_input(qmud_resolve_string_path(file))
+    end
+  end
+
+  local io_output = io.output
+  if type(io_output) == "function" then
+    io.output = function(file)
+      if file == nil then
+        return io_output()
+      end
+      return io_output(qmud_resolve_string_path(file))
+    end
+  end
+end
+
+if type(os) == "table" then
+  local os_remove = os.remove
+  if type(os_remove) == "function" then
+    os.remove = function(filename)
+      return os_remove(qmud_resolve_string_path(filename))
+    end
+  end
+
+  local os_rename = os.rename
+  if type(os_rename) == "function" then
+    os.rename = function(oldname, newname)
+      return os_rename(qmud_resolve_string_path(oldname), qmud_resolve_string_path(newname))
+    end
+  end
+end
+
+local qmud_loadfile = loadfile
+if type(qmud_loadfile) == "function" then
+  loadfile = function(filename)
+    if filename == nil then
+      return qmud_loadfile()
+    end
+    return qmud_loadfile(qmud_resolve_string_path(filename))
+  end
+end
+
+local qmud_dofile = dofile
+if type(qmud_dofile) == "function" then
+  dofile = function(filename)
+    if filename == nil then
+      return qmud_dofile()
+    end
+    return qmud_dofile(qmud_resolve_string_path(filename))
+  end
+end
+
+if type(sqlite3) == "table" and type(sqlite3.open) == "function" then
+  local sqlite_open = sqlite3.open
+  sqlite3.open = function(filename, ...)
+    if filename == ":memory:" then
+      return sqlite_open(filename, ...)
+    end
+    return sqlite_open(qmud_resolve_string_path(filename), ...)
+  end
+end
+end
+)lua";
+
+	const bool         failed = luaL_dostring(L, kFilePathCompatScript) != 0;
+	lua_pushnil(L);
+	lua_setglobal(L, "__qmud_resolve_file_path");
+	if (failed)
+	{
+		const char *err = lua_tostring(L, -1);
+		qWarning() << "Failed to install Lua file path normalization mapping:" << (err ? err : "<unknown>");
+		lua_pop(L, 1);
+	}
+}
+
 bool LuaCallbackEngine::ensureState()
 {
 	bindOrAssertExecutionThread("LuaCallbackEngine::ensureState");
@@ -42801,7 +43059,10 @@ bool LuaCallbackEngine::ensureState()
 	}
 
 	if (!m_worldBindingsReady)
+	{
 		registerWorldBindings();
+		installLuaFilePathCompat(m_state, this);
+	}
 
 	if (!m_packageRestrictionsApplied || m_packageRestrictionsAppliedValue != m_allowPackage)
 	{
@@ -42960,7 +43221,18 @@ static int luaTestGetInfo(lua_State *L)
 		lua_pushnil(L);
 		return 1;
 	}
-	const int infoType = static_cast<int>(luaL_checkinteger(L, 1));
+	WorldRuntime *runtime  = engine->worldRuntimeForBridgedCall();
+	const int     infoType = static_cast<int>(luaL_checkinteger(L, 1));
+	if (infoType == 56)
+	{
+		pushLuaString(L, QMudPluginPathUtils::normalizeSeparators(QCoreApplication::applicationFilePath()));
+		return 1;
+	}
+	if (!runtime)
+	{
+		lua_pushnil(L);
+		return 1;
+	}
 	if (infoType == 86)
 	{
 		if (const auto *snapshot = engine->currentDispatchMiniWindowSnapshot();
@@ -42972,9 +43244,76 @@ static int luaTestGetInfo(lua_State *L)
 			lua_pushlstring(L, bytes.constData(), bytes.size());
 			return 1;
 		}
+		lua_pushstring(L, "");
+		return 1;
 	}
-	lua_pushnil(L);
-	return 1;
+
+	const auto pushRelative = [L, engine](const QString &path, const bool trailingSlash)
+	{
+		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, path, trailingSlash));
+		return 1;
+	};
+	const auto pushAttribute = [&](const QString &key, const bool trailingSlash)
+	{ return pushRelative(runtime->worldAttributeValue(key), trailingSlash); };
+
+	switch (infoType)
+	{
+	case 9:
+		return pushAttribute(QStringLiteral("new_activity_sound"), false);
+	case 10:
+		return pushAttribute(QStringLiteral("script_editor"), false);
+	case 35:
+		return pushAttribute(QStringLiteral("script_filename"), false);
+	case 40:
+		return pushAttribute(QStringLiteral("auto_log_file_name"), false);
+	case 50:
+		return pushAttribute(QStringLiteral("beep_sound"), false);
+	case 59:
+	case 64:
+		return pushRelative(qmudHomeForLuaFileApi(engine), true);
+	case 78:
+		return pushAttribute(QStringLiteral("foreground_image"), false);
+	case 79:
+		return pushAttribute(QStringLiteral("background_image"), false);
+	default:
+		break;
+	}
+
+	const WorldRuntime::RuntimeCountersSnapshot snapshot = runtime->runtimeCountersSnapshot(true);
+	switch (infoType)
+	{
+	case 51:
+		return pushRelative(snapshot.logFileName, false);
+	case 54:
+		return pushRelative(snapshot.worldFilePath, false);
+	case 57:
+		return pushRelative(snapshot.defaultWorldDirectory, true);
+	case 58:
+		return pushRelative(snapshot.defaultLogDirectory, true);
+	case 60:
+		return pushRelative(snapshot.pluginsDirectory, true);
+	case 66:
+	case 68:
+		return pushRelative(snapshot.startupDirectory, true);
+	case 67:
+		return pushRelative(
+		    QFileInfo(QMudPluginPathUtils::normalizeSeparators(snapshot.worldFilePath)).path(), true);
+	case 69:
+		return pushRelative(snapshot.translatorFile, false);
+	case 74:
+		return pushRelative(QDir(snapshot.startupDirectory).filePath(QStringLiteral("sounds")), true);
+	case 76:
+		return pushRelative(snapshot.firstSpecialFontPath, false);
+	case 82:
+		return pushRelative(snapshot.preferencesDatabaseName, false);
+	case 84:
+		return pushRelative(snapshot.fileBrowsingDirectory, true);
+	case 85:
+		return pushRelative(snapshot.stateFilesDirectory, true);
+	default:
+		lua_pushnil(L);
+		return 1;
+	}
 }
 
 static int luaTestNote(lua_State *L)
@@ -43190,6 +43529,14 @@ void LuaCallbackEngine::registerWorldBindings()
 	};
 	for (const LuaBindingEntry *entry = kMinimalWorldBindings; entry->name != nullptr; ++entry)
 		registerWorldFn(entry->name, entry->function);
+	lua_newtable(m_state);
+	lua_pushlightuserdata(m_state, this);
+	lua_pushcclosure(m_state, luaUtilsInfo, 1);
+	lua_setfield(m_state, -2, "info");
+	lua_pushlightuserdata(m_state, this);
+	lua_pushcclosure(m_state, luaUtilsReadDir, 1);
+	lua_setfield(m_state, -2, "readdir");
+	lua_setglobal(m_state, "utils");
 	lua_pushnumber(m_state, eOK);
 	lua_setglobal(m_state, "eOK");
 	m_worldBindingsReady = true;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -12,6 +12,7 @@
 #include "LuaApiExport.h"
 #include "MainFrame.h"
 #include "ReloadUtils.h"
+#include "WorldView.h"
 #include <QApplication>
 #include <QCoreApplication>
 #include <QDebug>
@@ -117,6 +118,7 @@ int main(int argc, char *argv[])
 	QCoreApplication::setApplicationName(QStringLiteral("QMud"));
 	QCoreApplication::setOrganizationName(QStringLiteral("QMudOrg"));
 	QApplication::setWindowIcon(QIcon(QStringLiteral(":/qmud/res/QMud.png")));
+	qmudInstallWorldOutputAccessibility();
 
 	const QStringList args      = QCoreApplication::arguments();
 	bool allowMultipleInstances = isEnabledValue(qEnvironmentVariable("QMUD_ALLOW_MULTI_INSTANCE").trimmed());

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -46,6 +46,7 @@
 #include "WorldView.h"
 #include "helpers/LuaExecutionUtils.h"
 #include "helpers/OutputWrapUtils.h"
+#include "helpers/PluginPathUtils.h"
 #include "scripting/ScriptingErrors.h"
 
 #include <QApplication>
@@ -3543,11 +3544,7 @@ namespace
 
 	QString normalizePathForRuntime(const QString &value)
 	{
-#ifdef Q_OS_WIN
-		return QDir::toNativeSeparators(value);
-#else
 		return normalizePathForStorage(value);
-#endif
 	}
 
 	bool isAbsolutePathLike(const QString &value)
@@ -3880,33 +3877,14 @@ namespace
 		if (normalized.isEmpty() || hasUrlScheme(normalized))
 			return normalized;
 
-		if (const QString portableRelative = extractPortableRootRelativePath(normalized);
-		    !portableRelative.isEmpty())
-		{
-			return toDotRelativePath(portableRelative);
-		}
-
-		if (!isAbsolutePathLike(normalized))
-			return toDotRelativePath(normalized);
-
-		if (normalized.startsWith(QLatin1Char('/')) && normalized.size() > 3 && normalized.at(1).isLetter() &&
-		    normalized.at(2) == QLatin1Char(':'))
-		{
-			normalized.remove(0, 1);
-		}
-
-		QString cleanedAbsolute = QDir::cleanPath(normalized);
-		if (!workingDir.isEmpty())
-		{
-			const QString relative = QDir(workingDir).relativeFilePath(cleanedAbsolute);
-			if (!relative.isEmpty() && relative != QStringLiteral("..") &&
-			    !relative.startsWith(QStringLiteral("../")) && !QDir::isAbsolutePath(relative))
-			{
-				return toDotRelativePath(relative);
-			}
-		}
-
-		return cleanedAbsolute;
+		const bool trailingSlash = normalized.endsWith(QLatin1Char('/'));
+		QString relative = QMudPluginPathUtils::qmudHomeRelativePath(workingDir, normalized, trailingSlash);
+		if (relative.isEmpty())
+			return {};
+		relative = toDotRelativePath(relative);
+		if (trailingSlash && !relative.endsWith(QLatin1Char('/')))
+			relative += QLatin1Char('/');
+		return relative;
 	}
 
 	QString canonicalizePathForRuntime(const QString &path, const QString &workingDir)
@@ -7331,15 +7309,22 @@ int WorldRuntime::addFontFromFile(const QString &path)
 	if (trimmed.isEmpty())
 		return eBadParameter;
 
-	QFileInfo const info(trimmed);
+	QString resolved;
+	QString error;
+	if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, trimmed, &resolved, &error))
+		return eFileNotFound;
+
+	QFileInfo const info(resolved);
 	if (!info.exists())
 		return eFileNotFound;
 
-	const QString key = info.absoluteFilePath();
+	const QString absoluteFontPath = info.absoluteFilePath();
+	const QString key =
+	    QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, absoluteFontPath, false);
 	if (m_specialFontPaths.contains(key))
 		return eOK;
 
-	const int fontId = QFontDatabase::addApplicationFont(key);
+	const int fontId = QFontDatabase::addApplicationFont(absoluteFontPath);
 	if (fontId < 0)
 		return eFileNotFound;
 
@@ -7513,7 +7498,7 @@ void WorldRuntime::setClientStartTime(const QDateTime &when)
 
 void WorldRuntime::setWorldFilePath(const QString &path)
 {
-	m_worldFilePath = path;
+	m_worldFilePath = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, false);
 }
 
 QString WorldRuntime::worldFilePath() const
@@ -7727,11 +7712,22 @@ bool WorldRuntime::saveWorldFile(const QString &fileName, QString *error)
 	// Preserve ordering: run world/plugin save callbacks before persisting.
 	fireWorldSaveHandlers();
 
-	SaveSnapshot const snapshot = buildSaveSnapshot(trimmed);
+	QString resolvedFileName;
+	QString pathError;
+	if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, trimmed, &resolvedFileName,
+	                                                &pathError))
+	{
+		if (error)
+			*error = pathError;
+		return false;
+	}
+
+	SaveSnapshot const snapshot = buildSaveSnapshot(resolvedFileName);
 	if (!writeSaveSnapshot(snapshot, error))
 		return false;
 
-	m_worldFilePath = snapshot.targetFilePath;
+	m_worldFilePath =
+	    QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, snapshot.targetFilePath, false);
 	if (saveStateMatchesSnapshot(snapshot))
 	{
 		setWorldFileModified(false);
@@ -7758,7 +7754,17 @@ void WorldRuntime::saveWorldFileAsync(const QString                             
 	// Preserve ordering: run world/plugin save callbacks before persisting.
 	fireWorldSaveHandlers();
 
-	auto           snapshot = QSharedPointer<SaveSnapshot>::create(buildSaveSnapshot(trimmed));
+	QString resolvedFileName;
+	QString pathError;
+	if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, trimmed, &resolvedFileName,
+	                                                &pathError))
+	{
+		if (completion)
+			completion(false, pathError);
+		return;
+	}
+
+	auto           snapshot = QSharedPointer<SaveSnapshot>::create(buildSaveSnapshot(resolvedFileName));
 	QPointer const guard(this);
 	auto           completionFn =
 	    QSharedPointer<std::function<void(bool, const QString &)>>::create(std::move(completion));
@@ -7776,7 +7782,8 @@ void WorldRuntime::saveWorldFileAsync(const QString                             
 
 			                           if (ok)
 			                           {
-				                           guard->m_worldFilePath = snapshot->targetFilePath;
+				                           guard->m_worldFilePath = QMudPluginPathUtils::qmudHomeRelativePath(
+				                               guard->m_startupDirectory, snapshot->targetFilePath, false);
 				                           if (guard->saveStateMatchesSnapshot(*snapshot))
 				                           {
 					                           guard->setWorldFileModified(false);
@@ -7794,9 +7801,11 @@ bool WorldRuntime::writeSaveSnapshot(const SaveSnapshot &snapshot, QString *erro
 {
 	SaveSnapshot  normalizedSnapshot = snapshot;
 	const QString workingDir         = resolveWorkingDir(normalizedSnapshot.startupDirectory);
-	const QString worldDir   = normalizedSnapshot.worldFilePath.trimmed().isEmpty()
-	                               ? QString()
-	                               : QFileInfo(normalizedSnapshot.worldFilePath.trimmed()).absolutePath();
+	const QString worldFilePath      = normalizedSnapshot.worldFilePath.trimmed();
+	const QString absoluteWorldFilePath =
+	    worldFilePath.isEmpty() ? QString() : makeAbsolutePath(worldFilePath, workingDir);
+	const QString worldDir =
+	    absoluteWorldFilePath.isEmpty() ? QString() : QFileInfo(absoluteWorldFilePath).absolutePath();
 	const QString pluginsDir = normalizedSnapshot.pluginsDirectory.trimmed();
 
 	const auto    normalizePathAttributes = [&](QMap<QString, QString> &attributes)
@@ -8518,7 +8527,7 @@ bool WorldRuntime::writeSaveSnapshot(const SaveSnapshot &snapshot, QString *erro
 
 void WorldRuntime::setPluginsDirectory(const QString &path)
 {
-	m_pluginsDirectory = path;
+	m_pluginsDirectory = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, true);
 }
 
 QString WorldRuntime::pluginsDirectory() const
@@ -8528,7 +8537,7 @@ QString WorldRuntime::pluginsDirectory() const
 
 void WorldRuntime::setStateFilesDirectory(const QString &path)
 {
-	m_stateFilesDirectory = path;
+	m_stateFilesDirectory = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, true);
 }
 
 QString WorldRuntime::stateFilesDirectory() const
@@ -8538,7 +8547,7 @@ QString WorldRuntime::stateFilesDirectory() const
 
 void WorldRuntime::setFileBrowsingDirectory(const QString &path)
 {
-	m_fileBrowsingDirectory = path;
+	m_fileBrowsingDirectory = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, true);
 }
 
 QString WorldRuntime::fileBrowsingDirectory() const
@@ -8548,7 +8557,7 @@ QString WorldRuntime::fileBrowsingDirectory() const
 
 void WorldRuntime::setPreferencesDatabaseName(const QString &path)
 {
-	m_preferencesDatabaseName = path;
+	m_preferencesDatabaseName = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, false);
 }
 
 QString WorldRuntime::preferencesDatabaseName() const
@@ -8558,7 +8567,7 @@ QString WorldRuntime::preferencesDatabaseName() const
 
 void WorldRuntime::setTranslatorFile(const QString &path)
 {
-	m_translatorFile = path;
+	m_translatorFile = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, false);
 }
 
 QString WorldRuntime::translatorFile() const
@@ -9846,12 +9855,8 @@ QSharedPointer<const LuaCallbackMiniWindowSnapshot> WorldRuntime::captureLuaCall
 		QString dir = plugin.directory;
 		if (!dir.isEmpty() && !dir.endsWith('/') && !dir.endsWith('\\'))
 			dir += '/';
-#ifdef Q_OS_WIN
-		snapshot->pluginDirectoriesById.insert(pluginId, QDir::toNativeSeparators(dir));
-#else
 		dir.replace(QLatin1Char('\\'), QLatin1Char('/'));
 		snapshot->pluginDirectoriesById.insert(pluginId, dir);
-#endif
 		snapshot->pluginEnabledById.insert(pluginId, plugin.enabled);
 		snapshot->pluginEnginesById.insert(pluginId, plugin.lua);
 		if (const auto functionsIt = m_pluginLuaFunctionCatalogById.constFind(pluginId);
@@ -10391,15 +10396,6 @@ static double normalizeSoundVolume(double volume)
 	return qBound(0.0, scaled, 1.0);
 }
 
-static bool isAbsolutePathPortable(const QString &path)
-{
-	if (path.isEmpty())
-		return false;
-	const QChar first   = path.at(0);
-	const bool  isDrive = path.size() > 1 && path.at(1) == QLatin1Char(':') && first.isLetter();
-	return isDrive || first == QLatin1Char('/') || first == QLatin1Char('\\');
-}
-
 int WorldRuntime::playSound(int buffer, const QString &fileName, bool loop, double volume, double pan)
 {
 	if (QThread::currentThread() != thread())
@@ -10480,28 +10476,20 @@ int WorldRuntime::playSound(int buffer, const QString &fileName, bool loop, doub
 		entry.tempFile = nullptr;
 	}
 
-	const QString workingDir         = resolveWorkingDir(m_startupDirectory);
-	const QString normalizedFileName = normalizeSeparators(fileName.trimmed());
+	const QString relative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(fileName);
 	QString       resolved;
 	QStringList   candidates;
-	if (isAbsolutePathPortable(normalizedFileName))
-	{
-		candidates.push_back(normalizedFileName);
-	}
-	else
-	{
-		QString relative = normalizedFileName;
-		if (relative.startsWith(QStringLiteral("./")))
-			relative = relative.mid(2);
-		QDir const base(workingDir);
-		if (!relative.startsWith(QStringLiteral("sounds/"), Qt::CaseInsensitive))
-			candidates.push_back(base.filePath(QStringLiteral("sounds/%1").arg(relative)));
-		candidates.push_back(base.filePath(relative));
-	}
+	if (!relative.isEmpty() && !relative.startsWith(QStringLiteral("sounds/"), Qt::CaseInsensitive))
+		candidates.push_back(QStringLiteral("sounds/%1").arg(relative));
+	candidates.push_back(fileName);
 
 	for (const QString &candidate : candidates)
 	{
-		const QString normalizedCandidate = QDir::cleanPath(normalizeSeparators(candidate));
+		QString normalizedCandidate;
+		QString error;
+		if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, candidate, &normalizedCandidate,
+		                                                &error))
+			continue;
 		if (QFileInfo::exists(normalizedCandidate))
 		{
 			resolved = normalizedCandidate;
@@ -11456,11 +11444,21 @@ int WorldRuntime::setBackgroundImage(const QString &fileName, int mode)
 {
 	if (mode < 0 || mode > 13)
 		return eBadParameter;
-	const int result = loadWorldImageFile(fileName, &m_backgroundImage, &m_backgroundImageName);
+	QString resolvedFileName;
+	QString error;
+	if (!fileName.trimmed().isEmpty() &&
+	    !QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, fileName, &resolvedFileName, &error))
+		return eFileNotFound;
+	const QString imageFileName = fileName.trimmed().isEmpty() ? QString() : resolvedFileName;
+	const int     result        = loadWorldImageFile(imageFileName, &m_backgroundImage, nullptr);
 	if (result == eOK)
 	{
 		m_backgroundImageMode = mode;
-		m_worldFileModified   = true;
+		m_backgroundImageName =
+		    imageFileName.isEmpty()
+		        ? QString()
+		        : QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, imageFileName, false);
+		m_worldFileModified = true;
 		if (m_view)
 		{
 			m_view->applyRuntimeSettings();
@@ -11474,11 +11472,21 @@ int WorldRuntime::setForegroundImage(const QString &fileName, int mode)
 {
 	if (mode < 0 || mode > 13)
 		return eBadParameter;
-	const int result = loadWorldImageFile(fileName, &m_foregroundImage, &m_foregroundImageName);
+	QString resolvedFileName;
+	QString error;
+	if (!fileName.trimmed().isEmpty() &&
+	    !QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, fileName, &resolvedFileName, &error))
+		return eFileNotFound;
+	const QString imageFileName = fileName.trimmed().isEmpty() ? QString() : resolvedFileName;
+	const int     result        = loadWorldImageFile(imageFileName, &m_foregroundImage, nullptr);
 	if (result == eOK)
 	{
 		m_foregroundImageMode = mode;
-		m_worldFileModified   = true;
+		m_foregroundImageName =
+		    imageFileName.isEmpty()
+		        ? QString()
+		        : QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, imageFileName, false);
+		m_worldFileModified = true;
 		if (m_view)
 		{
 			m_view->applyRuntimeSettings();
@@ -12926,15 +12934,24 @@ int WorldRuntime::openLog(const QString &logFileName, bool append)
 	if (m_logFileName.isEmpty())
 		return eCouldNotOpenFile;
 
-	// Resolve relative log paths under the configured default log directory.
-	// If no default is configured, fall back to <startup>/logs.
 	const QString workingDir = resolveWorkingDir(m_startupDirectory);
 	QString       logBaseDir = m_defaultLogDirectory.trimmed();
 	if (logBaseDir.isEmpty())
 		logBaseDir = QDir::cleanPath(QDir(workingDir).filePath(QStringLiteral("logs")));
 	else
 		logBaseDir = makeAbsolutePath(logBaseDir, workingDir);
-	m_logFileName = makeAbsolutePath(m_logFileName, logBaseDir);
+	const QString baseRelative =
+	    QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, logBaseDir, true);
+	QString logRelative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(m_logFileName);
+	if (logRelative.isEmpty() && !QMudPluginPathUtils::normalizeSeparators(m_logFileName).isEmpty())
+		return eCouldNotOpenFile;
+	if (!baseRelative.isEmpty() && baseRelative != QLatin1String("./") &&
+	    !logRelative.startsWith(QStringLiteral("logs/"), Qt::CaseInsensitive) &&
+	    !logRelative.startsWith(QStringLiteral("worlds/"), Qt::CaseInsensitive))
+		logRelative = QDir::cleanPath(QDir(baseRelative).filePath(logRelative));
+	QString error;
+	if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, logRelative, &m_logFileName, &error))
+		return eCouldNotOpenFile;
 
 	// Ensure missing parent folders (for patterns like logs/foo/bar.txt) exist.
 	const QFileInfo logInfo(m_logFileName);
@@ -13165,12 +13182,12 @@ QString WorldRuntime::formatTime(const QDateTime &time, const QString &format, b
 
 void WorldRuntime::setDefaultWorldDirectory(const QString &path)
 {
-	m_defaultWorldDirectory = path;
+	m_defaultWorldDirectory = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, true);
 }
 
 void WorldRuntime::setDefaultLogDirectory(const QString &path)
 {
-	m_defaultLogDirectory = path;
+	m_defaultLogDirectory = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, path, true);
 }
 
 void WorldRuntime::setStartupDirectory(const QString &path)
@@ -16963,25 +16980,32 @@ int WorldRuntime::databaseOpen(const QString &name, const QString &filename, int
 		                          { return databaseOpen(name, filename, flags); });
 
 	qmudAssertObjectThreadAffinity(this, "WorldRuntime::databaseOpen");
+	const bool isMemory = (flags & SQLITE_OPEN_MEMORY) != 0 || filename == QStringLiteral(":memory:");
+	QString    diskName = filename;
+	if (!isMemory)
+	{
+		QString error;
+		if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, filename, &diskName, &error))
+			return SQLITE_CANTOPEN;
+	}
 	const auto it = m_databases.find(name);
 	if (it != m_databases.end())
 	{
-		if (it->diskName == filename)
+		if (it->diskName == diskName)
 			return SQLITE_OK;
 		return kDbErrorDatabaseAlreadyExists;
 	}
 
-	const bool isMemory = (flags & SQLITE_OPEN_MEMORY) != 0 || filename == QStringLiteral(":memory:");
-	if (!isMemory && (flags & SQLITE_OPEN_CREATE) == 0 && !QFileInfo::exists(filename))
+	if (!isMemory && (flags & SQLITE_OPEN_CREATE) == 0 && !QFileInfo::exists(diskName))
 		return SQLITE_CANTOPEN;
 
 	static std::atomic<quint64> connectionCounter{0};
 	DatabaseEntry               entry;
-	entry.diskName = filename;
+	entry.diskName = diskName;
 	entry.connectionName =
 	    QStringLiteral("world_db_%1").arg(connectionCounter.fetch_add(1, std::memory_order_relaxed) + 1);
 	entry.db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), entry.connectionName);
-	entry.db.setDatabaseName(isMemory ? QStringLiteral(":memory:") : filename);
+	entry.db.setDatabaseName(isMemory ? QStringLiteral(":memory:") : diskName);
 	if (flags & SQLITE_OPEN_READONLY)
 		entry.db.setConnectOptions(QStringLiteral("QSQLITE_OPEN_READONLY"));
 	if (!entry.db.open())
@@ -17676,41 +17700,28 @@ bool WorldRuntime::loadPluginFile(const QString &fileName, QString *error, bool 
 		return false;
 	}
 
-	QString const workingDir = resolveWorkingDir(m_startupDirectory);
-	QString       pluginsDir = m_pluginsDirectory;
-	if (!pluginsDir.isEmpty())
-		pluginsDir = makeAbsolutePath(pluginsDir, workingDir);
-	QString resolved = normalizeSeparators(raw);
-	if (resolved.startsWith(QStringLiteral("./")) || resolved.startsWith(QStringLiteral(".\\")))
-		resolved = resolved.mid(2);
+	const QString pluginsRelative =
+	    QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, m_pluginsDirectory, true);
+	const QString rawRelative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(raw);
+	QStringList   candidates;
+	if (!rawRelative.isEmpty() && !pluginsRelative.isEmpty() && pluginsRelative != QLatin1String("./") &&
+	    !rawRelative.startsWith(QStringLiteral("worlds/"), Qt::CaseInsensitive) &&
+	    !rawRelative.startsWith(QStringLiteral("plugins/"), Qt::CaseInsensitive))
+		candidates.push_back(QDir::cleanPath(QDir(pluginsRelative).filePath(rawRelative)));
+	candidates.push_back(raw);
 
-	if (resolved.startsWith(QLatin1Char('/')))
+	QString resolved;
+	for (const QString &candidate : candidates)
 	{
-		QString candidate = resolved;
-		while (candidate.startsWith(QLatin1Char('/')))
-			candidate.remove(0, 1);
-		const QString lower = candidate.toLower();
-		const bool    looksPortable =
-		    lower == QStringLiteral("worlds") || lower.startsWith(QStringLiteral("worlds/")) ||
-		    lower == QStringLiteral("logs") || lower.startsWith(QStringLiteral("logs/"));
-		if (looksPortable)
-			resolved = candidate;
+		QString errorMessage;
+		if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, candidate, &resolved,
+		                                                &errorMessage))
+			continue;
+		if (QFileInfo::exists(resolved))
+			break;
+		resolved.clear();
 	}
 	QFileInfo info(resolved);
-	if (!info.isAbsolute())
-	{
-		const QString normalizedResolved  = normalizeSeparators(resolved);
-		const QString normalizedPlugins   = normalizeSeparators(pluginsDir);
-		const QString normalizedWorking   = normalizeSeparators(workingDir);
-		const bool    looksLikeWorldsPath = normalizedResolved.startsWith(QStringLiteral("worlds/"));
-		const bool    pluginsIsWorlds     = normalizedPlugins.endsWith(QStringLiteral("worlds/plugins/")) ||
-		                                    normalizedPlugins.endsWith(QStringLiteral("worlds/plugins"));
-		if (!normalizedPlugins.isEmpty() && !looksLikeWorldsPath && !pluginsIsWorlds)
-			resolved = QDir::cleanPath(QDir(normalizedPlugins).filePath(normalizedResolved));
-		else
-			resolved = QDir::cleanPath(QDir(normalizedWorking).filePath(normalizedResolved));
-		info = QFileInfo(resolved);
-	}
 
 	if (!info.exists())
 	{
@@ -17731,6 +17742,11 @@ bool WorldRuntime::loadPluginFile(const QString &fileName, QString *error, bool 
 		return false;
 	}
 
+	QString pluginsDir;
+	QString pluginsDirError;
+	static_cast<void>(QMudPluginPathUtils::resolveInsideQmudHome(
+	    m_startupDirectory, pluginsRelative.isEmpty() ? QStringLiteral("worlds/plugins") : pluginsRelative,
+	    &pluginsDir, &pluginsDirError));
 	if (!doc.expandIncludes(resolved, pluginsDir, resolveWorkingDir(m_startupDirectory),
 	                        m_stateFilesDirectory))
 	{
@@ -17757,8 +17773,10 @@ bool WorldRuntime::loadPluginFile(const QString &fileName, QString *error, bool 
 			existing.global = true;
 			if (existing.source.isEmpty())
 			{
-				existing.source    = resolved;
-				existing.directory = info.absolutePath();
+				existing.source =
+				    QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, resolved, false);
+				existing.directory =
+				    QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, info.absolutePath(), true);
 			}
 			return true;
 		}
@@ -17774,14 +17792,14 @@ bool WorldRuntime::loadPluginFile(const QString &fileName, QString *error, bool 
 	}
 
 	Plugin rp;
-	rp.attributes                  = p.attributes;
-	rp.description                 = p.description;
-	rp.script                      = p.script;
-	rp.source                      = resolved;
-	rp.directory                   = info.absolutePath();
-	rp.global                      = markGlobal;
-	rp.sequence                    = pluginSequenceFromAttributes(rp.attributes);
-	rp.version                     = rp.attributes.value(QStringLiteral("version")).toDouble();
+	rp.attributes  = p.attributes;
+	rp.description = p.description;
+	rp.script      = p.script;
+	rp.source      = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, resolved, false);
+	rp.directory   = QMudPluginPathUtils::qmudHomeRelativePath(m_startupDirectory, info.absolutePath(), true);
+	rp.global      = markGlobal;
+	rp.sequence    = pluginSequenceFromAttributes(rp.attributes);
+	rp.version     = rp.attributes.value(QStringLiteral("version")).toDouble();
 	rp.requiredVersion             = rp.attributes.value(QStringLiteral("requires")).toDouble();
 	rp.dateWritten                 = parsePluginDate(rp.attributes.value(QStringLiteral("date_written")));
 	rp.dateModified                = parsePluginDate(rp.attributes.value(QStringLiteral("date_modified")));
@@ -19479,6 +19497,12 @@ int WorldRuntime::chatSendFile(long id, const QString &path)
 		if (fileName.isEmpty())
 			return eFileNotFound;
 	}
+	else
+	{
+		QString error;
+		if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, fileName, &fileName, &error))
+			return eFileNotFound;
+	}
 
 	connection->m_ourFileName = fileName;
 	QFileInfo const info(fileName);
@@ -19921,12 +19945,8 @@ QVariant WorldRuntime::pluginInfo(const QString &pluginId, int infoType) const
 		QString dir = plugin.directory;
 		if (!dir.isEmpty() && !dir.endsWith('/') && !dir.endsWith('\\'))
 			dir += '/';
-#ifdef Q_OS_WIN
-		return QDir::toNativeSeparators(dir);
-#else
 		dir.replace(QLatin1Char('\\'), QLatin1Char('/'));
 		return dir;
-#endif
 	}
 	case 21:
 		return index + 1;
@@ -22753,10 +22773,15 @@ int WorldRuntime::windowLoadImage(const QString &name, const QString &imageId, c
 	if (!lower.endsWith(QStringLiteral(".bmp")) && !lower.endsWith(QStringLiteral(".png")))
 		return eBadParameter;
 
-	if (!QFileInfo::exists(trimmed))
+	QString resolved;
+	QString error;
+	if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, trimmed, &resolved, &error))
 		return eFileNotFound;
 
-	if (!MiniWindowUtils::loadImage(*window, imageId, trimmed))
+	if (!QFileInfo::exists(resolved))
+		return eFileNotFound;
+
+	if (!MiniWindowUtils::loadImage(*window, imageId, resolved))
 		return eUnableToLoadImage;
 	return eOK;
 }
@@ -22967,7 +22992,12 @@ int WorldRuntime::windowWrite(const QString &name, const QString &filename)
 	if (!lower.endsWith(QStringLiteral(".bmp")) && !lower.endsWith(QStringLiteral(".png")))
 		return eBadParameter;
 
-	if (!MiniWindowUtils::saveWindowImage24Bit(*window, trimmedFilename))
+	QString resolved;
+	QString error;
+	if (!QMudPluginPathUtils::resolveInsideQmudHome(m_startupDirectory, trimmedFilename, &resolved, &error))
+		return eCouldNotOpenFile;
+
+	if (!MiniWindowUtils::saveWindowImage24Bit(*window, resolved))
 		return eCouldNotOpenFile;
 	return eOK;
 }

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -10,6 +10,7 @@
 #include "WorldView.h"
 
 #include "AcceleratorUtils.h"
+#include "AccessibleTextUtils.h"
 #include "AppController.h"
 #include "Environment.h"
 #include "FontUtils.h"
@@ -27,6 +28,9 @@
 #include <QAbstractScrollArea>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QAbstractTextDocumentLayout>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QAccessible>
+#include <QAccessibleWidget>
 #include <QApplication>
 #include <QClipboard>
 #include <QColor>
@@ -79,7 +83,10 @@
 
 namespace
 {
-	int sizeToInt(const qsizetype value)
+	constexpr const char *kWorldOutputAccessibleProperty = "qmud_world_output_widget";
+	constexpr const char *kWorldOutputLiveProperty       = "qmud_world_output_live";
+
+	int                   sizeToInt(const qsizetype value)
 	{
 		constexpr qsizetype kMin = 0;
 		constexpr qsizetype kMax = std::numeric_limits<int>::max();
@@ -1092,6 +1099,9 @@ class WrapTextBrowser : public QAbstractScrollArea
 		explicit WrapTextBrowser(WorldView *view, QWidget *parent = nullptr, bool isLive = false)
 		    : QAbstractScrollArea(parent), m_view(view), m_isLive(isLive)
 		{
+			setAccessibleName(isLive ? QStringLiteral("Live world output") : QStringLiteral("World output"));
+			setProperty(kWorldOutputAccessibleProperty, true);
+			setProperty(kWorldOutputLiveProperty, isLive);
 			setFrameShape(QFrame::NoFrame);
 			setViewport(new QWidget(this));
 			if (QWidget *const vp = viewport())
@@ -1121,6 +1131,16 @@ class WrapTextBrowser : public QAbstractScrollArea
 		[[nodiscard]] QMargins viewportMarginsPublic() const
 		{
 			return viewportMargins();
+		}
+
+		[[nodiscard]] WorldView *worldView() const
+		{
+			return m_view;
+		}
+
+		[[nodiscard]] bool isLiveOutput() const
+		{
+			return m_isLive;
 		}
 
 	protected:
@@ -1246,6 +1266,231 @@ class WrapTextBrowser : public QAbstractScrollArea
 		bool         m_isLive{false};
 		LineWrapMode m_lineWrapMode{NoWrap};
 };
+
+class WorldOutputAccessible final : public QAccessibleWidget, public QAccessibleTextInterface
+{
+	public:
+		explicit WorldOutputAccessible(WrapTextBrowser *widget)
+		    : QAccessibleWidget(widget, QAccessible::Terminal,
+		                        widget && widget->isLiveOutput() ? QStringLiteral("Live world output")
+		                                                         : QStringLiteral("World output"))
+		{
+			if (widget && widget->worldView())
+				widget->worldView()->primeAccessibleOutputTextState();
+		}
+
+		void *interface_cast(const QAccessible::InterfaceType type) override
+		{
+			if (type == QAccessible::TextInterface)
+				return static_cast<QAccessibleTextInterface *>(this);
+			return QAccessibleWidget::interface_cast(type);
+		}
+
+		[[nodiscard]] QString text(const QAccessible::Text type) const override
+		{
+			if (type == QAccessible::Name)
+			{
+				const WrapTextBrowser *browser = outputWidget();
+				if (browser && browser->isLiveOutput())
+					return QStringLiteral("Live world output");
+				return QStringLiteral("World output");
+			}
+			if (type == QAccessible::Value)
+				return accessibleText().text(0, accessibleText().characterCount());
+			return QAccessibleWidget::text(type);
+		}
+
+		void selection(int selectionIndex, int *startOffset, int *endOffset) const override
+		{
+			if (startOffset)
+				*startOffset = 0;
+			if (endOffset)
+				*endOffset = 0;
+			if (selectionIndex != 0)
+				return;
+
+			int              startLine   = 0;
+			int              startColumn = 0;
+			int              endLine     = 0;
+			int              endColumn   = 0;
+			const WorldView *view        = worldView();
+			if (!view || !view->nativeOutputSelectionBounds(startLine, startColumn, endLine, endColumn))
+				return;
+
+			const QMudAccessibleTextUtils::LineOffsetMap map = accessibleText();
+			if (startOffset)
+				*startOffset = map.offsetForPosition({qMax(0, startLine - 1), qMax(0, startColumn - 1)});
+			if (endOffset)
+				*endOffset = map.offsetForPosition({qMax(0, endLine - 1), qMax(0, endColumn - 1)});
+		}
+
+		[[nodiscard]] int selectionCount() const override
+		{
+			int              startLine   = 0;
+			int              startColumn = 0;
+			int              endLine     = 0;
+			int              endColumn   = 0;
+			const WorldView *view        = worldView();
+			return view && view->nativeOutputSelectionBounds(startLine, startColumn, endLine, endColumn) ? 1
+			                                                                                             : 0;
+		}
+
+		void addSelection(int startOffset, int endOffset) override
+		{
+			setSelection(0, startOffset, endOffset);
+		}
+
+		void removeSelection(int selectionIndex) override
+		{
+			if (selectionIndex != 0)
+				return;
+			if (WorldView *view = worldView())
+				view->clearNativeOutputSelection(true);
+		}
+
+		void setSelection(int selectionIndex, int startOffset, int endOffset) override
+		{
+			if (selectionIndex != 0)
+				return;
+			WorldView       *view    = worldView();
+			WrapTextBrowser *browser = outputWidget();
+			if (!view || !browser)
+				return;
+
+			const QMudAccessibleTextUtils::LineOffsetMap map = accessibleText();
+			const QMudAccessibleTextUtils::TextPosition  start =
+			    map.positionForOffset(qMin(startOffset, endOffset));
+			const QMudAccessibleTextUtils::TextPosition end =
+			    map.positionForOffset(qMax(startOffset, endOffset));
+			view->setNativeOutputSelection(browser, {start.line, start.column}, {end.line, end.column},
+			                               false);
+		}
+
+		[[nodiscard]] int cursorPosition() const override
+		{
+			return characterCount();
+		}
+
+		void setCursorPosition(int position) override
+		{
+			Q_UNUSED(position);
+		}
+
+		[[nodiscard]] QString text(int startOffset, int endOffset) const override
+		{
+			return accessibleText().text(startOffset, endOffset);
+		}
+
+		[[nodiscard]] int characterCount() const override
+		{
+			return accessibleText().characterCount();
+		}
+
+		[[nodiscard]] QRect characterRect(int offset) const override
+		{
+			const QMudAccessibleTextUtils::LineOffsetMap map = accessibleText();
+			if (map.isEmpty())
+				return {};
+
+			const QMudAccessibleTextUtils::TextPosition position =
+			    map.positionForOffset(qBound(0, offset, map.characterCount()));
+			WorldView       *view    = worldView();
+			WrapTextBrowser *browser = outputWidget();
+			if (!view || !browser)
+				return {};
+
+			QRect rect;
+			return view->nativeOutputCharacterRect(browser, {position.line, position.column}, rect) ? rect
+			                                                                                        : QRect();
+		}
+
+		[[nodiscard]] int offsetAtPoint(const QPoint &point) const override
+		{
+			WorldView       *view    = worldView();
+			WrapTextBrowser *browser = outputWidget();
+			if (!view || !browser)
+				return -1;
+
+			WrapTextBrowser                *hitView = nullptr;
+			WorldView::NativeOutputPosition position;
+			if (!view->nativeOutputHitTestGlobal(point, hitView, position, nullptr, nullptr, true, true) ||
+			    hitView != browser)
+			{
+				return -1;
+			}
+
+			const QMudAccessibleTextUtils::LineOffsetMap map = accessibleText();
+			return map.offsetForPosition({position.line, position.column});
+		}
+
+		void scrollToSubstring(int startIndex, int endIndex) override
+		{
+			WorldView             *view    = worldView();
+			const WrapTextBrowser *browser = outputWidget();
+			if (!view || !browser)
+				return;
+
+			const QMudAccessibleTextUtils::LineOffsetMap map = accessibleText();
+			if (map.isEmpty())
+				return;
+
+			const QMudAccessibleTextUtils::TextPosition start =
+			    map.positionForOffset(qMin(startIndex, endIndex));
+			const QMudAccessibleTextUtils::TextPosition end =
+			    map.positionForOffset(qMax(startIndex, endIndex));
+			view->scrollNativeOutputRangeIntoView(browser, start.line, end.line);
+		}
+
+		QString attributes(int offset, int *startOffset, int *endOffset) const override
+		{
+			if (startOffset)
+				*startOffset = qBound(0, offset, characterCount());
+			if (endOffset)
+				*endOffset = qBound(0, offset, characterCount());
+			return {};
+		}
+
+	private:
+		[[nodiscard]] WrapTextBrowser *outputWidget() const
+		{
+			return dynamic_cast<WrapTextBrowser *>(widget());
+		}
+
+		[[nodiscard]] WorldView *worldView() const
+		{
+			const WrapTextBrowser *browser = outputWidget();
+			return browser ? browser->worldView() : nullptr;
+		}
+
+		[[nodiscard]] QMudAccessibleTextUtils::LineOffsetMap accessibleText() const
+		{
+			const WorldView *view = worldView();
+			if (!view)
+				return {};
+
+			const QVector<WorldView::NativeOutputRenderLine> &renderLines = view->nativeOutputRenderLines();
+			return WorldView::accessibleNativeOutputTextMap(renderLines);
+		}
+};
+
+QAccessibleInterface *worldOutputAccessibleFactory(const QString &className, QObject *object)
+{
+	Q_UNUSED(className);
+	auto *scrollArea = qobject_cast<QAbstractScrollArea *>(object);
+	if (!scrollArea || !scrollArea->property(kWorldOutputAccessibleProperty).toBool())
+		return nullptr;
+	auto *browser = dynamic_cast<WrapTextBrowser *>(scrollArea);
+	return browser ? new WorldOutputAccessible(browser) : nullptr;
+}
+
+void qmudInstallWorldOutputAccessibility()
+{
+	static bool installed = false;
+	if (installed)
+		return;
+	QAccessible::installFactory(worldOutputAccessibleFactory);
+	installed = true;
+}
 
 class InputTextEdit : public QPlainTextEdit
 {
@@ -2790,6 +3035,75 @@ void WorldView::requestNativeOutputPresentationRepaint(const bool repaintVisible
 	requestNativeOutputRepaint();
 }
 
+QMudAccessibleTextUtils::LineOffsetMap
+WorldView::accessibleNativeOutputTextMap(const QVector<NativeOutputRenderLine> &lines)
+{
+	QVector<QString> textLines;
+	textLines.reserve(lines.size());
+	for (const NativeOutputRenderLine &line : lines)
+		textLines.push_back(line.text);
+	return QMudAccessibleTextUtils::LineOffsetMap(std::move(textLines));
+}
+
+void WorldView::primeAccessibleOutputTextState() const
+{
+	const QMudAccessibleTextUtils::LineOffsetMap map =
+	    accessibleNativeOutputTextMap(nativeOutputRenderLines());
+	m_accessibleOutputCharacterCount = map.characterCount();
+	m_accessibleOutputRevision       = m_nativeRenderLineCacheRevision;
+}
+
+void WorldView::notifyAccessibleOutputPresented(const QVector<NativeOutputRenderLine> &lines) const
+{
+	if (!QAccessible::isActive())
+	{
+		m_accessibleOutputCharacterCount    = -1;
+		m_accessibleOutputRevision          = 0;
+		m_accessibleOutputPendingTailAppend = false;
+		return;
+	}
+
+	const QMudAccessibleTextUtils::LineOffsetMap map                   = accessibleNativeOutputTextMap(lines);
+	const int                                    currentCharacterCount = map.characterCount();
+	if (m_accessibleOutputCharacterCount < 0)
+	{
+		m_accessibleOutputCharacterCount = currentCharacterCount;
+		m_accessibleOutputRevision       = m_nativeRenderLineCacheRevision;
+		return;
+	}
+
+	const bool revisionChanged = m_accessibleOutputRevision != m_nativeRenderLineCacheRevision;
+	if (!revisionChanged)
+	{
+		m_accessibleOutputCharacterCount = currentCharacterCount;
+		return;
+	}
+
+	const bool exactTailAppend = m_accessibleOutputPendingTailAppend &&
+	                             (m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::TailAppend ||
+	                              !m_nativeRenderLineCacheFromRuntime);
+	if (currentCharacterCount > m_accessibleOutputCharacterCount && exactTailAppend)
+	{
+		const QString insertedText = map.text(m_accessibleOutputCharacterCount, currentCharacterCount);
+		if (!insertedText.isEmpty())
+		{
+			if (WrapTextBrowser *const target = activeOutputView())
+			{
+				QAccessibleTextInsertEvent event(target, m_accessibleOutputCharacterCount, insertedText);
+				QAccessible::updateAccessibility(&event);
+			}
+		}
+	}
+	else if (WrapTextBrowser *const target = activeOutputView())
+	{
+		QAccessibleEvent event(target, QAccessible::ValueChanged);
+		QAccessible::updateAccessibility(&event);
+	}
+	m_accessibleOutputCharacterCount    = currentCharacterCount;
+	m_accessibleOutputRevision          = m_nativeRenderLineCacheRevision;
+	m_accessibleOutputPendingTailAppend = false;
+}
+
 WorldView::NativeOutputPanePaintState *
 WorldView::nativeOutputPanePaintStateForView(const WrapTextBrowser *view) const
 {
@@ -3600,10 +3914,10 @@ bool WorldView::nativeLayoutCacheReadyFor(const QVector<NativeOutputRenderLine> 
 	    static_cast<qreal>(qMax(1, QFontMetrics(layoutFont).lineSpacing())) * lineSpacingFactor;
 	const quint64 styleKey             = nativeLayoutStyleKey();
 	const bool    cacheDimensionsMatch = m_nativeLayoutCumulativeHeights.size() == lines.size() + 1 &&
-	                                     m_nativeLayoutVisualRows.size() == lines.size() &&
-	                                     m_nativeLayoutLineLayouts.size() == lines.size() &&
-	                                     m_nativeLayoutLineContentHashes.size() == lines.size() &&
-	                                     m_nativeLayoutRowsExact.size() == lines.size();
+	                                  m_nativeLayoutVisualRows.size() == lines.size() &&
+	                                  m_nativeLayoutLineLayouts.size() == lines.size() &&
+	                                  m_nativeLayoutLineContentHashes.size() == lines.size() &&
+	                                  m_nativeLayoutRowsExact.size() == lines.size();
 	return m_nativeLayoutCacheValid && cacheDimensionsMatch &&
 	       m_nativeLayoutCachedRenderRevision == m_nativeRenderLineCacheRevision &&
 	       m_nativeLayoutCachedWrapWidth == wrapWidthPixels &&
@@ -3998,10 +4312,10 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 				break;
 			}
 
-			const NativeOutputRenderLine &line = lines.at(reusablePrefix);
-			const bool exactLineHasLayout      = m_nativeLayoutRowsExact.at(sourceIndex) == 0 ||
-			                                     line.text.isEmpty() ||
-			                                     static_cast<bool>(m_nativeLayoutLineLayouts.at(sourceIndex));
+			const NativeOutputRenderLine &line               = lines.at(reusablePrefix);
+			const bool                    exactLineHasLayout = m_nativeLayoutRowsExact.at(sourceIndex) == 0 ||
+			                                line.text.isEmpty() ||
+			                                static_cast<bool>(m_nativeLayoutLineLayouts.at(sourceIndex));
 			if (m_nativeLayoutVisualRows.at(sourceIndex) <= 0 || !exactLineHasLayout ||
 			    m_nativeLayoutLineContentHashes.at(sourceIndex) != lineContentHashForWidth(line))
 			{
@@ -4283,14 +4597,14 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 	}
 
 	const bool layoutRangesMatch      = renderDeltaFastPathApplied ? true : [&]
-	{
-		if (m_nativeLayoutRuntimeLineKeys.size() != lines.size())
-			return false;
-		if (lines.isEmpty())
-			return true;
-		return m_nativeLayoutRuntimeLineKeys.constFirst() == runtimeLineKeyForLine(lines.constFirst()) &&
-		       m_nativeLayoutRuntimeLineKeys.constLast() == runtimeLineKeyForLine(lines.constLast());
-	}();
+    {
+        if (m_nativeLayoutRuntimeLineKeys.size() != lines.size())
+            return false;
+        if (lines.isEmpty())
+            return true;
+        return m_nativeLayoutRuntimeLineKeys.constFirst() == runtimeLineKeyForLine(lines.constFirst()) &&
+               m_nativeLayoutRuntimeLineKeys.constLast() == runtimeLineKeyForLine(lines.constLast());
+    }();
 	const bool layoutRangesFullyMatch = (!renderDeltaFastPathApplied && renderRevisionChanged) ? [&]
 	{
 		if (m_nativeLayoutRuntimeLineKeys.size() != lines.size())
@@ -4599,7 +4913,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 		const int  effectiveWrapWidth = hasLocalContent ? localWrapWidthPixels : wrapWidthPixels;
 		const quint64 contentHash     = lineContentHashForWidth(line);
 		const bool    hashMatches     = i < m_nativeLayoutLineContentHashes.size() &&
-		                                m_nativeLayoutLineContentHashes.at(i) == contentHash;
+		                         m_nativeLayoutLineContentHashes.at(i) == contentHash;
 		if (!hashMatches)
 		{
 			m_nativeLayoutLineLayouts[i].clear();
@@ -5296,9 +5610,9 @@ const QVector<WorldView::NativeOutputRenderLine> &WorldView::nativeOutputRenderL
 	const qint64 oldFirstLineNumber   = m_nativeCachedRuntimeFirstLineNumber;
 	const qint64 oldLastLineNumber    = m_nativeCachedRuntimeLastLineNumber;
 	const bool   runtimeNowContiguous = newLastLineNumber >= newFirstLineNumber &&
-	                                    (newLastLineNumber - newFirstLineNumber + 1) == runtimeLines.size();
+	                                  (newLastLineNumber - newFirstLineNumber + 1) == runtimeLines.size();
 
-	auto         renderLineBeforeRuntimeLine = [](const NativeOutputRenderLine &line, const qint64 lineNumber)
+	auto renderLineBeforeRuntimeLine = [](const NativeOutputRenderLine &line, const qint64 lineNumber)
 	{ return line.lastRuntimeLineNumber > 0 && line.lastRuntimeLineNumber < lineNumber; };
 
 	auto renderLineStraddlesRuntimeLine = [](const NativeOutputRenderLine &line, const qint64 lineNumber)
@@ -5481,7 +5795,7 @@ const QVector<WorldView::NativeOutputRenderLine> &WorldView::nativeOutputRenderL
 		{
 			const WorldRuntime::LineEntry &previousEntry       = runtimeLines.at(previousRuntimeIndex);
 			const int                      previousRenderIndex = renderIndexForRuntimeLineNumberNear(
-			    previousEntry.lineNumber, previousRuntimeIndex, searchRenderCacheFromTail);
+                previousEntry.lineNumber, previousRuntimeIndex, searchRenderCacheFromTail);
 			if (previousRenderIndex >= 0)
 			{
 				if (previousEntry.hardReturn)
@@ -6091,16 +6405,16 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	if (viewportRect.width() <= 0 || viewportRect.height() <= 0)
 		return false;
 
-	const int    x = qBound(0, viewPos.x(), viewportRect.width() - 1);
-	const int    y = qBound(0, viewPos.y(), viewportRect.height() - 1);
+	const int   x = qBound(0, viewPos.x(), viewportRect.width() - 1);
+	const int   y = qBound(0, viewPos.y(), viewportRect.height() - 1);
 
-	const bool   wrapEnabled          = view->lineWrapMode() != WrapTextBrowser::NoWrap;
-	const int    wrapWidthPixels      = nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
-	const int    localWrapWidthPixels = nativeLocalWrapWidthPixels(viewportRect.width(), wrapEnabled);
-	const int    lineSpacing          = qMax(0, m_lineSpacing);
-	const qreal  lineAdvance = static_cast<qreal>(qMax(1, QFontMetrics(view->font()).lineSpacing())) *
-	                           ((100.0 + static_cast<qreal>(lineSpacing)) / 100.0);
-	const QFont &layoutFont  = view->font();
+	const bool  wrapEnabled          = view->lineWrapMode() != WrapTextBrowser::NoWrap;
+	const int   wrapWidthPixels      = nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
+	const int   localWrapWidthPixels = nativeLocalWrapWidthPixels(viewportRect.width(), wrapEnabled);
+	const int   lineSpacing          = qMax(0, m_lineSpacing);
+	const qreal lineAdvance          = static_cast<qreal>(qMax(1, QFontMetrics(view->font()).lineSpacing())) *
+	                          ((100.0 + static_cast<qreal>(lineSpacing)) / 100.0);
+	const QFont &layoutFont = view->font();
 	const bool   cacheReadyForHitTest =
 	    nativeLayoutCacheReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont);
 	if (!allowCacheBuild && !cacheReadyForHitTest)
@@ -6268,23 +6582,209 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	return true;
 }
 
+bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const NativeOutputPosition &position,
+                                          QRect &globalRect) const
+{
+	globalRect = {};
+	if (!nativeOutputInteractionActive() || !view || !view->viewport())
+		return false;
+
+	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	if (lines.isEmpty())
+		return false;
+
+	const QRect viewportRect = view->viewport()->rect();
+	if (viewportRect.width() <= 0 || viewportRect.height() <= 0)
+		return false;
+
+	const int    lineIndex = qBound(0, position.line, sizeToInt(lines.size()) - 1);
+
+	const bool   wrapEnabled          = view->lineWrapMode() != WrapTextBrowser::NoWrap;
+	const int    wrapWidthPixels      = nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
+	const int    localWrapWidthPixels = nativeLocalWrapWidthPixels(viewportRect.width(), wrapEnabled);
+	const int    lineSpacing          = qMax(0, m_lineSpacing);
+	const QFont &layoutFont           = view->font();
+	const qreal  fallbackLineAdvance  = static_cast<qreal>(qMax(1, QFontMetrics(layoutFont).lineSpacing())) *
+	                                  ((100.0 + static_cast<qreal>(lineSpacing)) / 100.0);
+
+	if (!nativeLayoutCacheReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont))
+		ensureNativeLayoutCaches(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont);
+	if (ensureNativeLayoutRange(lines, qMax(0, lineIndex - 2),
+	                            qMin(sizeToInt(lines.size()) - 1, lineIndex + 2), wrapWidthPixels,
+	                            localWrapWidthPixels, lineSpacing, layoutFont))
+	{
+		syncNativeOutputScrollBarsFromLayout(lines, false);
+	}
+
+	if (lineIndex + 1 >= m_nativeLayoutCumulativeHeights.size())
+		return false;
+
+	const qreal effectiveLineAdvance =
+	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : fallbackLineAdvance;
+	const qreal docY            = m_nativeLayoutCumulativeHeights.size() > lines.size()
+	                                  ? m_nativeLayoutCumulativeHeights.at(lines.size())
+	                                  : 0.0;
+	const int   nativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
+	int         scrollY         = 0;
+	int         scrollMax       = 0;
+	if (const QScrollBar *const bar = view->verticalScrollBar())
+	{
+		scrollY   = qMax(0, bar->value());
+		scrollMax = qMax(0, bar->maximum());
+	}
+
+	int effectiveScrollY = 0;
+	if (nativeMaxScroll > 0)
+	{
+		if (scrollMax > 0)
+		{
+			const double ratio = static_cast<double>(scrollY) / static_cast<double>(scrollMax);
+			effectiveScrollY =
+			    qBound(0, static_cast<int>(std::round(ratio * nativeMaxScroll)), nativeMaxScroll);
+		}
+		else
+			effectiveScrollY = qBound(0, scrollY, nativeMaxScroll);
+	}
+
+	const qreal                   lineTop    = m_nativeLayoutCumulativeHeights.at(lineIndex);
+	const qreal                   lineBottom = m_nativeLayoutCumulativeHeights.at(lineIndex + 1);
+	const qreal                   lineHeight = qMax<qreal>(1.0, lineBottom - lineTop);
+	const NativeOutputRenderLine &line       = lines.at(lineIndex);
+
+	const QTextLayout            *layout = nativeLayoutForLine(lineIndex);
+	if (line.text.isEmpty() || !layout || layout->lineCount() <= 0)
+	{
+		const QRect localRect(0, static_cast<int>(std::floor(lineTop - effectiveScrollY)), 1,
+		                      qMax(1, static_cast<int>(std::ceil(lineHeight))));
+		const QRect visibleRect = localRect.intersected(viewportRect);
+		if (visibleRect.isEmpty())
+			return false;
+		globalRect = QRect(view->viewport()->mapToGlobal(visibleRect.topLeft()), visibleRect.size());
+		return true;
+	}
+
+	const int textSize = sizeToInt(line.text.size());
+	const int column   = qBound(0, position.column, textSize);
+
+	QTextLine targetRow;
+	for (int i = 0; i < layout->lineCount(); ++i)
+	{
+		const QTextLine row      = layout->lineAt(i);
+		const int       rowStart = row.textStart();
+		const int       rowEnd   = rowStart + row.textLength();
+		if (column < rowEnd || i == layout->lineCount() - 1)
+		{
+			targetRow = row;
+			break;
+		}
+	}
+	if (!targetRow.isValid())
+		return false;
+
+	const int   rowStartColumn = targetRow.textStart();
+	const int   rowEndColumn   = rowStartColumn + targetRow.textLength();
+	const int   leadingColumn  = qBound(rowStartColumn, column, rowEndColumn);
+	const int   trailingColumn = qBound(rowStartColumn, leadingColumn + 1, rowEndColumn);
+	const qreal leadingX       = targetRow.cursorToX(leadingColumn);
+	const qreal trailingX =
+	    trailingColumn > leadingColumn ? targetRow.cursorToX(trailingColumn) : leadingX + 1.0;
+	const qreal leftX  = qMin(leadingX, trailingX);
+	const qreal rightX = qMax(leadingX, trailingX);
+	const QRect localRect(static_cast<int>(std::floor(leftX)),
+	                      static_cast<int>(std::floor(lineTop - effectiveScrollY + targetRow.y())),
+	                      qMax(1, static_cast<int>(std::ceil(rightX - leftX))),
+	                      qMax(1, static_cast<int>(std::ceil(effectiveLineAdvance))));
+	const QRect visibleRect = localRect.intersected(viewportRect);
+	if (visibleRect.isEmpty())
+		return false;
+
+	globalRect = QRect(view->viewport()->mapToGlobal(visibleRect.topLeft()), visibleRect.size());
+	return true;
+}
+
+void WorldView::scrollNativeOutputRangeIntoView(const WrapTextBrowser *view, int firstLine,
+                                                int lastLine) const
+{
+	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	if (lines.isEmpty() || !view || !view->viewport())
+		return;
+
+	QScrollBar *const bar = view->verticalScrollBar();
+	if (!bar)
+		return;
+
+	const QRect viewportRect = view->viewport()->rect();
+	if (viewportRect.isEmpty())
+		return;
+
+	firstLine = qBound(0, firstLine, sizeToInt(lines.size()) - 1);
+	lastLine  = qBound(0, lastLine, sizeToInt(lines.size()) - 1);
+	if (firstLine > lastLine)
+		std::swap(firstLine, lastLine);
+
+	const bool   wrapEnabled          = view->lineWrapMode() != WrapTextBrowser::NoWrap;
+	const int    wrapWidthPixels      = nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
+	const int    localWrapWidthPixels = nativeLocalWrapWidthPixels(viewportRect.width(), wrapEnabled);
+	const int    lineSpacingSetting   = qMax(0, m_lineSpacing);
+	const QFont &layoutFont           = view->font();
+	ensureNativeLayoutCaches(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting, layoutFont);
+	const bool layoutHeightChanged = ensureNativeLayoutRange(
+	    lines, firstLine, lastLine, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting, layoutFont);
+	if (layoutHeightChanged)
+		syncNativeOutputScrollBarsFromLayout(lines, false);
+
+	if (lastLine + 1 >= m_nativeLayoutCumulativeHeights.size())
+		return;
+
+	const int rangeTop = qMax(0, static_cast<int>(std::floor(m_nativeLayoutCumulativeHeights.at(firstLine))));
+	const int rangeBottom =
+	    qMax(rangeTop + 1, static_cast<int>(std::ceil(m_nativeLayoutCumulativeHeights.at(lastLine + 1))));
+
+	const int currentTop    = bar->value();
+	const int pageStep      = qMax(1, bar->pageStep());
+	const int currentBottom = currentTop + pageStep;
+	int       target        = currentTop;
+	if (rangeTop < currentTop)
+		target = rangeTop;
+	else if (rangeBottom > currentBottom)
+		target = rangeBottom - pageStep;
+
+	target = qBound(bar->minimum(), target, bar->maximum());
+	if (view == m_output && target < bar->maximum())
+		const_cast<WorldView *>(this)->setScrollbackSplitActive(true);
+	if (target == bar->value())
+		return;
+	if (view == m_output && m_outputScrollBar)
+		m_outputScrollBar->setValue(target);
+	else
+		bar->setValue(target);
+}
+
 bool WorldView::nativeOutputHitTestGlobal(const QPoint &globalPos, WrapTextBrowser *&view,
-                                          NativeOutputPosition &position, QString *href, QString *hint) const
+                                          NativeOutputPosition &position, QString *href, QString *hint,
+                                          const bool allowCacheBuild, const bool requireTextHit,
+                                          bool *const textHit) const
 {
 	view     = nullptr;
 	position = {};
+	if (textHit)
+		*textHit = false;
 	if (!nativeOutputInteractionActive())
 		return false;
 
-	auto tryView = [this, &globalPos, &view, &position, href, hint](WrapTextBrowser *candidate)
+	auto tryView = [this, &globalPos, &view, &position, href, hint, allowCacheBuild, requireTextHit,
+	                textHit](WrapTextBrowser *candidate)
 	{
 		if (!candidate || !candidate->isVisible() || !candidate->viewport())
 			return false;
 		const QPoint local = candidate->viewport()->mapFromGlobal(globalPos);
 		if (!candidate->viewport()->rect().contains(local))
 			return false;
-		if (!nativeOutputHitTest(candidate, local, position, href, hint))
+		if (!nativeOutputHitTest(candidate, local, position, href, hint, allowCacheBuild, requireTextHit,
+		                         textHit))
+		{
 			return false;
+		}
 		view = candidate;
 		return true;
 	};
@@ -6371,10 +6871,10 @@ void WorldView::applyResolvedOutputSelection(const bool hasSelection, const int 
 
 void WorldView::clearNativeOutputSelection(const bool notify)
 {
-	const bool  hadNativeState = m_nativeOutputSelection.hasSelection || m_nativeOutputSelection.dragging ||
-	                             m_nativeOutputSelection.sourceView != nullptr;
-	const QRect oldPaneRect    = nativeOutputPaneRect(m_nativeOutputSelection.sourceView);
-	m_nativeOutputSelection    = {};
+	const bool hadNativeState = m_nativeOutputSelection.hasSelection || m_nativeOutputSelection.dragging ||
+	                            m_nativeOutputSelection.sourceView != nullptr;
+	const QRect oldPaneRect               = nativeOutputPaneRect(m_nativeOutputSelection.sourceView);
+	m_nativeOutputSelection               = {};
 	m_nativeSelectionPendingHeadTrimLines = 0;
 	requestNativeOutputRepaint(oldPaneRect);
 	if (notify && hadNativeState)
@@ -6653,8 +7153,8 @@ QString WorldView::nativeOutputSelectionHtml() const
 				continue;
 			const QString segment = line.text.mid(selectStart, selectEnd - selectStart).toHtmlEscaped();
 			const QString style   = htmlStyleForSpan(
-			    span, defaultTextColour, m_useCustomLinkColour, m_hyperlinkColour, m_showBold, m_showItalic,
-			    m_showUnderline, m_alternativeInverse, m_underlineHyperlinks);
+                span, defaultTextColour, m_useCustomLinkColour, m_hyperlinkColour, m_showBold, m_showItalic,
+                m_showUnderline, m_alternativeInverse, m_underlineHyperlinks);
 			if (style.isEmpty())
 				html += segment;
 			else
@@ -7079,8 +7579,8 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 		int   nativeMaxScroll  = qMax(0, static_cast<int>(std::ceil(docY)) - pane.textRect.height());
 		int   effectiveScrollY = nativeMaxScroll > 0 ? qBound(0, pane.scrollY, nativeMaxScroll) : 0;
 
-		qreal visibleTop    = static_cast<qreal>(effectiveScrollY) +
-		                      static_cast<qreal>(clippedPaneRect.top() - pane.textRect.top());
+		qreal visibleTop = static_cast<qreal>(effectiveScrollY) +
+		                   static_cast<qreal>(clippedPaneRect.top() - pane.textRect.top());
 		qreal visibleBottom = static_cast<qreal>(effectiveScrollY) +
 		                      static_cast<qreal>(clippedPaneRect.bottom() - pane.textRect.top());
 
@@ -7117,9 +7617,9 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 			nativeMaxScroll  = qMax(0, static_cast<int>(std::ceil(docY)) - pane.textRect.height());
 			effectiveScrollY = nativeMaxScroll > 0 ? qBound(0, pane.scrollY, nativeMaxScroll) : 0;
 			visibleTop       = static_cast<qreal>(effectiveScrollY) +
-			                   static_cast<qreal>(clippedPaneRect.top() - pane.textRect.top());
-			visibleBottom    = static_cast<qreal>(effectiveScrollY) +
-			                   static_cast<qreal>(clippedPaneRect.bottom() - pane.textRect.top());
+			             static_cast<qreal>(clippedPaneRect.top() - pane.textRect.top());
+			visibleBottom = static_cast<qreal>(effectiveScrollY) +
+			                static_cast<qreal>(clippedPaneRect.bottom() - pane.textRect.top());
 			firstVisibleIt =
 			    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
 			                                                   m_nativeLayoutCumulativeHeights.cend()),
@@ -7140,7 +7640,7 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 			const qreal                   lineBottom  = m_nativeLayoutCumulativeHeights.at(i + 1);
 			const qreal                   lineOpacity = qBound(0.0, line.opacity, 1.0);
 			const int                     lineY       = static_cast<int>(
-			    std::floor(static_cast<qreal>(pane.textRect.top() - effectiveScrollY) + lineTop));
+                std::floor(static_cast<qreal>(pane.textRect.top() - effectiveScrollY) + lineTop));
 			const int lineBottomY = static_cast<int>(
 			    std::ceil(static_cast<qreal>(pane.textRect.top() - effectiveScrollY) + lineBottom));
 			QRect lineBackgroundRect(pane.textRect.left(), lineY, pane.textRect.width(),
@@ -7163,7 +7663,7 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 				{
 					const qreal lineHeight = qMax<qreal>(1.0, lineBottom - lineTop);
 					const int   baseY      = static_cast<int>(
-					    std::round(pane.textRect.top() - effectiveScrollY + lineTop + (lineHeight / 2.0)));
+                        std::round(pane.textRect.top() - effectiveScrollY + lineTop + (lineHeight / 2.0)));
 					painter->save();
 					if (lineOpacity < 0.999)
 						painter->setOpacity(painter->opacity() * lineOpacity);
@@ -7411,6 +7911,7 @@ WorldView::synchronizeNativeRuntimeOutputPresentation(const bool allowLayoutBuil
 	}
 	clearNativeSelectionIfOutsideVisibleViewport(m_output);
 	clearNativeSelectionIfOutsideVisibleViewport(m_liveOutput);
+	notifyAccessibleOutputPresented(lines);
 	return lines;
 }
 
@@ -7425,18 +7926,18 @@ void WorldView::requestNativeRuntimeOutputPresentationSync(const bool allowLayou
 	m_nativeRuntimeOutputPresentationQueued = true;
 	QPointer<WorldView> that(this);
 	const bool          queued = QMetaObject::invokeMethod(
-	    this,
-	    [that]
-	    {
-		    if (!that)
-			    return;
-		    const bool allowLayoutBuild = that->m_nativeRuntimeOutputPresentationNeedsLayoutSync;
-		    const bool followTail       = that->m_nativeRuntimeOutputPresentationFollowTail;
-		    that->m_nativeRuntimeOutputPresentationQueued          = false;
-		    that->m_nativeRuntimeOutputPresentationNeedsLayoutSync = false;
-		    that->m_nativeRuntimeOutputPresentationFollowTail      = false;
-		    const QVector<NativeOutputRenderLine> &lines =
-		        that->synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, followTail);
+        this,
+        [that]
+        {
+            if (!that)
+                return;
+            const bool allowLayoutBuild = that->m_nativeRuntimeOutputPresentationNeedsLayoutSync;
+            const bool followTail       = that->m_nativeRuntimeOutputPresentationFollowTail;
+            that->m_nativeRuntimeOutputPresentationQueued          = false;
+            that->m_nativeRuntimeOutputPresentationNeedsLayoutSync = false;
+            that->m_nativeRuntimeOutputPresentationFollowTail      = false;
+            const QVector<NativeOutputRenderLine> &lines =
+                that->synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, followTail);
 #ifndef NDEBUG
 		    if (that->m_nativeRangeRestitchDiagCount > 0)
 		    {
@@ -7517,33 +8018,33 @@ void WorldView::requestOutputScrollToEnd(const bool allowLayoutBuild)
 	m_scrollToEndQueued = true;
 	QPointer<WorldView> that(this);
 	const bool          queued = QMetaObject::invokeMethod(
-	    this,
-	    [that]
-	    {
-		    if (!that)
-			    return;
-		    const bool allowLayoutBuild        = that->m_scrollToEndNeedsLayoutSync;
-		    that->m_scrollToEndQueued          = false;
-		    that->m_scrollToEndNeedsLayoutSync = false;
-		    if (that->m_frozen)
-			    return;
-		    if (traceOutputBackfillEnabled())
-		    {
-			    const QScrollBar *const bar = that->m_output ? that->m_output->verticalScrollBar() : nullptr;
-			    qInfo().noquote() << QStringLiteral(
-			                             "[OutputBackfill] scroll-to-end fire world=%1 value=%2 max=%3 "
-			                             "split=%4")
-			                             .arg(traceWorldName(that->m_runtime))
-			                             .arg(bar ? bar->value() : -1)
-			                             .arg(bar ? bar->maximum() : -1)
-			                             .arg(that->m_scrollbackSplitActive ? QStringLiteral("1")
-			                                                                : QStringLiteral("0"));
-		    }
-		    const QVector<NativeOutputRenderLine> &lines =
-		        that->synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, true);
-		    that->requestNativeOutputPresentationRepaint(true, lines);
-	    },
-	    Qt::QueuedConnection);
+        this,
+        [that]
+        {
+            if (!that)
+                return;
+            const bool allowLayoutBuild        = that->m_scrollToEndNeedsLayoutSync;
+            that->m_scrollToEndQueued          = false;
+            that->m_scrollToEndNeedsLayoutSync = false;
+            if (that->m_frozen)
+                return;
+            if (traceOutputBackfillEnabled())
+            {
+                const QScrollBar *const bar = that->m_output ? that->m_output->verticalScrollBar() : nullptr;
+                qInfo().noquote() << QStringLiteral(
+                                         "[OutputBackfill] scroll-to-end fire world=%1 value=%2 max=%3 "
+			                                      "split=%4")
+                                         .arg(traceWorldName(that->m_runtime))
+                                         .arg(bar ? bar->value() : -1)
+                                         .arg(bar ? bar->maximum() : -1)
+                                         .arg(that->m_scrollbackSplitActive ? QStringLiteral("1")
+			                                                                         : QStringLiteral("0"));
+            }
+            const QVector<NativeOutputRenderLine> &lines =
+                that->synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, true);
+            that->requestNativeOutputPresentationRepaint(true, lines);
+        },
+        Qt::QueuedConnection);
 	if (!queued)
 	{
 		m_scrollToEndQueued          = false;
@@ -8918,6 +9419,7 @@ void WorldView::appendOutputTextInternal(const QString &text, bool newLine, bool
 	if (recordLine && m_runtime)
 	{
 		Q_UNUSED(injectPendingBreakBeforeRender);
+		m_accessibleOutputPendingTailAppend = true;
 		removeNativePartialRenderLineOverlay(false);
 		m_hasPartialOutput       = false;
 		m_partialOutputStart     = 0;
@@ -8958,6 +9460,7 @@ void WorldView::appendOutputTextInternal(const QString &text, bool newLine, bool
 	if (injectPendingBreakBeforeRender)
 		appendStandaloneOutputEntry(QString(), {}, true, WorldRuntime::LineOutput, displayEntry.time);
 	appendStandaloneOutputEntry(displayText, renderedSpans, newLine, displayEntry.flags, displayEntry.time);
+	m_accessibleOutputPendingTailAppend = true;
 	syncOutputTextVisibilityForNativeCanvas();
 	if (!m_frozen)
 		requestOutputScrollToEnd();
@@ -9060,7 +9563,8 @@ bool WorldView::commitPendingIncomingPartialOutput()
 		const int tailIndex               = qMax(0, sizeToInt(m_nativeLayoutVisualRows.size()) - 1);
 		m_nativeLayoutCumulativeDirtyFrom = qMin(m_nativeLayoutCumulativeDirtyFrom, tailIndex);
 	}
-	m_nativeRenderLineCacheFromRuntime = true;
+	m_nativeRenderLineCacheFromRuntime  = true;
+	m_accessibleOutputPendingTailAppend = true;
 	syncOutputTextVisibilityForNativeCanvas();
 	requestNativeOutputTailRepaint();
 	requestOutputScrollToEnd();
@@ -9076,11 +9580,13 @@ void WorldView::notifyRuntimeOutputLineChanged()
 	m_nativeHasPartialOutput = false;
 	m_nativePartialOutputText.clear();
 	m_nativePartialOutputSpans.clear();
-	m_nativeRenderLineCacheFromRuntime = true;
+	m_nativeRenderLineCacheFromRuntime  = true;
+	m_accessibleOutputPendingTailAppend = false;
 	syncOutputTextVisibilityForNativeCanvas();
 	if (!m_frozen)
 		requestOutputScrollToEnd();
 	requestNativeOutputRepaint();
+	notifyAccessibleOutputPresented(nativeOutputRenderLines());
 	requestDrawOutputWindowNotification();
 }
 
@@ -9092,7 +9598,8 @@ void WorldView::notifyRuntimeOutputLineChanged(const int runtimeLineIndex)
 	m_nativeHasPartialOutput = false;
 	m_nativePartialOutputText.clear();
 	m_nativePartialOutputSpans.clear();
-	m_nativeRenderLineCacheFromRuntime = true;
+	m_nativeRenderLineCacheFromRuntime  = true;
+	m_accessibleOutputPendingTailAppend = false;
 	markNativeRuntimeLineRestitchPending(runtimeLineIndex);
 	syncOutputTextVisibilityForNativeCanvas();
 	requestNativeRuntimeOutputPresentationSync(false, !m_frozen);
@@ -9107,7 +9614,8 @@ void WorldView::notifyRuntimeOutputRangeChanged(const int runtimeLineIndex)
 	m_nativeHasPartialOutput = false;
 	m_nativePartialOutputText.clear();
 	m_nativePartialOutputSpans.clear();
-	m_nativeRenderLineCacheFromRuntime = true;
+	m_nativeRenderLineCacheFromRuntime  = true;
+	m_accessibleOutputPendingTailAppend = false;
 	markNativeRuntimeRangeRestitchPending(runtimeLineIndex);
 	syncOutputTextVisibilityForNativeCanvas();
 	requestNativeRuntimeOutputPresentationSync(false, !m_frozen);
@@ -9126,20 +9634,23 @@ void WorldView::clearOutputBuffer()
 	m_nativePartialOutputSpans.clear();
 	if (m_runtime)
 	{
-		m_nativeRenderLineCacheFromRuntime = true;
-		m_nativeRenderLineCacheValid       = false;
+		m_nativeRenderLineCacheFromRuntime  = true;
+		m_nativeRenderLineCacheValid        = false;
+		m_accessibleOutputPendingTailAppend = false;
 	}
 	else
 	{
 		m_nativeStandaloneOutputLines.clear();
-		m_nativeStandaloneNextLineNumber   = 1;
-		m_nativeRenderLineCacheFromRuntime = false;
-		m_nativeRenderLineCacheValid       = false;
+		m_nativeStandaloneNextLineNumber    = 1;
+		m_nativeRenderLineCacheFromRuntime  = false;
+		m_nativeRenderLineCacheValid        = false;
+		m_accessibleOutputPendingTailAppend = false;
 	}
 	syncNativeOutputScrollBarsFromLayout(nativeOutputRenderLines());
 	clearNativeOutputSelection(true);
 	syncOutputTextVisibilityForNativeCanvas();
 	requestNativeOutputRepaint();
+	notifyAccessibleOutputPresented(nativeOutputRenderLines());
 
 	if (m_scrollbackSplitActive)
 		scrollViewToEnd(m_liveOutput);
@@ -9159,7 +9670,8 @@ void WorldView::restoreOutputFromPersistedLines(const QVector<WorldRuntime::Line
 	m_nativePartialOutputText.clear();
 	m_nativePartialOutputSpans.clear();
 
-	const bool runtimeAttached = m_runtime && m_runtime->view() == this;
+	const bool runtimeAttached          = m_runtime && m_runtime->view() == this;
+	m_accessibleOutputPendingTailAppend = false;
 	if (runtimeAttached)
 	{
 		// Runtime-attached views always render from runtime-owned line state.
@@ -9189,6 +9701,7 @@ void WorldView::restoreOutputFromPersistedLines(const QVector<WorldRuntime::Line
 		clearNativeOutputSelection(true);
 	syncOutputTextVisibilityForNativeCanvas();
 	syncNativeOutputScrollBarsFromLayout(nativeOutputRenderLines());
+	notifyAccessibleOutputPresented(nativeOutputRenderLines());
 	if (m_scrollbackSplitActive)
 		scrollViewToEnd(m_liveOutput);
 	else
@@ -10676,8 +11189,8 @@ void WorldView::applyRuntimeSettingsImpl(const bool rebuildOutput)
 	const int     wrapColumn     = attrs.value(QStringLiteral("wrap_column")).toInt();
 	const QString wrapEnabled    = attrs.value(QStringLiteral("wrap"));
 	const bool    wrapOutput     = (wrapEnabled.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
-	                                wrapEnabled == QStringLiteral("1") ||
-	                                wrapEnabled.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0);
+                             wrapEnabled == QStringLiteral("1") ||
+                             wrapEnabled.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0);
 	const bool    nawsNegotiated = m_runtime && m_runtime->isNawsNegotiated();
 	if (m_output)
 	{
@@ -11262,7 +11775,7 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 {
 	const QWidget *outputViewport     = m_output ? m_output->viewport() : nullptr;
 	const QWidget *liveOutputViewport = m_liveOutput ? m_liveOutput->viewport() : nullptr;
-	const bool isOutputWidget = watched == m_outputContainer || watched == m_outputStack ||
+	const bool     isOutputWidget     = watched == m_outputContainer || watched == m_outputStack ||
 	                            watched == m_outputSplitter || watched == m_outputScrollBar ||
 	                            watched == m_output || watched == m_liveOutput || watched == outputViewport ||
 	                            watched == liveOutputViewport;
@@ -12086,9 +12599,9 @@ bool WorldView::executeMacroByName(const QString &name)
 	{
 		const QMap<QString, QString> &attrs = m_runtime->worldAttributes();
 		const QString noHistoryFlag = attrs.value(QStringLiteral("do_not_add_macros_to_command_history"));
-		const bool    noHistory = (noHistoryFlag == QStringLiteral("1") ||
-		                           noHistoryFlag.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
-		                           noHistoryFlag.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0);
+		const bool    noHistory     = (noHistoryFlag == QStringLiteral("1") ||
+                                noHistoryFlag.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
+                                noHistoryFlag.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0);
 		m_runtime->setCurrentActionSource(WorldRuntime::eUserMacro);
 		(void)m_runtime->sendCommand(send, true, false, true, !noHistory, true);
 		m_runtime->setCurrentActionSource(WorldRuntime::eUnknownActionSource);
@@ -12243,7 +12756,7 @@ bool WorldView::handleWorldHotkey(QKeyEvent *event)
 	const bool keypadRepeatFallback = !keypadModifier && isRepeat && m_keypadRepeatArmed &&
 	                                  event->key() == m_keypadRepeatQtKey && hasCtrl == m_keypadRepeatCtrl &&
 	                                  !hasMeta && !hasAlt && !hasShift;
-	const bool keypad               = keypadModifier || keypadRepeatFallback;
+	const bool keypad = keypadModifier || keypadRepeatFallback;
 
 	auto       tryAccelerator = [&]() -> bool
 	{
@@ -12311,11 +12824,11 @@ bool WorldView::handleWorldHotkey(QKeyEvent *event)
 	// 2) World keypad mapping from world properties.
 	if (keypad)
 	{
-		const QMap<QString, QString> &attrs   = m_runtime->worldAttributes();
-		const QString                 enabled = attrs.value(QStringLiteral("keypad_enable"));
-		const bool keypadEnabled = (enabled == QStringLiteral("1") ||
-		                            enabled.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
-		                            enabled.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0);
+		const QMap<QString, QString> &attrs         = m_runtime->worldAttributes();
+		const QString                 enabled       = attrs.value(QStringLiteral("keypad_enable"));
+		const bool                    keypadEnabled = (enabled == QStringLiteral("1") ||
+                                    enabled.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
+                                    enabled.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0);
 		if (keypadEnabled)
 		{
 			QString token;
@@ -12969,7 +13482,7 @@ void InputTextEdit::keyPressEvent(QKeyEvent *event)
 			const bool scriptingEnabled = isEnabled(attrs.value(QStringLiteral("enable_scripts"))) &&
 			                              attrs.value(QStringLiteral("script_language"))
 			                                      .compare(QStringLiteral("Lua"), Qt::CaseInsensitive) == 0;
-			const QString scriptPrefix  = attrs.value(QStringLiteral("script_prefix"));
+			const QString scriptPrefix = attrs.value(QStringLiteral("script_prefix"));
 			const bool    scriptCommand =
 			    scriptingEnabled && !scriptPrefix.isEmpty() && text.startsWith(scriptPrefix);
 			if (spellOnSend && !scriptCommand)
@@ -13121,9 +13634,9 @@ bool InputTextEdit::event(QEvent *event)
 		{
 			const Qt::KeyboardModifiers modifiers = keyEvent->modifiers();
 			const bool                  plainCtrl = (modifiers & Qt::ControlModifier) != 0 &&
-			                                        (modifiers & (Qt::AltModifier | Qt::MetaModifier)) == 0;
-			const bool                  isCtrlBackspace = plainCtrl && keyEvent->key() == Qt::Key_Backspace;
-			const bool                  isCopyShortcut =
+			                       (modifiers & (Qt::AltModifier | Qt::MetaModifier)) == 0;
+			const bool isCtrlBackspace = plainCtrl && keyEvent->key() == Qt::Key_Backspace;
+			const bool isCopyShortcut =
 			    keyEvent->matches(QKeySequence::Copy) || (plainCtrl && keyEvent->key() == Qt::Key_C);
 			if (isCtrlBackspace)
 			{

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -84,13 +84,57 @@
 namespace
 {
 	constexpr const char *kWorldOutputAccessibleProperty = "qmud_world_output_widget";
-	constexpr const char *kWorldOutputLiveProperty       = "qmud_world_output_live";
 
 	int                   sizeToInt(const qsizetype value)
 	{
 		constexpr qsizetype kMin = 0;
 		constexpr qsizetype kMax = std::numeric_limits<int>::max();
 		return static_cast<int>(qBound(kMin, value, kMax));
+	}
+
+	QString trimLeadingAnnouncementBreaks(QString text)
+	{
+		while (!text.isEmpty() && (text.front() == QLatin1Char('\n') || text.front() == QLatin1Char('\r')))
+			text.remove(0, 1);
+		return text;
+	}
+
+	QVector<int> prefixTableForText(const QString &text)
+	{
+		QVector<int> table(text.size(), 0);
+		for (int i = 1; i < text.size(); ++i)
+		{
+			int candidate = table.at(i - 1);
+			while (candidate > 0 && text.at(i) != text.at(candidate))
+				candidate = table.at(candidate - 1);
+			if (text.at(i) == text.at(candidate))
+				++candidate;
+			table[i] = candidate;
+		}
+		return table;
+	}
+
+	QString accessibleAnnouncementDelta(const QString &previousText, const QString &currentText)
+	{
+		if (previousText.isEmpty() || currentText.isEmpty() || previousText == currentText)
+			return {};
+		if (currentText.startsWith(previousText))
+			return trimLeadingAnnouncementBreaks(currentText.mid(previousText.size()));
+
+		const QVector<int> prefixTable = prefixTableForText(currentText);
+		int                overlap     = 0;
+		for (const QChar ch : previousText)
+		{
+			while (overlap > 0 && ch != currentText.at(overlap))
+				overlap = prefixTable.at(overlap - 1);
+			if (ch == currentText.at(overlap))
+				++overlap;
+			if (overlap == currentText.size())
+				overlap = prefixTable.at(overlap - 1);
+		}
+		if (overlap <= 0 || overlap >= currentText.size())
+			return {};
+		return trimLeadingAnnouncementBreaks(currentText.mid(overlap));
 	}
 
 	void appendDeduplicatedHistoryEntry(QVector<QString> &history, const QString &entry,
@@ -1099,9 +1143,6 @@ class WrapTextBrowser : public QAbstractScrollArea
 		explicit WrapTextBrowser(WorldView *view, QWidget *parent = nullptr, bool isLive = false)
 		    : QAbstractScrollArea(parent), m_view(view), m_isLive(isLive)
 		{
-			setAccessibleName(isLive ? QStringLiteral("Live world output") : QStringLiteral("World output"));
-			setProperty(kWorldOutputAccessibleProperty, true);
-			setProperty(kWorldOutputLiveProperty, isLive);
 			setFrameShape(QFrame::NoFrame);
 			setViewport(new QWidget(this));
 			if (QWidget *const vp = viewport())
@@ -1131,16 +1172,6 @@ class WrapTextBrowser : public QAbstractScrollArea
 		[[nodiscard]] QMargins viewportMarginsPublic() const
 		{
 			return viewportMargins();
-		}
-
-		[[nodiscard]] WorldView *worldView() const
-		{
-			return m_view;
-		}
-
-		[[nodiscard]] bool isLiveOutput() const
-		{
-			return m_isLive;
 		}
 
 	protected:
@@ -1267,16 +1298,46 @@ class WrapTextBrowser : public QAbstractScrollArea
 		LineWrapMode m_lineWrapMode{NoWrap};
 };
 
+class WorldOutputCanvas : public QWidget
+{
+	public:
+		explicit WorldOutputCanvas(WorldView *view, QWidget *parent = nullptr) : QWidget(parent), m_view(view)
+		{
+			setAccessibleName(QStringLiteral("World output"));
+			setProperty(kWorldOutputAccessibleProperty, true);
+			setAttribute(Qt::WA_TransparentForMouseEvents);
+			setAttribute(Qt::WA_OpaquePaintEvent);
+			setAutoFillBackground(false);
+		}
+
+		[[nodiscard]] WorldView *worldView() const
+		{
+			return m_view;
+		}
+
+	protected:
+		void paintEvent(QPaintEvent *event) override
+		{
+			if (!m_view)
+				return;
+			QPainter      painter(this);
+			const QRegion dirtyRegion = event ? event->region() : QRegion(rect());
+			m_view->paintNativeOutputCanvas(&painter, dirtyRegion);
+			m_view->miniWindowLayerPainted(true, dirtyRegion);
+		}
+
+	private:
+		WorldView *m_view{nullptr};
+};
+
 class WorldOutputAccessible final : public QAccessibleWidget, public QAccessibleTextInterface
 {
 	public:
-		explicit WorldOutputAccessible(WrapTextBrowser *widget)
-		    : QAccessibleWidget(widget, QAccessible::Terminal,
-		                        widget && widget->isLiveOutput() ? QStringLiteral("Live world output")
-		                                                         : QStringLiteral("World output"))
+		explicit WorldOutputAccessible(WorldOutputCanvas *widget)
+		    : QAccessibleWidget(widget, QAccessible::Terminal, QStringLiteral("World output"))
 		{
-			if (widget && widget->worldView())
-				widget->worldView()->primeAccessibleOutputTextState();
+			if (WorldView *view = widget ? widget->worldView() : nullptr)
+				view->primeAccessibleOutputTextState();
 		}
 
 		void *interface_cast(const QAccessible::InterfaceType type) override
@@ -1290,14 +1351,20 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 		{
 			if (type == QAccessible::Name)
 			{
-				const WrapTextBrowser *browser = outputWidget();
-				if (browser && browser->isLiveOutput())
-					return QStringLiteral("Live world output");
 				return QStringLiteral("World output");
 			}
 			if (type == QAccessible::Value)
 				return accessibleText().text(0, accessibleText().characterCount());
 			return QAccessibleWidget::text(type);
+		}
+
+		[[nodiscard]] QAccessible::State state() const override
+		{
+			QAccessible::State state = QAccessibleWidget::state();
+			state.readOnly           = true;
+			state.multiLine          = true;
+			state.selectableText     = true;
+			return state;
 		}
 
 		void selection(int selectionIndex, int *startOffset, int *endOffset) const override
@@ -1353,7 +1420,7 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 			if (selectionIndex != 0)
 				return;
 			WorldView       *view    = worldView();
-			WrapTextBrowser *browser = outputWidget();
+			WrapTextBrowser *browser = targetBrowser();
 			if (!view || !browser)
 				return;
 
@@ -1395,7 +1462,7 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 			const QMudAccessibleTextUtils::TextPosition position =
 			    map.positionForOffset(qBound(0, offset, map.characterCount()));
 			WorldView       *view    = worldView();
-			WrapTextBrowser *browser = outputWidget();
+			WrapTextBrowser *browser = targetBrowser();
 			if (!view || !browser)
 				return {};
 
@@ -1407,7 +1474,7 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 		[[nodiscard]] int offsetAtPoint(const QPoint &point) const override
 		{
 			WorldView       *view    = worldView();
-			WrapTextBrowser *browser = outputWidget();
+			WrapTextBrowser *browser = targetBrowser();
 			if (!view || !browser)
 				return -1;
 
@@ -1426,7 +1493,7 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 		void scrollToSubstring(int startIndex, int endIndex) override
 		{
 			WorldView             *view    = worldView();
-			const WrapTextBrowser *browser = outputWidget();
+			const WrapTextBrowser *browser = targetBrowser();
 			if (!view || !browser)
 				return;
 
@@ -1451,15 +1518,21 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 		}
 
 	private:
-		[[nodiscard]] WrapTextBrowser *outputWidget() const
+		[[nodiscard]] WorldOutputCanvas *outputCanvas() const
 		{
-			return dynamic_cast<WrapTextBrowser *>(widget());
+			return dynamic_cast<WorldOutputCanvas *>(widget());
+		}
+
+		[[nodiscard]] WrapTextBrowser *targetBrowser() const
+		{
+			WorldView *view = worldView();
+			return view ? view->activeOutputView() : nullptr;
 		}
 
 		[[nodiscard]] WorldView *worldView() const
 		{
-			const WrapTextBrowser *browser = outputWidget();
-			return browser ? browser->worldView() : nullptr;
+			WorldOutputCanvas *canvas = outputCanvas();
+			return canvas ? canvas->worldView() : nullptr;
 		}
 
 		[[nodiscard]] QMudAccessibleTextUtils::LineOffsetMap accessibleText() const
@@ -1476,11 +1549,11 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 QAccessibleInterface *worldOutputAccessibleFactory(const QString &className, QObject *object)
 {
 	Q_UNUSED(className);
-	auto *scrollArea = qobject_cast<QAbstractScrollArea *>(object);
-	if (!scrollArea || !scrollArea->property(kWorldOutputAccessibleProperty).toBool())
+	auto *widget = qobject_cast<QWidget *>(object);
+	if (!widget || !widget->property(kWorldOutputAccessibleProperty).toBool())
 		return nullptr;
-	auto *browser = dynamic_cast<WrapTextBrowser *>(scrollArea);
-	return browser ? new WorldOutputAccessible(browser) : nullptr;
+	auto *canvas = dynamic_cast<WorldOutputCanvas *>(widget);
+	return canvas ? new WorldOutputAccessible(canvas) : nullptr;
 }
 
 void qmudInstallWorldOutputAccessibility()
@@ -1550,31 +1623,6 @@ class MiniWindowLayer : public QWidget
 	private:
 		WorldView *m_view{nullptr};
 		bool       m_underneath{false};
-};
-
-class WorldOutputCanvas : public QWidget
-{
-	public:
-		explicit WorldOutputCanvas(WorldView *view, QWidget *parent = nullptr) : QWidget(parent), m_view(view)
-		{
-			setAttribute(Qt::WA_TransparentForMouseEvents);
-			setAttribute(Qt::WA_OpaquePaintEvent);
-			setAutoFillBackground(false);
-		}
-
-	protected:
-		void paintEvent(QPaintEvent *event) override
-		{
-			if (!m_view)
-				return;
-			QPainter      painter(this);
-			const QRegion dirtyRegion = event ? event->region() : QRegion(rect());
-			m_view->paintNativeOutputCanvas(&painter, dirtyRegion);
-			m_view->miniWindowLayerPainted(true, dirtyRegion);
-		}
-
-	private:
-		WorldView *m_view{nullptr};
 };
 
 struct WorldView::OutputFindState
@@ -3051,24 +3099,28 @@ void WorldView::primeAccessibleOutputTextState() const
 	    accessibleNativeOutputTextMap(nativeOutputRenderLines());
 	m_accessibleOutputCharacterCount = map.characterCount();
 	m_accessibleOutputRevision       = m_nativeRenderLineCacheRevision;
+	m_accessibleOutputText           = map.text(0, map.characterCount());
 }
 
 void WorldView::notifyAccessibleOutputPresented(const QVector<NativeOutputRenderLine> &lines) const
 {
 	if (!QAccessible::isActive())
 	{
-		m_accessibleOutputCharacterCount    = -1;
-		m_accessibleOutputRevision          = 0;
+		m_accessibleOutputCharacterCount = -1;
+		m_accessibleOutputRevision       = 0;
+		m_accessibleOutputText.clear();
 		m_accessibleOutputPendingTailAppend = false;
 		return;
 	}
 
 	const QMudAccessibleTextUtils::LineOffsetMap map                   = accessibleNativeOutputTextMap(lines);
 	const int                                    currentCharacterCount = map.characterCount();
+	const QString                                currentText           = map.text(0, currentCharacterCount);
 	if (m_accessibleOutputCharacterCount < 0)
 	{
 		m_accessibleOutputCharacterCount = currentCharacterCount;
 		m_accessibleOutputRevision       = m_nativeRenderLineCacheRevision;
+		m_accessibleOutputText           = currentText;
 		return;
 	}
 
@@ -3076,31 +3128,48 @@ void WorldView::notifyAccessibleOutputPresented(const QVector<NativeOutputRender
 	if (!revisionChanged)
 	{
 		m_accessibleOutputCharacterCount = currentCharacterCount;
+		m_accessibleOutputText           = currentText;
 		return;
 	}
 
 	const bool exactTailAppend = m_accessibleOutputPendingTailAppend &&
 	                             (m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::TailAppend ||
 	                              !m_nativeRenderLineCacheFromRuntime);
+	auto       announceCanvasText = [this](const QString &message)
+	{
+		const QString announcement = trimLeadingAnnouncementBreaks(message);
+		if (!m_nativeOutputCanvas || !m_nativeOutputCanvas->isVisible() || announcement.isEmpty())
+			return;
+		QAccessibleAnnouncementEvent event(m_nativeOutputCanvas, announcement);
+		event.setPoliteness(QAccessible::AnnouncementPoliteness::Polite);
+		QAccessible::updateAccessibility(&event);
+	};
 	if (currentCharacterCount > m_accessibleOutputCharacterCount && exactTailAppend)
 	{
 		const QString insertedText = map.text(m_accessibleOutputCharacterCount, currentCharacterCount);
 		if (!insertedText.isEmpty())
 		{
-			if (WrapTextBrowser *const target = activeOutputView())
+			if (m_nativeOutputCanvas && m_nativeOutputCanvas->isVisible())
 			{
-				QAccessibleTextInsertEvent event(target, m_accessibleOutputCharacterCount, insertedText);
+				QAccessibleTextInsertEvent event(m_nativeOutputCanvas, m_accessibleOutputCharacterCount,
+				                                 insertedText);
 				QAccessible::updateAccessibility(&event);
 			}
+			announceCanvasText(insertedText);
 		}
 	}
-	else if (WrapTextBrowser *const target = activeOutputView())
+	else if (m_nativeOutputCanvas && m_nativeOutputCanvas->isVisible())
 	{
-		QAccessibleEvent event(target, QAccessible::ValueChanged);
-		QAccessible::updateAccessibility(&event);
+		if (m_accessibleOutputText != currentText)
+		{
+			QAccessibleTextUpdateEvent event(m_nativeOutputCanvas, 0, m_accessibleOutputText, currentText);
+			QAccessible::updateAccessibility(&event);
+			announceCanvasText(accessibleAnnouncementDelta(m_accessibleOutputText, currentText));
+		}
 	}
 	m_accessibleOutputCharacterCount    = currentCharacterCount;
 	m_accessibleOutputRevision          = m_nativeRenderLineCacheRevision;
+	m_accessibleOutputText              = currentText;
 	m_accessibleOutputPendingTailAppend = false;
 }
 

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -1723,6 +1723,7 @@ class WorldView : public QWidget
 		mutable NativeRenderCacheDelta               m_nativeRenderCacheDelta;
 		mutable int                                  m_accessibleOutputCharacterCount{-1};
 		mutable quint64                              m_accessibleOutputRevision{0};
+		mutable QString                              m_accessibleOutputText;
 		mutable bool                                 m_accessibleOutputPendingTailAppend{false};
 		mutable bool                                 m_nativePartialRenderLineApplied{false};
 		mutable bool                                 m_nativePartialRenderLineAppended{false};

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -10,6 +10,7 @@
 #ifndef QMUD_WORLDVIEW_H
 #define QMUD_WORLDVIEW_H
 
+#include "AccessibleTextUtils.h"
 #include "WorldRuntime.h"
 
 #include <QFont>
@@ -40,6 +41,12 @@ class QWheelEvent;
 class QMouseEvent;
 class QPainter;
 class WorldOutputCanvas;
+class WorldOutputAccessible;
+
+/**
+ * @brief Installs the custom accessibility factory for native world output widgets.
+ */
+void qmudInstallWorldOutputAccessibility();
 
 /**
  * @brief Stateful options and cursor data for command-history find operations.
@@ -500,6 +507,7 @@ class WorldView : public QWidget
 		friend class InputTextEdit;
 		friend class WrapTextBrowser;
 		friend class MiniWindowLayer;
+		friend class WorldOutputAccessible;
 		/**
 		 * @brief Extended editing/selection/output APIs used by runtime and widgets.
 		 */
@@ -960,6 +968,22 @@ class WorldView : public QWidget
 		 */
 		void requestNativeOutputPresentationRepaint(bool repaintVisiblePanes,
 		                                            const QVector<NativeOutputRenderLine> &lines) const;
+		/**
+		 * @brief Builds an accessible text offset map from native output lines.
+		 * @param lines Native render lines to expose.
+		 * @return Accessible text map over the current logical output.
+		 */
+		[[nodiscard]] static QMudAccessibleTextUtils::LineOffsetMap
+		     accessibleNativeOutputTextMap(const QVector<NativeOutputRenderLine> &lines);
+		/**
+		 * @brief Primes the accessible text length without emitting backlog events.
+		 */
+		void primeAccessibleOutputTextState() const;
+		/**
+		 * @brief Emits active-only accessibility notifications for newly presented native output.
+		 * @param lines Native render lines after presentation synchronization.
+		 */
+		void notifyAccessibleOutputPresented(const QVector<NativeOutputRenderLine> &lines) const;
 		[[nodiscard]] QRect nativeOutputPaneRect(const WrapTextBrowser *view) const;
 		/**
 		 * @brief Returns mutable paint state for a native output pane.
@@ -1281,6 +1305,23 @@ class WorldView : public QWidget
 		                                          QString *hint = nullptr, bool allowCacheBuild = true,
 		                                          bool requireTextHit = false, bool *textHit = nullptr) const;
 		/**
+		 * @brief Resolves the global screen rectangle for a native-output character position.
+		 * @param view Source output view.
+		 * @param position Output line/column position.
+		 * @param globalRect Output global character rectangle when resolution succeeds.
+		 * @return `true` when @p position maps to a visible native output character/caret rectangle.
+		 */
+		[[nodiscard]] bool    nativeOutputCharacterRect(const WrapTextBrowser      *view,
+		                                                const NativeOutputPosition &position,
+		                                                QRect                      &globalRect) const;
+		/**
+		 * @brief Scrolls an output pane until the requested native output line range is visible.
+		 * @param view Output pane to scroll.
+		 * @param firstLine First zero-based native render line to reveal.
+		 * @param lastLine Last zero-based native render line to reveal.
+		 */
+		void scrollNativeOutputRangeIntoView(const WrapTextBrowser *view, int firstLine, int lastLine) const;
+		/**
 		 * @brief Resolves native-output hit-test information for a mouse event source widget.
 		 * @param watched Event source widget from the installed event filter.
 		 * @param event Mouse event carrying viewport/widget-relative coordinates.
@@ -1306,11 +1347,16 @@ class WorldView : public QWidget
 		 * @param position Output line/column position.
 		 * @param href Optional hyperlink href at hit point.
 		 * @param hint Optional hyperlink hint at hit point.
+		 * @param allowCacheBuild `true` to rebuild layout caches on demand.
+		 * @param requireTextHit `true` to require the point to fall inside rendered text glyph bounds.
+		 * @param textHit Optional output set to `true` when the point is over rendered text glyph bounds.
 		 * @return `true` when point maps to native output.
 		 */
 		[[nodiscard]] bool nativeOutputHitTestGlobal(const QPoint &globalPos, WrapTextBrowser *&view,
 		                                             NativeOutputPosition &position, QString *href = nullptr,
-		                                             QString *hint = nullptr) const;
+		                                             QString *hint = nullptr, bool allowCacheBuild = true,
+		                                             bool  requireTextHit = false,
+		                                             bool *textHit        = nullptr) const;
 		/**
 		 * @brief Clears native output selection state.
 		 * @param notify Emit selection changed flow when state changes.
@@ -1675,6 +1721,9 @@ class WorldView : public QWidget
 		mutable int                                  m_nativeRuntimeRangeRestitchStartIndex{-1};
 		mutable quint64                              m_nativeRenderLineCacheRevision{0};
 		mutable NativeRenderCacheDelta               m_nativeRenderCacheDelta;
+		mutable int                                  m_accessibleOutputCharacterCount{-1};
+		mutable quint64                              m_accessibleOutputRevision{0};
+		mutable bool                                 m_accessibleOutputPendingTailAppend{false};
 		mutable bool                                 m_nativePartialRenderLineApplied{false};
 		mutable bool                                 m_nativePartialRenderLineAppended{false};
 		mutable bool                                 m_nativePartialRenderBaseLastHardReturn{true};

--- a/src/dialogs/GlobalPreferencesDialog.cpp
+++ b/src/dialogs/GlobalPreferencesDialog.cpp
@@ -270,12 +270,7 @@ namespace
 
 	QString runtimePath(const QString &value)
 	{
-		const QString stored = storagePath(value);
-#ifdef Q_OS_WIN
-		return QDir::toNativeSeparators(stored);
-#else
-		return stored;
-#endif
+		return storagePath(value);
 	}
 
 	QString qmudHomeDirectory(const AppController *app)
@@ -526,7 +521,7 @@ QWidget *GlobalPreferencesDialog::buildWorldsPage()
 			                 app->changeToFileBrowsingDirectory();
 		                 const QString startDir = m_worldDefaultDir ? m_worldDefaultDir->text() : QString();
 		                 const QString dir      = QFileDialog::getExistingDirectory(
-                             this, QStringLiteral("Select Default World Files Directory"), startDir);
+		                     this, QStringLiteral("Select Default World Files Directory"), startDir);
 		                 if (app)
 			                 app->changeToStartupDirectory();
 		                 if (!dir.isEmpty())
@@ -1057,7 +1052,7 @@ QWidget *GlobalPreferencesDialog::buildDefaultsPage()
 	auto *layout = new QVBoxLayout(page);
 
 	auto  connectBrowse = [this](const QPushButton *button, QLineEdit *target, const QString &title,
-                                const QString &filter, const QString &suggestedName)
+	                             const QString &filter, const QString &suggestedName)
 	{
 		QObject::connect(button, &QPushButton::clicked, this,
 		                 [this, target, title, filter, suggestedName]()

--- a/src/helpers/AccessibleTextUtils.cpp
+++ b/src/helpers/AccessibleTextUtils.cpp
@@ -1,0 +1,159 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: AccessibleTextUtils.cpp
+ * Role: Accessible text offset mapping helpers for native world output.
+ */
+
+#include "AccessibleTextUtils.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace
+{
+	int safeQSizeToInt(const qsizetype size)
+	{
+		if (size <= 0)
+			return 0;
+		constexpr qsizetype kMaxInt = std::numeric_limits<int>::max();
+		return size > kMaxInt ? std::numeric_limits<int>::max() : static_cast<int>(size);
+	}
+
+	int saturatedAdd(const int value, const int amount)
+	{
+		if (amount <= 0)
+			return value;
+		constexpr int kMaxInt = std::numeric_limits<int>::max();
+		if (value >= kMaxInt - amount)
+			return kMaxInt;
+		return value + amount;
+	}
+
+	int clampedOffset(const int offset, const int characterCount)
+	{
+		return qBound(0, offset, characterCount);
+	}
+} // namespace
+
+QMudAccessibleTextUtils::LineOffsetMap::LineOffsetMap(QVector<QString> lines)
+{
+	reset(std::move(lines));
+}
+
+void QMudAccessibleTextUtils::LineOffsetMap::reset(QVector<QString> lines)
+{
+	m_lines = std::move(lines);
+	rebuildPrefixes();
+}
+
+int QMudAccessibleTextUtils::LineOffsetMap::lineCount() const
+{
+	return safeQSizeToInt(m_lines.size());
+}
+
+int QMudAccessibleTextUtils::LineOffsetMap::characterCount() const
+{
+	return m_characterCount;
+}
+
+bool QMudAccessibleTextUtils::LineOffsetMap::isEmpty() const
+{
+	return m_characterCount == 0;
+}
+
+int QMudAccessibleTextUtils::LineOffsetMap::offsetForPosition(const TextPosition position) const
+{
+	if (m_lines.isEmpty())
+		return 0;
+	if (position.line <= 0)
+		return qBound(0, position.column, clampedLineLength(0));
+	if (position.line >= m_lines.size())
+		return m_characterCount;
+
+	const int line   = position.line;
+	const int column = qBound(0, position.column, clampedLineLength(line));
+	return saturatedAdd(m_lineStarts.at(line), column);
+}
+
+QMudAccessibleTextUtils::TextPosition
+QMudAccessibleTextUtils::LineOffsetMap::positionForOffset(const int offset) const
+{
+	if (m_lines.isEmpty())
+		return {};
+
+	const int  target = clampedOffset(offset, m_characterCount);
+	const auto begin  = m_lineStarts.cbegin();
+	const auto end    = m_lineStarts.cend();
+	const auto upper  = std::upper_bound(begin, end, target);
+	const int  line   = upper == begin ? 0 : static_cast<int>(std::distance(begin, upper) - 1);
+
+	const int  column = qBound(0, target - m_lineStarts.at(line), clampedLineLength(line));
+	return TextPosition{line, column};
+}
+
+QString QMudAccessibleTextUtils::LineOffsetMap::text(const int startOffset, const int endOffset) const
+{
+	if (m_lines.isEmpty())
+		return {};
+
+	const int start = clampedOffset(qMin(startOffset, endOffset), m_characterCount);
+	const int end   = clampedOffset(qMax(startOffset, endOffset), m_characterCount);
+	if (end <= start)
+		return {};
+
+	QString result;
+	result.reserve(end - start);
+	for (int line = 0; line < m_lines.size(); ++line)
+	{
+		const int lineStart = m_lineStarts.at(line);
+		if (lineStart >= end)
+			break;
+
+		const QString &lineText = m_lines.at(line);
+		const int      lineEnd  = saturatedAdd(lineStart, clampedLineLength(line));
+		if (start < lineEnd && end > lineStart)
+		{
+			const int sliceStart = qMax(start, lineStart) - lineStart;
+			const int sliceEnd   = qMin(end, lineEnd) - lineStart;
+			result += lineText.mid(sliceStart, sliceEnd - sliceStart);
+		}
+
+		const bool hasSeparator = line + 1 < m_lines.size();
+		if (hasSeparator && start <= lineEnd && end > lineEnd)
+			result += QLatin1Char('\n');
+	}
+	return result;
+}
+
+QString QMudAccessibleTextUtils::LineOffsetMap::selectedText(const TextPosition anchor,
+                                                             const TextPosition cursor) const
+{
+	const int anchorOffset = offsetForPosition(anchor);
+	const int cursorOffset = offsetForPosition(cursor);
+	return text(qMin(anchorOffset, cursorOffset), qMax(anchorOffset, cursorOffset));
+}
+
+void QMudAccessibleTextUtils::LineOffsetMap::rebuildPrefixes()
+{
+	m_lineStarts.clear();
+	m_lineStarts.reserve(m_lines.size());
+
+	int offset = 0;
+	for (int line = 0; line < m_lines.size(); ++line)
+	{
+		m_lineStarts.push_back(offset);
+		offset = saturatedAdd(offset, clampedLineLength(line));
+		if (line + 1 < m_lines.size())
+			offset = saturatedAdd(offset, 1);
+	}
+	m_characterCount = offset;
+}
+
+int QMudAccessibleTextUtils::LineOffsetMap::clampedLineLength(const int line) const
+{
+	if (line < 0 || line >= m_lines.size())
+		return 0;
+	return safeQSizeToInt(m_lines.at(line).size());
+}

--- a/src/helpers/AccessibleTextUtils.h
+++ b/src/helpers/AccessibleTextUtils.h
@@ -1,0 +1,105 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: AccessibleTextUtils.h
+ * Role: Accessible text offset mapping helpers for native world output.
+ */
+
+#ifndef QMUD_ACCESSIBLETEXTUTILS_H
+#define QMUD_ACCESSIBLETEXTUTILS_H
+
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QString>
+#include <QVector>
+
+/**
+ * @brief Helpers for exposing native output text through Qt accessibility APIs.
+ */
+namespace QMudAccessibleTextUtils
+{
+	/**
+	 * @brief Line and column position in the accessible text model.
+	 */
+	struct TextPosition
+	{
+			int line{0};   ///< Zero-based line index.
+			int column{0}; ///< Zero-based UTF-16 column within the line.
+	};
+
+	/**
+	 * @brief Maps newline-joined logical output lines to linear accessible text offsets.
+	 */
+	class LineOffsetMap final
+	{
+		public:
+			/**
+			 * @brief Creates an empty offset map.
+			 */
+			LineOffsetMap() = default;
+			/**
+			 * @brief Creates an offset map for the supplied logical lines.
+			 * @param lines Output lines without implicit trailing newline.
+			 */
+			explicit LineOffsetMap(QVector<QString> lines);
+
+			/**
+			 * @brief Replaces the mapped output lines.
+			 * @param lines Output lines without implicit trailing newline.
+			 */
+			void                       reset(QVector<QString> lines);
+
+			/**
+			 * @brief Returns the number of mapped logical lines.
+			 * @return Line count clamped to the accessibility API integer range.
+			 */
+			[[nodiscard]] int          lineCount() const;
+			/**
+			 * @brief Returns the total accessible character count.
+			 * @return UTF-16 code-unit count including inserted newline separators.
+			 */
+			[[nodiscard]] int          characterCount() const;
+			/**
+			 * @brief Returns whether the accessible text is empty.
+			 * @return True when there are no accessible characters.
+			 */
+			[[nodiscard]] bool         isEmpty() const;
+
+			/**
+			 * @brief Converts a line position to a linear accessible offset.
+			 * @param position Line and column position to convert.
+			 * @return Clamped linear offset.
+			 */
+			[[nodiscard]] int          offsetForPosition(TextPosition position) const;
+			/**
+			 * @brief Converts a linear accessible offset to a line position.
+			 * @param offset Linear offset to convert.
+			 * @return Clamped line and column position.
+			 */
+			[[nodiscard]] TextPosition positionForOffset(int offset) const;
+			/**
+			 * @brief Extracts accessible text in a linear offset range.
+			 * @param startOffset Inclusive start offset.
+			 * @param endOffset Exclusive end offset.
+			 * @return Text slice with logical line separators inserted as newlines.
+			 */
+			[[nodiscard]] QString      text(int startOffset, int endOffset) const;
+			/**
+			 * @brief Extracts text between two line positions.
+			 * @param anchor First selection endpoint.
+			 * @param cursor Second selection endpoint.
+			 * @return Selected text with logical line separators inserted as newlines.
+			 */
+			[[nodiscard]] QString      selectedText(TextPosition anchor, TextPosition cursor) const;
+
+		private:
+			QVector<QString>  m_lines;
+			QVector<int>      m_lineStarts;
+			int               m_characterCount{0};
+
+			void              rebuildPrefixes();
+			[[nodiscard]] int clampedLineLength(int line) const;
+	};
+} // namespace QMudAccessibleTextUtils
+
+#endif // QMUD_ACCESSIBLETEXTUTILS_H

--- a/src/helpers/PluginPathUtils.cpp
+++ b/src/helpers/PluginPathUtils.cpp
@@ -1,0 +1,293 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: PluginPathUtils.cpp
+ * Role: Path normalization and containment helpers for legacy plugin file APIs.
+ */
+
+#include "PluginPathUtils.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QUrl>
+#include <array>
+#include <utility>
+
+namespace
+{
+	bool isPortableRootSegment(const QString &segment)
+	{
+		static constexpr std::array<const char *, 8> kPortableRoots = {"worlds", "lua",   "logs",   "plugins",
+		                                                               "sounds", "state", "backup", "docs"};
+		for (const char *root : kPortableRoots)
+		{
+			if (segment.compare(QLatin1String(root), Qt::CaseInsensitive) == 0)
+				return true;
+		}
+		return false;
+	}
+
+	bool containsParentTraversal(QString path)
+	{
+		path                       = QMudPluginPathUtils::normalizeSeparators(std::move(path));
+		const QStringList segments = path.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+		for (const QString &segment : segments)
+		{
+			if (segment == QLatin1String(".."))
+				return true;
+		}
+		return false;
+	}
+
+	bool isAbsolutePathLike(const QString &path)
+	{
+		if (path.isEmpty())
+			return false;
+		const QChar first   = path.at(0);
+		const bool  isDrive = path.size() > 1 && path.at(1) == QLatin1Char(':') && first.isLetter();
+		return isDrive || first == QLatin1Char('/');
+	}
+
+	QString directRelativePathUnderRoot(QString path, QString root, bool &matched)
+	{
+		path = QDir::cleanPath(QMudPluginPathUtils::normalizeSeparators(std::move(path)));
+		root = QDir::cleanPath(QMudPluginPathUtils::normalizeSeparators(std::move(root)));
+		if (root.endsWith(QLatin1Char('/')))
+			root.chop(1);
+		matched = false;
+		if (root.isEmpty())
+			return {};
+#ifdef Q_OS_WIN
+		const bool equals = path.compare(root, Qt::CaseInsensitive) == 0;
+		const bool below  = path.startsWith(root + QLatin1Char('/'), Qt::CaseInsensitive);
+#else
+		const bool equals = path == root;
+		const bool below  = path.startsWith(root + QLatin1Char('/'));
+#endif
+		if (!equals && !below)
+			return {};
+		matched = true;
+		if (equals)
+			return {};
+		return path.mid(root.size() + 1);
+	}
+
+	bool resolveExistingCanonicalParentInsideHome(const QString &absolutePath, const QString &canonicalHome,
+	                                              QString *error)
+	{
+		QFileInfo parentInfo(QFileInfo(absolutePath).absolutePath());
+		while (!parentInfo.exists())
+		{
+			const QString parentPath = parentInfo.absolutePath();
+			if (parentPath == parentInfo.filePath())
+				break;
+			parentInfo.setFile(parentPath);
+		}
+
+		const QString canonicalParent =
+		    QMudPluginPathUtils::normalizeSeparators(parentInfo.canonicalFilePath());
+		if (canonicalParent.isEmpty())
+		{
+			if (error)
+				*error = QStringLiteral("No existing parent directory inside QMud home directory");
+			return false;
+		}
+		if (!QMudPluginPathUtils::pathIsWithinOrEqualTo(canonicalParent, canonicalHome))
+		{
+			if (error)
+				*error = QStringLiteral("Path parent resolves outside QMud home directory");
+			return false;
+		}
+		return true;
+	}
+} // namespace
+
+QString QMudPluginPathUtils::normalizeSeparators(QString path)
+{
+	path = path.trimmed();
+	if (path.startsWith(QStringLiteral("file://"), Qt::CaseInsensitive))
+	{
+		const QUrl url(path);
+		if (url.isLocalFile())
+			path = url.toLocalFile();
+		else
+			path.remove(0, 7);
+	}
+	path.replace(QLatin1Char('\\'), QLatin1Char('/'));
+	while (path.contains(QStringLiteral("//")))
+		path.replace(QStringLiteral("//"), QStringLiteral("/"));
+	return path;
+}
+
+QString QMudPluginPathUtils::legacyPathRelativeToQmudHome(QString path)
+{
+	path = normalizeSeparators(std::move(path));
+	if (path.size() >= 2 && path.at(1) == QLatin1Char(':') && path.at(0).isLetter())
+		path.remove(0, 2);
+
+	const QStringList rawSegments = path.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+	QStringList       segments;
+	segments.reserve(rawSegments.size());
+	for (const QString &segment : rawSegments)
+	{
+		if (segment == QLatin1String("."))
+			continue;
+		if (segment == QLatin1String(".."))
+			return {};
+		segments.push_back(segment);
+	}
+
+	for (qsizetype i = 0; i < segments.size(); ++i)
+	{
+		if (isPortableRootSegment(segments.at(i)))
+			return segments.mid(i).join(QLatin1Char('/'));
+	}
+
+	return segments.join(QLatin1Char('/'));
+}
+
+bool QMudPluginPathUtils::pathIsWithinOrEqualTo(const QString &path, const QString &root)
+{
+	QString directPath = normalizeSeparators(path);
+	QString directRoot = normalizeSeparators(root);
+	if (directRoot.endsWith(QLatin1Char('/')))
+		directRoot.chop(1);
+	if (directRoot.isEmpty())
+		return false;
+#ifdef Q_OS_WIN
+	if (directPath.compare(directRoot, Qt::CaseInsensitive) == 0 ||
+	    directPath.startsWith(directRoot + QLatin1Char('/'), Qt::CaseInsensitive))
+		return true;
+#else
+	if (directPath == directRoot || directPath.startsWith(directRoot + QLatin1Char('/')))
+		return true;
+#endif
+
+	const QString normalizedPath = QDir::cleanPath(normalizeSeparators(path));
+	QString       normalizedRoot = QDir::cleanPath(normalizeSeparators(root));
+	if (normalizedRoot.endsWith(QLatin1Char('/')))
+		normalizedRoot.chop(1);
+	if (normalizedRoot.isEmpty())
+		return false;
+#ifdef Q_OS_WIN
+	return normalizedPath.compare(normalizedRoot, Qt::CaseInsensitive) == 0 ||
+	       normalizedPath.startsWith(normalizedRoot + QLatin1Char('/'), Qt::CaseInsensitive);
+#else
+	return normalizedPath == normalizedRoot || normalizedPath.startsWith(normalizedRoot + QLatin1Char('/'));
+#endif
+}
+
+bool QMudPluginPathUtils::resolveInsideQmudHome(const QString &qmudHome, const QString &rawPath,
+                                                QString *resolvedPath, QString *error)
+{
+	const QString home = normalizeSeparators(qmudHome);
+	if (home.isEmpty())
+	{
+		if (error)
+			*error = QStringLiteral("QMud home directory is not available");
+		return false;
+	}
+
+	const QString canonicalHome = normalizeSeparators(QFileInfo(home).canonicalFilePath());
+	if (canonicalHome.isEmpty())
+	{
+		if (error)
+			*error = QStringLiteral("QMud home directory does not resolve to an existing directory");
+		return false;
+	}
+
+	const QString normalizedRaw = normalizeSeparators(rawPath);
+	QString       relative;
+	if (isAbsolutePathLike(normalizedRaw))
+	{
+		const QString cleanHome  = QDir::cleanPath(home);
+		const QString cleanedRaw = QDir::cleanPath(normalizedRaw);
+		if (pathIsWithinOrEqualTo(cleanedRaw, cleanHome))
+			relative = normalizeSeparators(QDir(cleanHome).relativeFilePath(cleanedRaw));
+		else if (pathIsWithinOrEqualTo(cleanedRaw, canonicalHome))
+			relative = normalizeSeparators(QDir(canonicalHome).relativeFilePath(cleanedRaw));
+	}
+	if (relative.isEmpty())
+		relative = legacyPathRelativeToQmudHome(normalizedRaw);
+	if (relative.isEmpty() && !normalizeSeparators(rawPath).isEmpty() &&
+	    normalizeSeparators(rawPath) != QLatin1String("."))
+	{
+		if (error)
+			*error = QStringLiteral("Path contains an escaping parent segment");
+		return false;
+	}
+	if (relative.isEmpty())
+		relative = QStringLiteral(".");
+
+	const QString absolutePath = normalizeSeparators(QDir::cleanPath(QDir(canonicalHome).filePath(relative)));
+	if (!pathIsWithinOrEqualTo(absolutePath, canonicalHome))
+	{
+		if (error)
+			*error = QStringLiteral("Path resolves outside QMud home directory");
+		return false;
+	}
+
+	const QFileInfo targetInfo(absolutePath);
+	if (targetInfo.exists() || targetInfo.isSymLink())
+	{
+		const QString canonicalTarget = normalizeSeparators(targetInfo.canonicalFilePath());
+		if (canonicalTarget.isEmpty() || !pathIsWithinOrEqualTo(canonicalTarget, canonicalHome))
+		{
+			if (error)
+				*error = QStringLiteral("Path target resolves outside QMud home directory");
+			return false;
+		}
+	}
+	else if (!resolveExistingCanonicalParentInsideHome(absolutePath, canonicalHome, error))
+	{
+		return false;
+	}
+
+	if (resolvedPath)
+		*resolvedPath = absolutePath;
+	return true;
+}
+
+QString QMudPluginPathUtils::qmudHomeRelativePath(const QString &qmudHome, const QString &path,
+                                                  const bool trailingSlash)
+{
+	const QString normalizedPath = normalizeSeparators(path);
+	if (normalizedPath.isEmpty())
+		return {};
+	if (containsParentTraversal(normalizedPath))
+		return {};
+
+	QString relative;
+	bool    resolvedRelative = false;
+	if (!qmudHome.trimmed().isEmpty())
+	{
+		const QString cleanHome = QDir::cleanPath(normalizeSeparators(qmudHome));
+		const QString cleanPath = QDir::cleanPath(normalizedPath);
+		if (cleanPath == cleanHome)
+		{
+			relative.clear();
+			resolvedRelative = true;
+		}
+		else if (pathIsWithinOrEqualTo(cleanPath, cleanHome))
+		{
+			bool matched = false;
+			relative     = directRelativePathUnderRoot(cleanPath, cleanHome, matched);
+			if (!matched)
+				relative = normalizeSeparators(QDir(cleanHome).relativeFilePath(cleanPath));
+			if (relative == QLatin1String("."))
+				relative.clear();
+			resolvedRelative = true;
+		}
+	}
+
+	if (!resolvedRelative)
+		relative = legacyPathRelativeToQmudHome(normalizedPath);
+
+	relative = normalizeSeparators(QDir::cleanPath(relative.isEmpty() ? QStringLiteral(".") : relative));
+	if (relative == QLatin1String("."))
+		relative = trailingSlash ? QStringLiteral("./") : QStringLiteral(".");
+	else if (trailingSlash && !relative.endsWith(QLatin1Char('/')))
+		relative += QLatin1Char('/');
+	return relative;
+}

--- a/src/helpers/PluginPathUtils.h
+++ b/src/helpers/PluginPathUtils.h
@@ -1,0 +1,59 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: PluginPathUtils.h
+ * Role: Path normalization and containment helpers for legacy plugin file APIs.
+ */
+
+#ifndef QMUD_PLUGINPATHUTILS_H
+#define QMUD_PLUGINPATHUTILS_H
+
+#include <QString>
+
+/**
+ * @brief Helpers for mapping legacy MUSHclient-style plugin paths into the resolved QMud home directory.
+ */
+namespace QMudPluginPathUtils
+{
+	/**
+	 * @brief Normalizes path separators to POSIX style and collapses repeated slashes.
+	 * @param path Path text supplied by scripts or runtime state.
+	 * @return Separator-normalized path.
+	 */
+	[[nodiscard]] QString normalizeSeparators(QString path);
+	/**
+	 * @brief Interprets a legacy absolute or mixed-separator path as relative to the resolved QMud home directory.
+	 * @param path Script-supplied path.
+	 * @return QMud-home-relative POSIX path, or an empty string when parent traversal is present.
+	 */
+	[[nodiscard]] QString legacyPathRelativeToQmudHome(QString path);
+	/**
+	 * @brief Resolves a script file path under the resolved QMud home directory and rejects symlink/canonical escapes.
+	 * @param qmudHome Resolved QMud home directory path.
+	 * @param rawPath Script-supplied path.
+	 * @param resolvedPath Receives the absolute normalized path on success.
+	 * @param error Receives a diagnostic on failure.
+	 * @return True when the path is safely contained inside the resolved QMud home directory.
+	 */
+	[[nodiscard]] bool    resolveInsideQmudHome(const QString &qmudHome, const QString &rawPath,
+	                                            QString *resolvedPath, QString *error = nullptr);
+	/**
+	 * @brief Converts a path to a QMud-home-relative POSIX path for script metadata APIs.
+	 * @param qmudHome Resolved QMud home directory path.
+	 * @param path Path to convert.
+	 * @param trailingSlash True when directory-like values should end in `/`.
+	 * @return Relative POSIX path, or `./` for the resolved QMud home directory itself when requested.
+	 */
+	[[nodiscard]] QString qmudHomeRelativePath(const QString &qmudHome, const QString &path,
+	                                           bool trailingSlash);
+	/**
+	 * @brief Tests whether a path is inside a root directory after separator cleanup.
+	 * @param path Path to test.
+	 * @param root Root directory.
+	 * @return True when path equals root or is below it.
+	 */
+	[[nodiscard]] bool    pathIsWithinOrEqualTo(const QString &path, const QString &root);
+} // namespace QMudPluginPathUtils
+
+#endif // QMUD_PLUGINPATHUTILS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,13 @@ qmud_add_qtest(tst_OutputWrapUtils
         LABELS
         unit)
 
+qmud_add_qtest(tst_AccessibleTextUtils
+        SOURCES
+        unit/tst_AccessibleTextUtils.cpp
+        "${CMAKE_SOURCE_DIR}/src/helpers/AccessibleTextUtils.cpp"
+        LABELS
+        unit)
+
 qmud_add_qtest(tst_HyperlinkActionUtils
         SOURCES
         unit/tst_HyperlinkActionUtils.cpp
@@ -640,6 +647,7 @@ if (QMUD_ENABLE_GUI_TESTS)
             "${CMAKE_SOURCE_DIR}/src/WorldView.cpp"
             "${CMAKE_SOURCE_DIR}/src/TelnetProcessor.cpp"
             "${CMAKE_SOURCE_DIR}/src/helpers/AnsiSgrParseUtils.cpp"
+            "${CMAKE_SOURCE_DIR}/src/helpers/AccessibleTextUtils.cpp"
             "${CMAKE_SOURCE_DIR}/src/helpers/MiniWindowUtils.cpp"
             "${CMAKE_SOURCE_DIR}/src/helpers/OutputWrapUtils.cpp"
             "${CMAKE_SOURCE_DIR}/src/Environment.cpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,13 @@ qmud_add_qtest(tst_AccessibleTextUtils
         LABELS
         unit)
 
+qmud_add_qtest(tst_PluginPathUtils
+        SOURCES
+        unit/tst_PluginPathUtils.cpp
+        "${CMAKE_SOURCE_DIR}/src/helpers/PluginPathUtils.cpp"
+        LABELS
+        unit)
+
 qmud_add_qtest(tst_HyperlinkActionUtils
         SOURCES
         unit/tst_HyperlinkActionUtils.cpp
@@ -205,6 +212,7 @@ if (QMUD_ENABLE_LUA_SCRIPTING)
             "${CMAKE_SOURCE_DIR}/src/Sqlite3Lua.cpp"
             "${CMAKE_SOURCE_DIR}/src/Environment.cpp"
             "${CMAKE_SOURCE_DIR}/src/helpers/LuaExecutionUtils.cpp"
+            "${CMAKE_SOURCE_DIR}/src/helpers/PluginPathUtils.cpp"
             LIBRARIES
             ${LUA_LIBRARIES}
             Qt6::Gui

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -92,10 +92,26 @@ namespace
 			QString  text;
 	};
 
-	QVector<AccessibleTextInsertRecord> g_accessibleTextInsertRecords;
-	int                                 g_accessibleValueChangedCount{0};
+	struct AccessibleTextUpdateRecord
+	{
+			QObject *object{nullptr};
+			int      position{0};
+			QString  removedText;
+			QString  insertedText;
+	};
 
-	void                                captureAccessibleUpdate(QAccessibleEvent *event)
+	struct AccessibleAnnouncementRecord
+	{
+			QObject *object{nullptr};
+			QString  message;
+	};
+
+	QVector<AccessibleTextInsertRecord>   g_accessibleTextInsertRecords;
+	QVector<AccessibleTextUpdateRecord>   g_accessibleTextUpdateRecords;
+	QVector<AccessibleAnnouncementRecord> g_accessibleAnnouncementRecords;
+	int                                   g_accessibleValueChangedCount{0};
+
+	void                                  captureAccessibleUpdate(QAccessibleEvent *event)
 	{
 		if (!event)
 			return;
@@ -104,13 +120,32 @@ namespace
 			++g_accessibleValueChangedCount;
 			return;
 		}
-		if (event->type() != QAccessible::TextInserted)
+		if (event->type() == QAccessible::TextInserted)
+		{
+			const auto *insertEvent = dynamic_cast<QAccessibleTextInsertEvent *>(event);
+			if (!insertEvent)
+				return;
+			g_accessibleTextInsertRecords.push_back(
+			    {event->object(), insertEvent->changePosition(), insertEvent->textInserted()});
 			return;
-		const auto *insertEvent = dynamic_cast<QAccessibleTextInsertEvent *>(event);
-		if (!insertEvent)
+		}
+		if (event->type() == QAccessible::TextUpdated)
+		{
+			const auto *updateEvent = dynamic_cast<QAccessibleTextUpdateEvent *>(event);
+			if (!updateEvent)
+				return;
+			g_accessibleTextUpdateRecords.push_back({event->object(), updateEvent->changePosition(),
+			                                         updateEvent->textRemoved(),
+			                                         updateEvent->textInserted()});
 			return;
-		g_accessibleTextInsertRecords.push_back(
-		    {event->object(), insertEvent->changePosition(), insertEvent->textInserted()});
+		}
+		if (event->type() == QAccessible::Announcement)
+		{
+			const auto *announcementEvent = dynamic_cast<QAccessibleAnnouncementEvent *>(event);
+			if (!announcementEvent)
+				return;
+			g_accessibleAnnouncementRecords.push_back({event->object(), announcementEvent->message()});
+		}
 	}
 
 	class ScopedAccessibleUpdateCapture
@@ -121,6 +156,8 @@ namespace
 			      m_previousHandler(QAccessible::installUpdateHandler(captureAccessibleUpdate))
 			{
 				g_accessibleTextInsertRecords.clear();
+				g_accessibleTextUpdateRecords.clear();
+				g_accessibleAnnouncementRecords.clear();
 				g_accessibleValueChangedCount = 0;
 				QAccessible::setActive(true);
 			}
@@ -130,6 +167,8 @@ namespace
 				QAccessible::installUpdateHandler(m_previousHandler);
 				QAccessible::setActive(m_previousActive);
 				g_accessibleTextInsertRecords.clear();
+				g_accessibleTextUpdateRecords.clear();
+				g_accessibleAnnouncementRecords.clear();
 				g_accessibleValueChangedCount = 0;
 			}
 
@@ -199,6 +238,8 @@ namespace
 		g_acceleratorExecutionCount      = 0;
 		g_lastExecutedAcceleratorCommand = -1;
 		g_accessibleTextInsertRecords.clear();
+		g_accessibleTextUpdateRecords.clear();
+		g_accessibleAnnouncementRecords.clear();
 		g_accessibleValueChangedCount = 0;
 	}
 
@@ -337,6 +378,11 @@ namespace
 		if (!bestBrowser)
 			bestBrowser = topBrowser ? topBrowser : bottomBrowser;
 		return bestBrowser;
+	}
+
+	QWidget *findNativeOutputCanvas(const WorldView &view)
+	{
+		return view.findChild<QWidget *>(QStringLiteral("worldOutputNativeCanvas"));
 	}
 
 	QPoint findHyperlinkPoint(WorldView &view, QTextBrowser &browser, const QString &href)
@@ -1293,14 +1339,23 @@ class tst_WorldView_Basic : public QObject
 			qmudInstallWorldOutputAccessibility();
 
 			WorldView view;
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
 			view.appendOutputText(QStringLiteral("alpha"), true);
 			view.appendOutputText(QStringLiteral("beta"), true);
+			QCoreApplication::processEvents();
 
 			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
 			QVERIFY(topBrowser);
 			QVERIFY(bottomBrowser);
 
-			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(topBrowser);
+			QAccessibleInterface *browserAccessible = QAccessible::queryAccessibleInterface(topBrowser);
+			QVERIFY(!browserAccessible || !browserAccessible->textInterface());
+
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(canvas);
 			QVERIFY(accessible);
 			QCOMPARE(accessible->role(), QAccessible::Terminal);
 			QCOMPARE(accessible->text(QAccessible::Name), QStringLiteral("World output"));
@@ -1323,6 +1378,53 @@ class tst_WorldView_Basic : public QObject
 			QCOMPARE(textInterface->selectionCount(), 0);
 		}
 
+		void worldOutputAccessibleCanvasExposesTextAndReceivesNotifications()
+		{
+			qmudInstallWorldOutputAccessibility();
+
+			WorldView view;
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QVERIFY(canvas->isVisible());
+
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(canvas);
+			QVERIFY(accessible);
+			QCOMPARE(accessible->role(), QAccessible::Terminal);
+			QCOMPARE(accessible->text(QAccessible::Name), QStringLiteral("World output"));
+			const QAccessible::State state = accessible->state();
+			QVERIFY(state.readOnly);
+			QVERIFY(state.multiLine);
+			QVERIFY(state.selectableText);
+
+			QAccessibleTextInterface *textInterface = accessible->textInterface();
+			QVERIFY(textInterface);
+			QCOMPARE(textInterface->characterCount(), 0);
+
+			ScopedAccessibleUpdateCapture capture;
+
+			view.appendOutputText(QStringLiteral("alpha"), true);
+			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 1);
+			QCOMPARE(g_accessibleTextInsertRecords.at(0).object, canvas);
+			QCOMPARE(g_accessibleTextInsertRecords.at(0).position, 0);
+			QCOMPARE(g_accessibleTextInsertRecords.at(0).text, QStringLiteral("alpha"));
+			QCOMPARE(textInterface->text(0, textInterface->characterCount()), QStringLiteral("alpha"));
+
+			view.clearOutputBuffer();
+			QTRY_COMPARE(g_accessibleTextUpdateRecords.size(), 1);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).object, canvas);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).position, 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).removedText, QStringLiteral("alpha"));
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).insertedText, QString());
+			QCOMPARE(g_accessibleAnnouncementRecords.size(), 1);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(0).object, canvas);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(0).message, QStringLiteral("alpha"));
+			QCOMPARE(g_accessibleValueChangedCount, 0);
+		}
+
 		void worldOutputAccessibleGeometryUsesNativeTextHitTesting()
 		{
 			qmudInstallWorldOutputAccessibility();
@@ -1340,7 +1442,9 @@ class tst_WorldView_Basic : public QObject
 			QVERIFY(browser);
 			QVERIFY(browser->viewport());
 
-			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(browser);
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(canvas);
 			QVERIFY(accessible);
 			QAccessibleTextInterface *textInterface = accessible->textInterface();
 			QVERIFY(textInterface);
@@ -1380,7 +1484,9 @@ class tst_WorldView_Basic : public QObject
 			const int tailScrollValue = browser->verticalScrollBar()->value();
 			QVERIFY(tailScrollValue > 0);
 
-			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(browser);
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(canvas);
 			QVERIFY(accessible);
 			QAccessibleTextInterface *textInterface = accessible->textInterface();
 			QVERIFY(textInterface);
@@ -1396,10 +1502,15 @@ class tst_WorldView_Basic : public QObject
 			qmudInstallWorldOutputAccessibility();
 
 			WorldView view;
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
 			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
 			QVERIFY(topBrowser);
 			QVERIFY(bottomBrowser);
-			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(topBrowser);
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(canvas);
 			QVERIFY(accessible);
 			QCOMPARE(accessible->role(), QAccessible::Terminal);
 			QAccessibleTextInterface *textInterface = accessible->textInterface();
@@ -1410,20 +1521,27 @@ class tst_WorldView_Basic : public QObject
 
 			view.appendOutputText(QStringLiteral("alpha"), true);
 			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 1);
-			QCOMPARE(g_accessibleTextInsertRecords.at(0).object, topBrowser);
+			QCOMPARE(g_accessibleTextInsertRecords.at(0).object, canvas);
 			QCOMPARE(g_accessibleTextInsertRecords.at(0).position, 0);
 			QCOMPARE(g_accessibleTextInsertRecords.at(0).text, QStringLiteral("alpha"));
+			QTRY_COMPARE(g_accessibleAnnouncementRecords.size(), 1);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(0).object, canvas);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(0).message, QStringLiteral("alpha"));
 
 			view.appendOutputText(QStringLiteral("beta"), true);
 			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 2);
-			QCOMPARE(g_accessibleTextInsertRecords.at(1).object, topBrowser);
+			QCOMPARE(g_accessibleTextInsertRecords.at(1).object, canvas);
 			QCOMPARE(g_accessibleTextInsertRecords.at(1).position, 5);
 			QCOMPARE(g_accessibleTextInsertRecords.at(1).text, QStringLiteral("\nbeta"));
+			QTRY_COMPARE(g_accessibleAnnouncementRecords.size(), 2);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(1).object, canvas);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(1).message, QStringLiteral("beta"));
 
 			QAccessible::setActive(false);
 			view.appendOutputText(QStringLiteral("gamma"), true);
 			QCoreApplication::processEvents();
 			QCOMPARE(g_accessibleTextInsertRecords.size(), 2);
+			QCOMPARE(g_accessibleAnnouncementRecords.size(), 2);
 			QCOMPARE(g_accessibleValueChangedCount, 0);
 		}
 
@@ -1432,10 +1550,15 @@ class tst_WorldView_Basic : public QObject
 			qmudInstallWorldOutputAccessibility();
 
 			WorldView view;
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
 			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
 			QVERIFY(topBrowser);
 			QVERIFY(bottomBrowser);
-			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(topBrowser);
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(canvas);
 			QVERIFY(accessible);
 			QAccessibleTextInterface *textInterface = accessible->textInterface();
 			QVERIFY(textInterface);
@@ -1445,19 +1568,48 @@ class tst_WorldView_Basic : public QObject
 
 			view.appendOutputText(QStringLiteral("alpha"), true);
 			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 1);
+			QTRY_COMPARE(g_accessibleAnnouncementRecords.size(), 1);
 			QCOMPARE(g_accessibleValueChangedCount, 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.size(), 0);
 
 			view.clearOutputBuffer();
-			QTRY_COMPARE(g_accessibleValueChangedCount, 1);
+			QTRY_COMPARE(g_accessibleTextUpdateRecords.size(), 1);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).object, canvas);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).position, 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).removedText, QStringLiteral("alpha"));
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).insertedText, QString());
+			QCOMPARE(g_accessibleAnnouncementRecords.size(), 1);
+			QCOMPARE(g_accessibleValueChangedCount, 0);
 			QCOMPARE(g_accessibleTextInsertRecords.size(), 1);
 			QCOMPARE(textInterface->characterCount(), 0);
 
 			QVector<WorldRuntime::LineEntry> replacementLines{
 			    makeRuntimeLine(QStringLiteral("replacement"), WorldRuntime::LineOutput, true, 1)};
 			view.restoreOutputFromPersistedLines(replacementLines);
-			QTRY_COMPARE(g_accessibleValueChangedCount, 2);
+			QTRY_COMPARE(g_accessibleTextUpdateRecords.size(), 2);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(1).object, canvas);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(1).position, 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(1).removedText, QString());
+			QCOMPARE(g_accessibleTextUpdateRecords.at(1).insertedText, QStringLiteral("replacement"));
+			QCOMPARE(g_accessibleAnnouncementRecords.size(), 1);
+			QCOMPARE(g_accessibleValueChangedCount, 0);
 			QCOMPARE(g_accessibleTextInsertRecords.size(), 1);
 			QCOMPARE(textInterface->text(0, textInterface->characterCount()), QStringLiteral("replacement"));
+
+			QVector<WorldRuntime::LineEntry> preservedPrefixLines{
+			    makeRuntimeLine(QStringLiteral("replacement"), WorldRuntime::LineOutput, true, 1),
+			    makeRuntimeLine(QStringLiteral("delta"), WorldRuntime::LineOutput, true, 2)};
+			view.restoreOutputFromPersistedLines(preservedPrefixLines);
+			QTRY_COMPARE(g_accessibleTextUpdateRecords.size(), 3);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(2).object, canvas);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(2).position, 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(2).removedText, QStringLiteral("replacement"));
+			QCOMPARE(g_accessibleTextUpdateRecords.at(2).insertedText, QStringLiteral("replacement\ndelta"));
+			QTRY_COMPARE(g_accessibleAnnouncementRecords.size(), 2);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(1).object, canvas);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(1).message, QStringLiteral("delta"));
+			QCOMPARE(textInterface->text(0, textInterface->characterCount()),
+			         QStringLiteral("replacement\ndelta"));
 		}
 
 		void worldOutputAccessibleHeadTrimAppendUsesContentChangedFallback()
@@ -1469,20 +1621,35 @@ class tst_WorldView_Basic : public QObject
 			WorldView view;
 			view.setRuntimeObserver(fakeRuntimePointer());
 			view.applyRuntimeSettings();
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
 			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
 			QVERIFY(topBrowser);
 			QVERIFY(bottomBrowser);
-			QVERIFY(QAccessible::queryAccessibleInterface(topBrowser));
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QVERIFY(QAccessible::queryAccessibleInterface(canvas));
 
 			ScopedAccessibleUpdateCapture capture;
 
 			view.appendOutputText(QStringLiteral("one"), true);
 			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 1);
+			QTRY_COMPARE(g_accessibleAnnouncementRecords.size(), 1);
 			view.appendOutputText(QStringLiteral("two"), true);
 			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 2);
+			QTRY_COMPARE(g_accessibleAnnouncementRecords.size(), 2);
 
 			view.appendOutputText(QStringLiteral("three"), true);
-			QTRY_COMPARE(g_accessibleValueChangedCount, 1);
+			QTRY_COMPARE(g_accessibleTextUpdateRecords.size(), 1);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).object, canvas);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).position, 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).removedText, QStringLiteral("one\ntwo"));
+			QCOMPARE(g_accessibleTextUpdateRecords.at(0).insertedText, QStringLiteral("two\nthree"));
+			QTRY_COMPARE(g_accessibleAnnouncementRecords.size(), 3);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(2).object, canvas);
+			QCOMPARE(g_accessibleAnnouncementRecords.at(2).message, QStringLiteral("three"));
+			QCOMPARE(g_accessibleValueChangedCount, 0);
 			QCOMPARE(g_accessibleTextInsertRecords.size(), 2);
 			QVERIFY(view.outputLines().contains(QStringLiteral("three")));
 			QVERIFY(!view.outputLines().contains(QStringLiteral("one")));

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -17,6 +17,7 @@
 
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QAbstractScrollArea>
+#include <QAccessible>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QApplication>
 #include <QCheckBox>
@@ -84,7 +85,60 @@ namespace
 	int                                 g_acceleratorExecutionCount{0};
 	int                                 g_lastExecutedAcceleratorCommand{-1};
 
-	AppController                      *fakeAppControllerPointer()
+	struct AccessibleTextInsertRecord
+	{
+			QObject *object{nullptr};
+			int      position{0};
+			QString  text;
+	};
+
+	QVector<AccessibleTextInsertRecord> g_accessibleTextInsertRecords;
+	int                                 g_accessibleValueChangedCount{0};
+
+	void                                captureAccessibleUpdate(QAccessibleEvent *event)
+	{
+		if (!event)
+			return;
+		if (event->type() == QAccessible::ValueChanged)
+		{
+			++g_accessibleValueChangedCount;
+			return;
+		}
+		if (event->type() != QAccessible::TextInserted)
+			return;
+		const auto *insertEvent = dynamic_cast<QAccessibleTextInsertEvent *>(event);
+		if (!insertEvent)
+			return;
+		g_accessibleTextInsertRecords.push_back(
+		    {event->object(), insertEvent->changePosition(), insertEvent->textInserted()});
+	}
+
+	class ScopedAccessibleUpdateCapture
+	{
+		public:
+			ScopedAccessibleUpdateCapture()
+			    : m_previousActive(QAccessible::isActive()),
+			      m_previousHandler(QAccessible::installUpdateHandler(captureAccessibleUpdate))
+			{
+				g_accessibleTextInsertRecords.clear();
+				g_accessibleValueChangedCount = 0;
+				QAccessible::setActive(true);
+			}
+
+			~ScopedAccessibleUpdateCapture()
+			{
+				QAccessible::installUpdateHandler(m_previousHandler);
+				QAccessible::setActive(m_previousActive);
+				g_accessibleTextInsertRecords.clear();
+				g_accessibleValueChangedCount = 0;
+			}
+
+		private:
+			bool                       m_previousActive{false};
+			QAccessible::UpdateHandler m_previousHandler{nullptr};
+	};
+
+	AppController *fakeAppControllerPointer()
 	{
 		return reinterpret_cast<AppController *>(static_cast<quintptr>(1));
 	}
@@ -144,6 +198,8 @@ namespace
 		g_acceleratorCommands.clear();
 		g_acceleratorExecutionCount      = 0;
 		g_lastExecutedAcceleratorCommand = -1;
+		g_accessibleTextInsertRecords.clear();
+		g_accessibleValueChangedCount = 0;
 	}
 
 	qint64 makeAcceleratorMapKey(const Qt::Key key, const Qt::KeyboardModifiers modifiers,
@@ -1230,6 +1286,207 @@ class tst_WorldView_Basic : public QObject
 			const QStringList lines = view.outputLines();
 			QVERIFY(!lines.isEmpty());
 			QVERIFY(lines.contains(QStringLiteral("line-one")));
+		}
+
+		void worldOutputAccessibleFactoryExposesReadOnlyTextInterface()
+		{
+			qmudInstallWorldOutputAccessibility();
+
+			WorldView view;
+			view.appendOutputText(QStringLiteral("alpha"), true);
+			view.appendOutputText(QStringLiteral("beta"), true);
+
+			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
+			QVERIFY(topBrowser);
+			QVERIFY(bottomBrowser);
+
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(topBrowser);
+			QVERIFY(accessible);
+			QCOMPARE(accessible->role(), QAccessible::Terminal);
+			QCOMPARE(accessible->text(QAccessible::Name), QStringLiteral("World output"));
+
+			QAccessibleTextInterface *textInterface = accessible->textInterface();
+			QVERIFY(textInterface);
+			QCOMPARE(textInterface->text(0, textInterface->characterCount()), QStringLiteral("alpha\nbeta"));
+			QCOMPARE(textInterface->selectionCount(), 0);
+
+			textInterface->setSelection(0, 2, 8);
+			int startOffset = 0;
+			int endOffset   = 0;
+			QCOMPARE(textInterface->selectionCount(), 1);
+			textInterface->selection(0, &startOffset, &endOffset);
+			QCOMPARE(startOffset, 2);
+			QCOMPARE(endOffset, 8);
+			QCOMPARE(view.outputSelectionText(), QStringLiteral("pha\nbe"));
+
+			textInterface->removeSelection(0);
+			QCOMPARE(textInterface->selectionCount(), 0);
+		}
+
+		void worldOutputAccessibleGeometryUsesNativeTextHitTesting()
+		{
+			qmudInstallWorldOutputAccessibility();
+
+			WorldView view;
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			view.appendOutputText(QStringLiteral("alpha"), true);
+			view.appendOutputText(QStringLiteral("beta"), true);
+			QCoreApplication::processEvents();
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QVERIFY(browser->viewport());
+
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(browser);
+			QVERIFY(accessible);
+			QAccessibleTextInterface *textInterface = accessible->textInterface();
+			QVERIFY(textInterface);
+
+			const QRect characterRect = textInterface->characterRect(0);
+			QVERIFY(!characterRect.isEmpty());
+			QVERIFY(characterRect.width() < browser->viewport()->width());
+			QVERIFY(characterRect.height() < browser->viewport()->height());
+
+			const QPoint firstCharacterPoint(characterRect.left(), characterRect.center().y());
+			QCOMPARE(textInterface->offsetAtPoint(firstCharacterPoint), 0);
+
+			const QPoint outsideTextPoint = browser->viewport()->mapToGlobal(
+			    QPoint(browser->viewport()->width() - 2,
+			           characterRect.center().y() - browser->viewport()->mapToGlobal(QPoint(0, 0)).y()));
+			QCOMPARE(textInterface->offsetAtPoint(outsideTextPoint), -1);
+		}
+
+		void worldOutputAccessibleScrollToSubstringUsesNativeOutputScroll()
+		{
+			qmudInstallWorldOutputAccessibility();
+
+			WorldView view;
+			view.resize(640, 240);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			for (int i = 0; i < 120; ++i)
+				view.appendOutputText(QStringLiteral("line-%1").arg(i, 3, 10, QLatin1Char('0')), true);
+			QCoreApplication::processEvents();
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QVERIFY(browser->verticalScrollBar());
+			QTRY_VERIFY(browser->verticalScrollBar()->maximum() > 0);
+			browser->verticalScrollBar()->setValue(browser->verticalScrollBar()->maximum());
+			const int tailScrollValue = browser->verticalScrollBar()->value();
+			QVERIFY(tailScrollValue > 0);
+
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(browser);
+			QVERIFY(accessible);
+			QAccessibleTextInterface *textInterface = accessible->textInterface();
+			QVERIFY(textInterface);
+
+			textInterface->scrollToSubstring(0, 8);
+			QCoreApplication::processEvents();
+
+			QVERIFY(browser->verticalScrollBar()->value() < tailScrollValue);
+		}
+
+		void worldOutputAccessibleInsertNotificationUsesPresentedAppendPayload()
+		{
+			qmudInstallWorldOutputAccessibility();
+
+			WorldView view;
+			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
+			QVERIFY(topBrowser);
+			QVERIFY(bottomBrowser);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(topBrowser);
+			QVERIFY(accessible);
+			QCOMPARE(accessible->role(), QAccessible::Terminal);
+			QAccessibleTextInterface *textInterface = accessible->textInterface();
+			QVERIFY(textInterface);
+			QCOMPARE(textInterface->characterCount(), 0);
+
+			ScopedAccessibleUpdateCapture capture;
+
+			view.appendOutputText(QStringLiteral("alpha"), true);
+			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 1);
+			QCOMPARE(g_accessibleTextInsertRecords.at(0).object, topBrowser);
+			QCOMPARE(g_accessibleTextInsertRecords.at(0).position, 0);
+			QCOMPARE(g_accessibleTextInsertRecords.at(0).text, QStringLiteral("alpha"));
+
+			view.appendOutputText(QStringLiteral("beta"), true);
+			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 2);
+			QCOMPARE(g_accessibleTextInsertRecords.at(1).object, topBrowser);
+			QCOMPARE(g_accessibleTextInsertRecords.at(1).position, 5);
+			QCOMPARE(g_accessibleTextInsertRecords.at(1).text, QStringLiteral("\nbeta"));
+
+			QAccessible::setActive(false);
+			view.appendOutputText(QStringLiteral("gamma"), true);
+			QCoreApplication::processEvents();
+			QCOMPARE(g_accessibleTextInsertRecords.size(), 2);
+			QCOMPARE(g_accessibleValueChangedCount, 0);
+		}
+
+		void worldOutputAccessibleNonAppendMutationsUseContentChangedFallback()
+		{
+			qmudInstallWorldOutputAccessibility();
+
+			WorldView view;
+			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
+			QVERIFY(topBrowser);
+			QVERIFY(bottomBrowser);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(topBrowser);
+			QVERIFY(accessible);
+			QAccessibleTextInterface *textInterface = accessible->textInterface();
+			QVERIFY(textInterface);
+			QCOMPARE(textInterface->characterCount(), 0);
+
+			ScopedAccessibleUpdateCapture capture;
+
+			view.appendOutputText(QStringLiteral("alpha"), true);
+			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 1);
+			QCOMPARE(g_accessibleValueChangedCount, 0);
+
+			view.clearOutputBuffer();
+			QTRY_COMPARE(g_accessibleValueChangedCount, 1);
+			QCOMPARE(g_accessibleTextInsertRecords.size(), 1);
+			QCOMPARE(textInterface->characterCount(), 0);
+
+			QVector<WorldRuntime::LineEntry> replacementLines{
+			    makeRuntimeLine(QStringLiteral("replacement"), WorldRuntime::LineOutput, true, 1)};
+			view.restoreOutputFromPersistedLines(replacementLines);
+			QTRY_COMPARE(g_accessibleValueChangedCount, 2);
+			QCOMPARE(g_accessibleTextInsertRecords.size(), 1);
+			QCOMPARE(textInterface->text(0, textInterface->characterCount()), QStringLiteral("replacement"));
+		}
+
+		void worldOutputAccessibleHeadTrimAppendUsesContentChangedFallback()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("max_output_lines"), QStringLiteral("2"));
+			qmudInstallWorldOutputAccessibility();
+
+			WorldView view;
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			const auto [topBrowser, bottomBrowser] = findSplitOutputBrowsers(view);
+			QVERIFY(topBrowser);
+			QVERIFY(bottomBrowser);
+			QVERIFY(QAccessible::queryAccessibleInterface(topBrowser));
+
+			ScopedAccessibleUpdateCapture capture;
+
+			view.appendOutputText(QStringLiteral("one"), true);
+			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 1);
+			view.appendOutputText(QStringLiteral("two"), true);
+			QTRY_COMPARE(g_accessibleTextInsertRecords.size(), 2);
+
+			view.appendOutputText(QStringLiteral("three"), true);
+			QTRY_COMPARE(g_accessibleValueChangedCount, 1);
+			QCOMPARE(g_accessibleTextInsertRecords.size(), 2);
+			QVERIFY(view.outputLines().contains(QStringLiteral("three")));
+			QVERIFY(!view.outputLines().contains(QStringLiteral("one")));
+			resetTestState();
 		}
 
 		void runtimeObserverTransitionDetachesPreviouslyAttachedRuntime()

--- a/tests/unit/tst_AccessibleTextUtils.cpp
+++ b/tests/unit/tst_AccessibleTextUtils.cpp
@@ -1,0 +1,128 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_AccessibleTextUtils.cpp
+ * Role: QTest coverage for accessible text offset mapping helpers.
+ */
+
+#include "AccessibleTextUtils.h"
+
+#include <QtTest/QTest>
+
+using QMudAccessibleTextUtils::LineOffsetMap;
+using QMudAccessibleTextUtils::TextPosition;
+
+/**
+ * @brief QTest fixture covering native output accessible text mapping.
+ */
+class tst_AccessibleTextUtils : public QObject
+{
+		Q_OBJECT
+
+		// NOLINTBEGIN(readability-convert-member-functions-to-static)
+	private slots:
+		void emptyOutputHasNoAccessibleText()
+		{
+			const LineOffsetMap map;
+
+			QVERIFY(map.isEmpty());
+			QCOMPARE(map.lineCount(), 0);
+			QCOMPARE(map.characterCount(), 0);
+			QCOMPARE(map.text(0, 10), QString());
+			QCOMPARE(map.offsetForPosition({3, 7}), 0);
+
+			const TextPosition position = map.positionForOffset(5);
+			QCOMPARE(position.line, 0);
+			QCOMPARE(position.column, 0);
+		}
+
+		void oneLineMapsOffsetsWithoutTrailingNewline()
+		{
+			const LineOffsetMap map({QStringLiteral("prompt> look")});
+
+			QVERIFY(!map.isEmpty());
+			QCOMPARE(map.lineCount(), 1);
+			QCOMPARE(map.characterCount(), 12);
+			QCOMPARE(map.text(0, map.characterCount()), QStringLiteral("prompt> look"));
+			QCOMPARE(map.offsetForPosition({0, 8}), 8);
+
+			const TextPosition position = map.positionForOffset(8);
+			QCOMPARE(position.line, 0);
+			QCOMPARE(position.column, 8);
+		}
+
+		void multipleLinesUseNewlineSeparators()
+		{
+			const LineOffsetMap map(
+			    {QStringLiteral("alpha"), QStringLiteral("beta"), QStringLiteral("gamma")});
+
+			QCOMPARE(map.characterCount(), 16);
+			QCOMPARE(map.text(0, map.characterCount()), QStringLiteral("alpha\nbeta\ngamma"));
+			QCOMPARE(map.offsetForPosition({1, 0}), 6);
+			QCOMPARE(map.offsetForPosition({2, 2}), 13);
+
+			const TextPosition newlinePosition = map.positionForOffset(5);
+			QCOMPARE(newlinePosition.line, 0);
+			QCOMPARE(newlinePosition.column, 5);
+		}
+
+		void slicesCanStartAndEndInsideDifferentLines()
+		{
+			const LineOffsetMap map(
+			    {QStringLiteral("alpha"), QStringLiteral("beta"), QStringLiteral("gamma")});
+
+			QCOMPARE(map.text(2, 12), QStringLiteral("pha\nbeta\ng"));
+			QCOMPARE(map.text(5, 6), QStringLiteral("\n"));
+			QCOMPARE(map.text(6, 10), QStringLiteral("beta"));
+		}
+
+		void positionsAndOffsetsClampToCurrentBuffer()
+		{
+			const LineOffsetMap map({QStringLiteral("one"), QStringLiteral("two")});
+
+			QCOMPARE(map.offsetForPosition({-2, -5}), 0);
+			QCOMPARE(map.offsetForPosition({0, 99}), 3);
+			QCOMPARE(map.offsetForPosition({7, 1}), map.characterCount());
+
+			TextPosition position = map.positionForOffset(-10);
+			QCOMPARE(position.line, 0);
+			QCOMPARE(position.column, 0);
+
+			position = map.positionForOffset(999);
+			QCOMPARE(position.line, 1);
+			QCOMPARE(position.column, 3);
+		}
+
+		void resetModelsCappedBufferTrim()
+		{
+			LineOffsetMap map({QStringLiteral("old1"), QStringLiteral("old2"), QStringLiteral("new")});
+			QCOMPARE(map.text(0, map.characterCount()), QStringLiteral("old1\nold2\nnew"));
+
+			map.reset({QStringLiteral("old2"), QStringLiteral("new"), QStringLiteral("tail")});
+
+			QCOMPARE(map.characterCount(), 13);
+			QCOMPARE(map.text(0, map.characterCount()), QStringLiteral("old2\nnew\ntail"));
+			QCOMPARE(map.offsetForPosition({1, 0}), 5);
+		}
+
+		void selectionTextUsesEitherEndpointOrder()
+		{
+			const LineOffsetMap map(
+			    {QStringLiteral("north"), QStringLiteral("east"), QStringLiteral("south")});
+
+			constexpr TextPosition anchor{0, 2};
+			constexpr TextPosition cursor{2, 3};
+
+			QCOMPARE(map.selectedText(anchor, cursor), QStringLiteral("rth\neast\nsou"));
+			QCOMPARE(map.selectedText(cursor, anchor), QStringLiteral("rth\neast\nsou"));
+			QCOMPARE(map.selectedText({1, 1}, {1, 1}), QString());
+		}
+		// NOLINTEND(readability-convert-member-functions-to-static)
+};
+
+QTEST_APPLESS_MAIN(tst_AccessibleTextUtils)
+
+#if __has_include("tst_AccessibleTextUtils.moc")
+#include "tst_AccessibleTextUtils.moc"
+#endif

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -508,6 +508,7 @@ namespace
 			void workerDispatchesPluginLifecycleCallbacksOnRealEngines();
 			void workerCallbackBatchCapturesOutputMiniWindowAndSaveStateMutations();
 			void workerColourOutputMatchesMushclientGroupingAndNewlineSemantics();
+			void colourTellIgnoresTrailingLuaGsubReturnAndKeepsFollowingNote();
 			void triggerAnchoredColourOutputKeepsNativePromptText();
 			void callbackSnapshotSuppliesGetInfoAndMiniWindowReads();
 			void deferredRuntimeMutationSkipsDestroyedRuntime();
@@ -1355,6 +1356,37 @@ end
 	         QStringList({QStringLiteral("note-a"), QStringLiteral("note-b"), QStringLiteral("note-c"),
 	                      QStringLiteral("tell-a"), QStringLiteral("tell-b")}));
 	QCOMPARE(state.outputNewLines, QList<bool>({false, false, true, false, false}));
+}
+
+void tst_LuaCallbackEngine::colourTellIgnoresTrailingLuaGsubReturnAndKeepsFollowingNote()
+{
+	WorldRuntime runtime;
+	auto         engine = QSharedPointer<LuaCallbackEngine>::create();
+	engine->setWorldRuntime(&runtime);
+	setEngineScript(*engine, QStringLiteral(R"lua(
+function OnPluginEnable()
+  local profit = 10000
+  Tell("You made ")
+  ColourTell("yellow", "black", tostring(profit):reverse():gsub("(%d%d%d)", "%1,"):reverse():gsub("^,", ""))
+  Note(" gold!")
+end
+)lua"));
+
+	LuaExecutorWorker       executor;
+	LuaBatchDispatchRequest request;
+	request.engines      = {engine};
+	request.kind         = LuaBatchDispatchKind::NoArgs;
+	request.functionName = QStringLiteral("OnPluginEnable");
+	LuaBatchDispatchResult result;
+	dispatchWorkerAndWait(executor, request, result);
+	executeDeferredMutations(result);
+
+	const RuntimeStubState &state = runtimeStubState(&runtime);
+	QCOMPARE(state.outputLines,
+	         QStringList({QStringLiteral("You made "), QStringLiteral("10,000"), QStringLiteral(" gold!")}));
+	QCOMPARE(state.outputNewLines, QList<bool>({false, false, true}));
+	QCOMPARE(logicalOutputLinesFromEntries(state.lineEntries),
+	         QStringList({QStringLiteral("You made 10,000 gold!")}));
 }
 
 void tst_LuaCallbackEngine::triggerAnchoredColourOutputKeepsNativePromptText()

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -16,6 +16,12 @@
 #include "WorldView.h"
 #include "helpers/LuaExecutionUtils.h"
 
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QDir>
+#include <QFile>
+#include <QMetaObject>
+#include <QScopeGuard>
+#include <QThread>
 #include <QtTest/QTest>
 
 #include <atomic>
@@ -41,6 +47,21 @@ QVariant AppController::getGlobalOption(const QString &name) const
 	return {};
 }
 
+QString AppController::iniFilePath() const
+{
+	return QDir::current().filePath(QStringLiteral("qmud.ini"));
+}
+
+bool AppController::isTranslatorLuaAvailable() const
+{
+	return false;
+}
+
+QVariantMap qmudCollectGuiSystemValues()
+{
+	return {};
+}
+
 TelnetProcessor::TelnetProcessor() = default;
 
 namespace
@@ -61,6 +82,18 @@ namespace
 			QHash<QString, QHash<int, QVariant>> windowInfo;
 			QHash<QString, QStringList>          hotspotIds;
 			QVector<WorldRuntime::LineEntry>     lineEntries;
+			QString                              startupDirectory;
+			QMap<QString, QString>               worldAttributes;
+			QString                              logFileName;
+			QString                              worldFilePath;
+			QString                              defaultWorldDirectory;
+			QString                              defaultLogDirectory;
+			QString                              pluginsDirectory;
+			QString                              translatorFile;
+			QString                              firstSpecialFontPath;
+			QString                              preferencesDatabaseName;
+			QString                              fileBrowsingDirectory;
+			QString                              stateFilesDirectory;
 	};
 
 	QHash<const WorldRuntime *, RuntimeStubState> &runtimeStubStates()
@@ -147,6 +180,20 @@ WorldRuntime::RuntimeCountersSnapshot WorldRuntime::runtimeCountersSnapshot(bool
 	snapshot.noteColourFore       = state.noteColourFore;
 	snapshot.noteColourBack       = state.noteColourBack;
 	snapshot.outputLineCount      = safeQSizeToInt(state.outputLines.size());
+	if (includeStrings)
+	{
+		snapshot.logFileName             = state.logFileName;
+		snapshot.worldFilePath           = state.worldFilePath;
+		snapshot.defaultWorldDirectory   = state.defaultWorldDirectory;
+		snapshot.defaultLogDirectory     = state.defaultLogDirectory;
+		snapshot.pluginsDirectory        = state.pluginsDirectory;
+		snapshot.startupDirectory        = state.startupDirectory;
+		snapshot.translatorFile          = state.translatorFile;
+		snapshot.firstSpecialFontPath    = state.firstSpecialFontPath;
+		snapshot.preferencesDatabaseName = state.preferencesDatabaseName;
+		snapshot.fileBrowsingDirectory   = state.fileBrowsingDirectory;
+		snapshot.stateFilesDirectory     = state.stateFilesDirectory;
+	}
 	return snapshot;
 }
 
@@ -184,7 +231,7 @@ void WorldRuntime::endMiniWindowMutationBatch()
 
 QString WorldRuntime::startupDirectory() const
 {
-	return {};
+	return runtimeStubState(this).startupDirectory;
 }
 
 QString WorldRuntime::defaultLogDirectory() const
@@ -194,7 +241,25 @@ QString WorldRuntime::defaultLogDirectory() const
 
 QString WorldRuntime::worldAttributeValue(const QString &key) const
 {
-	Q_UNUSED(key);
+	return runtimeStubState(this).worldAttributes.value(key);
+}
+
+QString WorldRuntime::worldMultilineAttributeValue(const QString &key) const
+{
+	return worldAttributeValue(key);
+}
+
+long WorldRuntime::backgroundColour() const
+{
+	return 0;
+}
+
+WorldRuntime::CommandUiSnapshot WorldRuntime::commandUiSnapshot(bool includeHistory, bool includeFrameData,
+                                                                bool allowSelectedWordHitTest) const
+{
+	Q_UNUSED(includeHistory);
+	Q_UNUSED(includeFrameData);
+	Q_UNUSED(allowSelectedWordHitTest);
 	return {};
 }
 
@@ -433,6 +498,10 @@ namespace
 			void mxpCallbacksMarshalArguments();
 			void callbackCatalogObserverTracksFunctionPresence();
 			void packageRestrictionsAreAppliedToExistingState();
+			void worldLuaFileApisAcceptMixedSeparators();
+			void worldLuaFileApisUseRuntimeHomeAcrossThreadAffinity();
+			void worldLuaFileApisIgnoreProcessQmudHome();
+			void luaVisiblePathApisReturnRelativePosix();
 			void deferredRuntimeMutationBatchesPreserveOrderAndOwnership();
 			void directExecutorDispatchesRealEngines();
 			void callPluginMarshallingUsesTargetEngineState();
@@ -756,6 +825,288 @@ restricted_seen = package.loadlib == nil and
 )lua"),
 	                             QStringLiteral("package restrictions")));
 	QVERIFY(luaGlobalBoolean(engine.luaState(), "restricted_seen"));
+}
+
+void tst_LuaCallbackEngine::worldLuaFileApisAcceptMixedSeparators()
+{
+	const QString rootPath = QDir::current().absoluteFilePath(QStringLiteral("qmud_lua_file_path_compat"));
+	QDir          root(rootPath);
+	if (root.exists())
+		QVERIFY(root.removeRecursively());
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("sounds"))));
+
+	QFile input(root.filePath(QStringLiteral("sounds/alert.txt")));
+	QVERIFY(input.open(QIODevice::WriteOnly | QIODevice::Text));
+	QCOMPARE(input.write(QByteArrayLiteral("ok")), qint64{2});
+	input.close();
+
+	WorldRuntime runtime;
+	runtimeStubState(&runtime).startupDirectory = root.absolutePath();
+	LuaCallbackEngine engine;
+	engine.setWorldRuntime(&runtime);
+	setEngineScript(engine, QString());
+
+	const QString script = QStringLiteral(R"lua(
+local input = assert(io.open([[C:\MUSHclient\sounds\\\alert.txt]], "r"))
+local text = input:read("*a")
+input:close()
+
+local output = assert(io.open([[\\legacy\share\sounds\written.txt]], "w"))
+output:write("done")
+output:close()
+
+local outside_ok = pcall(function()
+  return io.open([[..\outside.txt]], "w")
+end)
+
+local entries = utils.readdir([[C:\MUSHclient\sounds\\\*.txt]])
+mixed_path_io_ok = text == "ok"
+mixed_path_readdir_ok = entries["alert.txt"] ~= nil and entries["written.txt"] ~= nil
+mixed_path_escape_rejected = not outside_ok
+)lua");
+	QVERIFY(engine.executeScript(script, QStringLiteral("mixed path compatibility")));
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "mixed_path_io_ok"));
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "mixed_path_readdir_ok"));
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "mixed_path_escape_rejected"));
+	QVERIFY(QFile::exists(root.filePath(QStringLiteral("sounds/written.txt"))));
+	QVERIFY(root.removeRecursively());
+}
+
+void tst_LuaCallbackEngine::worldLuaFileApisUseRuntimeHomeAcrossThreadAffinity()
+{
+	const QString rootPath = QDir::current().absoluteFilePath(QStringLiteral("qmud_lua_file_path_affinity"));
+	QDir          root(rootPath);
+	if (root.exists())
+		QVERIFY(root.removeRecursively());
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("worlds/Tanthul"))));
+
+	QFile input(root.filePath(QStringLiteral("worlds/Tanthul/map.lua")));
+	QVERIFY(input.open(QIODevice::WriteOnly | QIODevice::Text));
+	QCOMPARE(input.write(QByteArrayLiteral("return 'loaded'")), qint64{15});
+	input.close();
+
+	QThread      worker;
+	WorldRuntime runtime;
+	QThread     *mainThread = QThread::currentThread();
+	const auto   cleanup    = qScopeGuard(
+	    [&]()
+	    {
+		    if (runtime.thread() == &worker)
+		    {
+			    const bool moved = QMetaObject::invokeMethod(
+			        &runtime, [&runtime, mainThread]() { runtime.moveToThread(mainThread); },
+			        Qt::BlockingQueuedConnection);
+			    QVERIFY(moved);
+		    }
+		    worker.quit();
+		    worker.wait();
+	    });
+	worker.start();
+	QVERIFY(worker.isRunning());
+	runtimeStubState(&runtime).startupDirectory = root.absolutePath();
+	runtime.moveToThread(&worker);
+
+	LuaCallbackEngine engine;
+	engine.setWorldRuntime(&runtime);
+	setEngineScript(engine, QString());
+
+	const QString script = QStringLiteral(R"lua(
+local chunk = assert(loadfile([[worlds\Tanthul\map.lua]]))
+affinity_path_loaded = chunk() == "loaded"
+)lua");
+	QVERIFY(engine.executeScript(script, QStringLiteral("runtime home across thread affinity")));
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "affinity_path_loaded"));
+	QVERIFY(root.removeRecursively());
+}
+
+void tst_LuaCallbackEngine::worldLuaFileApisIgnoreProcessQmudHome()
+{
+	const QString runtimeRootPath = QDir::current().absoluteFilePath(QStringLiteral("qmud_lua_runtime_home"));
+	const QString envRootPath     = QDir::current().absoluteFilePath(QStringLiteral("qmud_lua_env_home"));
+	QDir          runtimeRoot(runtimeRootPath);
+	QDir          envRoot(envRootPath);
+	if (runtimeRoot.exists())
+		QVERIFY(runtimeRoot.removeRecursively());
+	if (envRoot.exists())
+		QVERIFY(envRoot.removeRecursively());
+	QVERIFY(QDir().mkpath(runtimeRoot.filePath(QStringLiteral("worlds/Tanthul"))));
+	QVERIFY(QDir().mkpath(envRoot.filePath(QStringLiteral("worlds/Tanthul"))));
+
+	const auto writeScript = [](const QString &fileName, const QByteArray &content)
+	{
+		QFile file(fileName);
+		if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+			return false;
+		return file.write(content) == content.size();
+	};
+	QVERIFY(writeScript(runtimeRoot.filePath(QStringLiteral("worlds/Tanthul/map.lua")),
+	                    QByteArrayLiteral("return 'runtime'")));
+	QVERIFY(writeScript(envRoot.filePath(QStringLiteral("worlds/Tanthul/map.lua")),
+	                    QByteArrayLiteral("return 'env'")));
+
+	const bool       hadOriginalQmudHome = qEnvironmentVariableIsSet("QMUD_HOME");
+	const QByteArray originalQmudHome    = qgetenv("QMUD_HOME");
+	qputenv("QMUD_HOME", envRoot.absolutePath().toUtf8());
+	const auto restoreQmudHome = qScopeGuard(
+	    [hadOriginalQmudHome, originalQmudHome]()
+	    {
+		    if (hadOriginalQmudHome)
+			    qputenv("QMUD_HOME", originalQmudHome);
+		    else
+			    qunsetenv("QMUD_HOME");
+	    });
+
+	WorldRuntime      runtime;
+	RuntimeStubState &state = runtimeStubState(&runtime);
+	state.startupDirectory  = runtimeRoot.absolutePath();
+
+	LuaCallbackEngine engine;
+	engine.setWorldRuntime(&runtime);
+	setEngineScript(engine, QString());
+
+	const QString script = QStringLiteral(R"lua(
+local chunk = assert(loadfile([[worlds\Tanthul\map.lua]]))
+process_qmud_home_ignored = chunk() == "runtime"
+)lua");
+	QVERIFY(engine.executeScript(script, QStringLiteral("ignore process QMUD_HOME")));
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "process_qmud_home_ignored"));
+
+	state.startupDirectory.clear();
+	LuaCallbackEngine missingHomeEngine;
+	missingHomeEngine.setWorldRuntime(&runtime);
+	setEngineScript(missingHomeEngine, QString());
+
+	const QString missingHomeScript = QStringLiteral(R"lua(
+local ok = pcall(function()
+  assert(loadfile([[worlds\Tanthul\map.lua]]))
+end)
+missing_runtime_home_does_not_use_env = not ok
+)lua");
+	QVERIFY(missingHomeEngine.executeScript(missingHomeScript,
+	                                        QStringLiteral("missing runtime home ignores env")));
+	QVERIFY(luaGlobalBoolean(missingHomeEngine.luaState(), "missing_runtime_home_does_not_use_env"));
+	QVERIFY(runtimeRoot.removeRecursively());
+	QVERIFY(envRoot.removeRecursively());
+}
+
+void tst_LuaCallbackEngine::luaVisiblePathApisReturnRelativePosix()
+{
+	const QString rootPath = QDir::current().absoluteFilePath(QStringLiteral("qmud_lua_visible_path_api"));
+	QDir          root(rootPath);
+	if (root.exists())
+		QVERIFY(root.removeRecursively());
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("worlds/foo"))));
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("logs"))));
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("worlds/plugins/state"))));
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("locale"))));
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("fonts"))));
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("prefs"))));
+	QVERIFY(QDir().mkpath(root.filePath(QStringLiteral("worlds/browse"))));
+
+	const QString previousCurrentPath = QDir::currentPath();
+	QVERIFY(QDir::setCurrent(root.absolutePath()));
+	[[maybe_unused]] const auto restoreCurrentPath =
+	    qScopeGuard([previousCurrentPath] { QDir::setCurrent(previousCurrentPath); });
+
+	WorldRuntime      runtime;
+	RuntimeStubState &state = runtimeStubState(&runtime);
+	state.startupDirectory  = root.absolutePath();
+	state.worldAttributes.insert(QStringLiteral("new_activity_sound"),
+	                             QStringLiteral(R"(C:\MUSHclient\sounds\activity.wav)"));
+	state.worldAttributes.insert(QStringLiteral("script_editor"),
+	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\editor.lua)"));
+	state.worldAttributes.insert(QStringLiteral("script_filename"),
+	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\script.lua)"));
+	state.worldAttributes.insert(QStringLiteral("auto_log_file_name"),
+	                             QStringLiteral(R"(C:\MUSHclient\logs\auto.log)"));
+	state.worldAttributes.insert(QStringLiteral("beep_sound"),
+	                             QStringLiteral(R"(C:\MUSHclient\sounds\beep.wav)"));
+	state.worldAttributes.insert(QStringLiteral("foreground_image"),
+	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\foreground.png)"));
+	state.worldAttributes.insert(QStringLiteral("background_image"),
+	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\background.png)"));
+	state.logFileName             = root.filePath(QStringLiteral("logs/current.log"));
+	state.worldFilePath           = root.filePath(QStringLiteral("worlds/foo/test.mcl"));
+	state.defaultWorldDirectory   = QStringLiteral(R"(C:\MUSHclient\worlds\)");
+	state.defaultLogDirectory     = root.filePath(QStringLiteral("logs"));
+	state.pluginsDirectory        = QStringLiteral(R"(C:\MUSHclient\worlds\plugins\)");
+	state.translatorFile          = root.filePath(QStringLiteral("locale/EN.lua"));
+	state.firstSpecialFontPath    = root.filePath(QStringLiteral("fonts/special.ttf"));
+	state.preferencesDatabaseName = root.filePath(QStringLiteral("prefs/qmud.db"));
+	state.fileBrowsingDirectory   = root.filePath(QStringLiteral("worlds/browse"));
+	state.stateFilesDirectory     = QStringLiteral(R"(C:\MUSHclient\worlds\plugins\state\)");
+
+	LuaCallbackEngine engine;
+	engine.setWorldRuntime(&runtime);
+	setEngineScript(engine, QStringLiteral(R"lua(
+local values = {
+  GetInfo(9),
+  GetInfo(10),
+  GetInfo(35),
+  GetInfo(40),
+  GetInfo(50),
+  GetInfo(51),
+  GetInfo(54),
+  GetInfo(57),
+  GetInfo(58),
+  GetInfo(59),
+  GetInfo(60),
+  GetInfo(64),
+  GetInfo(66),
+  GetInfo(67),
+  GetInfo(68),
+  GetInfo(69),
+  GetInfo(74),
+  GetInfo(76),
+  GetInfo(78),
+  GetInfo(79),
+  GetInfo(82),
+  GetInfo(84),
+  GetInfo(85),
+}
+path_summary = table.concat(values, "|")
+path_no_backslashes = not path_summary:find("\\", 1, true)
+getinfo_56 = tostring(GetInfo(56))
+getinfo_56_ok = #getinfo_56 > 0 and not getinfo_56:find("\\", 1, true)
+local info = utils.info()
+utils_info_summary = tostring(info.app_directory) .. "|" .. tostring(info.current_directory)
+utils_info_ok = utils_info_summary == "./|./"
+)lua"));
+
+	const QString expected =
+	    QStringList{
+	        QStringLiteral("sounds/activity.wav"),
+	        QStringLiteral("worlds/foo/editor.lua"),
+	        QStringLiteral("worlds/foo/script.lua"),
+	        QStringLiteral("logs/auto.log"),
+	        QStringLiteral("sounds/beep.wav"),
+	        QStringLiteral("logs/current.log"),
+	        QStringLiteral("worlds/foo/test.mcl"),
+	        QStringLiteral("worlds/"),
+	        QStringLiteral("logs/"),
+	        QStringLiteral("./"),
+	        QStringLiteral("worlds/plugins/"),
+	        QStringLiteral("./"),
+	        QStringLiteral("./"),
+	        QStringLiteral("worlds/foo/"),
+	        QStringLiteral("./"),
+	        QStringLiteral("locale/EN.lua"),
+	        QStringLiteral("sounds/"),
+	        QStringLiteral("fonts/special.ttf"),
+	        QStringLiteral("worlds/foo/foreground.png"),
+	        QStringLiteral("worlds/foo/background.png"),
+	        QStringLiteral("prefs/qmud.db"),
+	        QStringLiteral("worlds/browse/"),
+	        QStringLiteral("worlds/plugins/state/"),
+	    }
+	        .join(QLatin1Char('|'));
+	QCOMPARE(luaGlobalString(engine.luaState(), "path_summary"), expected);
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "path_no_backslashes"));
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "getinfo_56_ok"));
+	QCOMPARE(luaGlobalString(engine.luaState(), "utils_info_summary"), QStringLiteral("./|./"));
+	QVERIFY(luaGlobalBoolean(engine.luaState(), "utils_info_ok"));
+	QVERIFY(QDir::setCurrent(previousCurrentPath));
+	QVERIFY(root.removeRecursively());
 }
 
 void tst_LuaCallbackEngine::deferredRuntimeMutationBatchesPreserveOrderAndOwnership()

--- a/tests/unit/tst_PluginPathUtils.cpp
+++ b/tests/unit/tst_PluginPathUtils.cpp
@@ -1,0 +1,151 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_PluginPathUtils.cpp
+ * Role: Unit coverage for plugin path normalization and QMUD_HOME containment helpers.
+ */
+
+#include "../../src/helpers/PluginPathUtils.h"
+
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QDir>
+#include <QFile>
+#include <QObject>
+#include <QtTest/QtTest>
+
+class tst_PluginPathUtils final : public QObject
+{
+		Q_OBJECT
+
+	private slots:
+		static void resolvesLegacyAbsolutePathsUnderQmudHome();
+		static void resolvesNativeAbsolutePathsInsideQmudHome();
+		static void rejectsParentTraversalAndSymlinkEscapes();
+		static void returnsRelativePosixPathsForGetInfo();
+		static void keepsWindowsStyleRelativePathsPosix();
+};
+
+static bool prepareSandbox(QString *rootPath)
+{
+	*rootPath = QDir(QDir::currentPath()).filePath(QStringLiteral("qmud_plugin_path_utils_case"));
+	QDir root(*rootPath);
+	if (root.exists())
+		static_cast<void>(root.removeRecursively());
+	return QDir().mkpath(QDir(*rootPath).filePath(QStringLiteral("home/worlds/foo"))) &&
+	       QDir().mkpath(QDir(*rootPath).filePath(QStringLiteral("home/sounds"))) &&
+	       QDir().mkpath(QDir(*rootPath).filePath(QStringLiteral("home/logs")));
+}
+
+static void writeFile(const QString &path)
+{
+	QFile file(path);
+	QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
+	QVERIFY(file.write("x") == 1);
+}
+
+void tst_PluginPathUtils::resolvesLegacyAbsolutePathsUnderQmudHome()
+{
+	QString root;
+	QVERIFY(prepareSandbox(&root));
+	const QString home = QDir(root).filePath(QStringLiteral("home"));
+	writeFile(QDir(home).filePath(QStringLiteral("worlds/foo/bar.txt")));
+	writeFile(QDir(home).filePath(QStringLiteral("sounds/alert.txt")));
+	writeFile(QDir(home).filePath(QStringLiteral("logs/test.txt")));
+
+	QString resolved;
+	QVERIFY(QMudPluginPathUtils::resolveInsideQmudHome(
+	    home, QStringLiteral(R"(C:\MUSHclient\worlds\\foo\bar.txt)"), &resolved));
+	QCOMPARE(QMudPluginPathUtils::normalizeSeparators(QDir(home).relativeFilePath(resolved)),
+	         QStringLiteral("worlds/foo/bar.txt"));
+
+	QVERIFY(QMudPluginPathUtils::resolveInsideQmudHome(
+	    home, QStringLiteral(R"(\\legacy\share\sounds\\alert.txt)"), &resolved));
+	QCOMPARE(QMudPluginPathUtils::normalizeSeparators(QDir(home).relativeFilePath(resolved)),
+	         QStringLiteral("sounds/alert.txt"));
+
+	QVERIFY(QMudPluginPathUtils::resolveInsideQmudHome(home, QStringLiteral("//legacy/share/logs///test.txt"),
+	                                                   &resolved));
+	QCOMPARE(QMudPluginPathUtils::normalizeSeparators(QDir(home).relativeFilePath(resolved)),
+	         QStringLiteral("logs/test.txt"));
+}
+
+void tst_PluginPathUtils::resolvesNativeAbsolutePathsInsideQmudHome()
+{
+	QString root;
+	QVERIFY(prepareSandbox(&root));
+	const QString home = QDir(root).filePath(QStringLiteral("home"));
+	QVERIFY(QDir().mkpath(QDir(home).filePath(QStringLiteral("custom"))));
+	writeFile(QDir(home).filePath(QStringLiteral("custom/local.txt")));
+
+	QString resolved;
+	QVERIFY(QMudPluginPathUtils::resolveInsideQmudHome(
+	    home, QDir(home).filePath(QStringLiteral("custom/local.txt")), &resolved));
+	QCOMPARE(QMudPluginPathUtils::normalizeSeparators(QDir(home).relativeFilePath(resolved)),
+	         QStringLiteral("custom/local.txt"));
+	QCOMPARE(QMudPluginPathUtils::qmudHomeRelativePath(
+	             home, QDir(home).filePath(QStringLiteral("custom/local.txt")), false),
+	         QStringLiteral("custom/local.txt"));
+}
+
+void tst_PluginPathUtils::rejectsParentTraversalAndSymlinkEscapes()
+{
+	QString root;
+	QVERIFY(prepareSandbox(&root));
+	const QString home = QDir(root).filePath(QStringLiteral("home"));
+	writeFile(QDir(root).filePath(QStringLiteral("outside.txt")));
+
+	QString resolved;
+	QString error;
+	QVERIFY(!QMudPluginPathUtils::resolveInsideQmudHome(
+	    home, QStringLiteral(R"(C:\MUSHclient\worlds\..\outside.txt)"), &resolved, &error));
+	QVERIFY(!error.isEmpty());
+	QVERIFY(QMudPluginPathUtils::qmudHomeRelativePath(
+	            home, QStringLiteral(R"(C:\MUSHclient\worlds\..\outside.txt)"), false)
+	            .isEmpty());
+	QVERIFY(!QMudPluginPathUtils::pathIsWithinOrEqualTo(QStringLiteral("/tmp/file.txt"), QString()));
+
+	const QString linkPath = QDir(home).filePath(QStringLiteral("worlds/foo/link.txt"));
+	if (QFile::link(QDir(root).filePath(QStringLiteral("outside.txt")), linkPath))
+	{
+		error.clear();
+		QVERIFY(!QMudPluginPathUtils::resolveInsideQmudHome(home, QStringLiteral("worlds/foo/link.txt"),
+		                                                    &resolved, &error));
+		QVERIFY(!error.isEmpty());
+	}
+}
+
+void tst_PluginPathUtils::returnsRelativePosixPathsForGetInfo()
+{
+	QString root;
+	QVERIFY(prepareSandbox(&root));
+	const QString home      = QDir(root).filePath(QStringLiteral("home"));
+	const QString worldPath = QDir(home).filePath(QStringLiteral("worlds/foo/test.mcl"));
+
+	QCOMPARE(QMudPluginPathUtils::qmudHomeRelativePath(home, worldPath, false),
+	         QStringLiteral("worlds/foo/test.mcl"));
+	QCOMPARE(QMudPluginPathUtils::qmudHomeRelativePath(
+	             home, QStringLiteral(R"(C:\MUSHclient\worlds\foo\test.mcl)"), false),
+	         QStringLiteral("worlds/foo/test.mcl"));
+	QCOMPARE(QMudPluginPathUtils::qmudHomeRelativePath(home, home, true), QStringLiteral("./"));
+}
+
+void tst_PluginPathUtils::keepsWindowsStyleRelativePathsPosix()
+{
+	const QString home = QStringLiteral("C:/QMud");
+
+	QCOMPARE(QMudPluginPathUtils::qmudHomeRelativePath(home, QStringLiteral(R"(C:\QMud\worlds\foo\)"), true),
+	         QStringLiteral("worlds/foo/"));
+	QCOMPARE(QMudPluginPathUtils::qmudHomeRelativePath(
+	             home, QStringLiteral(R"(C:\MUSHclient\worlds\\foo\bar.mcl)"), false),
+	         QStringLiteral("worlds/foo/bar.mcl"));
+	QCOMPARE(QMudPluginPathUtils::qmudHomeRelativePath(
+	             home, QStringLiteral(R"(C:\MUSHclient\logs\\session.log)"), false),
+	         QStringLiteral("logs/session.log"));
+	QVERIFY(QMudPluginPathUtils::qmudHomeRelativePath(
+	            home, QStringLiteral(R"(C:\QMud\worlds\..\outside.mcl)"), false)
+	            .isEmpty());
+}
+
+QTEST_MAIN(tst_PluginPathUtils)
+#include "tst_PluginPathUtils.moc"


### PR DESCRIPTION
## Summary

- Implement QAccessible interface for the native renderer. My fancy custom native renderer is not Qt text widget object so native screenreaders fail to read the text. This provides an interface that works with screenreaders like Jaws.
- Finalize path contract. Fixes #99 
- Fix ColourNote()/ColourTell() failing when additional arguments are not a full group or 3.

## Scope

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- Native screenreaders should work properly now, like with MUSHclient. 
- Finalization of the path contract implementation now also functions as a sandbox. All file I/O must be contained in QMUD_HOME.

## Validation

- Tests.
- Manual tests. 

## Checklist

- [x] I verified behavior manually or with tests.
- [ ] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

