### PR TITLE
Upgrade Qt to 6.11. Cleanup release packages. Add missing icon for Mac. Mac build is now universal and builds dmg. Change default QMUD_HOME for Mac to ~/Documents/QMud.  Platform/arch QMUD_HOME portability for lua native libs. Tighten MUSHclient parity for FlipToNotepad.

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -1249,7 +1249,7 @@ jobs:
           PY
           echo "body_path=ci-release-notes.md" >> "$GITHUB_OUTPUT"
 
-      - name: Remove old CI release assets
+      - name: Delete old CI release
         uses: actions/github-script@v9
         with:
           script: |
@@ -1267,15 +1267,12 @@ jobs:
               throw error;
             }
 
-            const assets = release.data.assets || [];
-            for (const asset of assets) {
-              core.info(`Deleting old CI asset: ${asset.name}`);
-              await github.rest.repos.deleteReleaseAsset({
-                owner,
-                repo,
-                asset_id: asset.id,
-              });
-            }
+            core.info(`Deleting old CI release for tag ${tag}.`);
+            await github.rest.repos.deleteRelease({
+              owner,
+              repo,
+              release_id: release.data.id,
+            });
 
       - name: Publish CI prerelease assets
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -581,35 +581,35 @@ jobs:
 
       - name: Build AppImage image
         run: |
-          if podman image exists qmud-appimage-builder:qt6.10; then
-            echo "Image qmud-appimage-builder:qt6.10 already exists, skipping build."
+          if podman image exists qmud-appimage-builder:qt6.11; then
+            echo "Image qmud-appimage-builder:qt6.11 already exists, skipping build."
           else
             podman build \
-              --file tools/docker/appimage-qt610/Dockerfile \
-              --tag qmud-appimage-builder:qt6.10 \
-              tools/docker/appimage-qt610
+              --file tools/docker/appimage-qt611/Dockerfile \
+              --tag qmud-appimage-builder:qt6.11 \
+              tools/docker/appimage-qt611
           fi
 
       - name: Build macOS cross image
         run: |
-          if podman image exists qmud-macos-builder:qt6.10; then
-            echo "Image qmud-macos-builder:qt6.10 already exists, skipping build."
+          if podman image exists qmud-macos-builder:qt6.11; then
+            echo "Image qmud-macos-builder:qt6.11 already exists, skipping build."
           else
             podman build \
-              --file tools/docker/macos-qt610/Dockerfile \
-              --tag qmud-macos-builder:qt6.10 \
-              tools/docker/macos-qt610
+              --file tools/docker/macos-qt611/Dockerfile \
+              --tag qmud-macos-builder:qt6.11 \
+              tools/docker/macos-qt611
           fi
 
       - name: Build Windows cross image
         run: |
-          if podman image exists qmud-windows-builder:qt6.10; then
-            echo "Image qmud-windows-builder:qt6.10 already exists, skipping build."
+          if podman image exists qmud-windows-builder:qt6.11; then
+            echo "Image qmud-windows-builder:qt6.11 already exists, skipping build."
           else
             podman build \
-              --file tools/docker/windows-qt610/Dockerfile \
-              --tag qmud-windows-builder:qt6.10 \
-              tools/docker/windows-qt610
+              --file tools/docker/windows-qt611/Dockerfile \
+              --tag qmud-windows-builder:qt6.11 \
+              tools/docker/windows-qt611
           fi
 
       - name: Build AppImage
@@ -618,7 +618,7 @@ jobs:
 
       - name: Build macOS package
         run: |
-          CCACHE_DISABLE=1 cmake --build cmake-build-release --target MacDocker -j 6
+          CCACHE_DISABLE=1 cmake --build cmake-build-release --target MacDockerU -j 6
 
       - name: Build Windows package
         run: |
@@ -628,15 +628,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          MAC_SRC="cmake-build-release/mac-docker-out/QMud.app.zip"
-          MAC_DST="cmake-build-release/mac-docker-out/QMud-${QMUD_PACKAGE_VERSION}-macos.zip"
+          MAC_ZIP_SRC="cmake-build-release/mac-docker-out/QMud.app.zip"
+          MAC_ZIP_DST="cmake-build-release/mac-docker-out/QMud-${QMUD_PACKAGE_VERSION}-macos.app.zip"
+          MAC_DMG_SRC="cmake-build-release/mac-docker-out/QMud.dmg"
+          MAC_DMG_DST="cmake-build-release/mac-docker-out/QMud-${QMUD_PACKAGE_VERSION}-macos.dmg"
           WIN_SRC="cmake-build-release/windows-docker-out/QMud.zip"
           WIN_DST="cmake-build-release/windows-docker-out/QMud-${QMUD_PACKAGE_VERSION}-windows.zip"
           WIN_SETUP_SRC="cmake-build-release/windows-docker-out/QMud-setup.exe"
           WIN_SETUP_DST="cmake-build-release/windows-docker-out/QMud-${QMUD_PACKAGE_VERSION}-win-setup.exe"
 
-          if [ ! -f "$MAC_SRC" ]; then
-            echo "Missing macOS package: $MAC_SRC" >&2
+          if [ ! -f "$MAC_ZIP_SRC" ]; then
+            echo "Missing macOS auto-update package: $MAC_ZIP_SRC" >&2
+            exit 1
+          fi
+          if [ ! -f "$MAC_DMG_SRC" ]; then
+            echo "Missing macOS DMG package: $MAC_DMG_SRC" >&2
             exit 1
           fi
           if [ ! -f "$WIN_SRC" ]; then
@@ -648,7 +654,8 @@ jobs:
             exit 1
           fi
 
-          mv -f "$MAC_SRC" "$MAC_DST"
+          mv -f "$MAC_ZIP_SRC" "$MAC_ZIP_DST"
+          mv -f "$MAC_DMG_SRC" "$MAC_DMG_DST"
           mv -f "$WIN_SRC" "$WIN_DST"
           mv -f "$WIN_SETUP_SRC" "$WIN_SETUP_DST"
 
@@ -673,7 +680,8 @@ jobs:
           name: qmud-macos
           if-no-files-found: error
           path: |
-            cmake-build-release/mac-docker-out/QMud-*.zip
+            cmake-build-release/mac-docker-out/QMud-*.app.zip
+            cmake-build-release/mac-docker-out/QMud-*.dmg
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
@@ -764,35 +772,35 @@ jobs:
 
       - name: Build AppImage image
         run: |
-          if podman image exists qmud-appimage-builder:qt6.10; then
-            echo "Image qmud-appimage-builder:qt6.10 already exists, skipping build."
+          if podman image exists qmud-appimage-builder:qt6.11; then
+            echo "Image qmud-appimage-builder:qt6.11 already exists, skipping build."
           else
             podman build \
-              --file tools/docker/appimage-qt610/Dockerfile \
-              --tag qmud-appimage-builder:qt6.10 \
-              tools/docker/appimage-qt610
+              --file tools/docker/appimage-qt611/Dockerfile \
+              --tag qmud-appimage-builder:qt6.11 \
+              tools/docker/appimage-qt611
           fi
 
       - name: Build macOS cross image
         run: |
-          if podman image exists qmud-macos-builder:qt6.10; then
-            echo "Image qmud-macos-builder:qt6.10 already exists, skipping build."
+          if podman image exists qmud-macos-builder:qt6.11; then
+            echo "Image qmud-macos-builder:qt6.11 already exists, skipping build."
           else
             podman build \
-              --file tools/docker/macos-qt610/Dockerfile \
-              --tag qmud-macos-builder:qt6.10 \
-              tools/docker/macos-qt610
+              --file tools/docker/macos-qt611/Dockerfile \
+              --tag qmud-macos-builder:qt6.11 \
+              tools/docker/macos-qt611
           fi
 
       - name: Build Windows cross image
         run: |
-          if podman image exists qmud-windows-builder:qt6.10; then
-            echo "Image qmud-windows-builder:qt6.10 already exists, skipping build."
+          if podman image exists qmud-windows-builder:qt6.11; then
+            echo "Image qmud-windows-builder:qt6.11 already exists, skipping build."
           else
             podman build \
-              --file tools/docker/windows-qt610/Dockerfile \
-              --tag qmud-windows-builder:qt6.10 \
-              tools/docker/windows-qt610
+              --file tools/docker/windows-qt611/Dockerfile \
+              --tag qmud-windows-builder:qt6.11 \
+              tools/docker/windows-qt611
           fi
 
       - name: Configure CMake
@@ -815,7 +823,7 @@ jobs:
 
       - name: Build macOS package
         run: |
-          CCACHE_DISABLE=1 cmake --build cmake-build-release --target MacDocker -j 6
+          CCACHE_DISABLE=1 cmake --build cmake-build-release --target MacDockerU -j 6
 
       - name: Build Windows package
         run: |
@@ -825,15 +833,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          MAC_SRC="cmake-build-release/mac-docker-out/QMud.app.zip"
-          MAC_DST="cmake-build-release/mac-docker-out/QMud-${QMUD_PACKAGE_VERSION}-macos.zip"
+          MAC_ZIP_SRC="cmake-build-release/mac-docker-out/QMud.app.zip"
+          MAC_ZIP_DST="cmake-build-release/mac-docker-out/QMud-${QMUD_PACKAGE_VERSION}-macos.app.zip"
+          MAC_DMG_SRC="cmake-build-release/mac-docker-out/QMud.dmg"
+          MAC_DMG_DST="cmake-build-release/mac-docker-out/QMud-${QMUD_PACKAGE_VERSION}-macos.dmg"
           WIN_SRC="cmake-build-release/windows-docker-out/QMud.zip"
           WIN_DST="cmake-build-release/windows-docker-out/QMud-${QMUD_PACKAGE_VERSION}-windows.zip"
           WIN_SETUP_SRC="cmake-build-release/windows-docker-out/QMud-setup.exe"
           WIN_SETUP_DST="cmake-build-release/windows-docker-out/QMud-${QMUD_PACKAGE_VERSION}-win-setup.exe"
 
-          if [ ! -f "$MAC_SRC" ]; then
-            echo "Missing macOS package: $MAC_SRC" >&2
+          if [ ! -f "$MAC_ZIP_SRC" ]; then
+            echo "Missing macOS auto-update package: $MAC_ZIP_SRC" >&2
+            exit 1
+          fi
+          if [ ! -f "$MAC_DMG_SRC" ]; then
+            echo "Missing macOS DMG package: $MAC_DMG_SRC" >&2
             exit 1
           fi
           if [ ! -f "$WIN_SRC" ]; then
@@ -845,7 +859,8 @@ jobs:
             exit 1
           fi
 
-          mv -f "$MAC_SRC" "$MAC_DST"
+          mv -f "$MAC_ZIP_SRC" "$MAC_ZIP_DST"
+          mv -f "$MAC_DMG_SRC" "$MAC_DMG_DST"
           mv -f "$WIN_SRC" "$WIN_DST"
           mv -f "$WIN_SETUP_SRC" "$WIN_SETUP_DST"
 
@@ -870,7 +885,8 @@ jobs:
           name: qmud-macos
           if-no-files-found: error
           path: |
-            cmake-build-release/mac-docker-out/QMud-*.zip
+            cmake-build-release/mac-docker-out/QMud-*.app.zip
+            cmake-build-release/mac-docker-out/QMud-*.dmg
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
@@ -1020,7 +1036,8 @@ jobs:
           files: |
             release-assets/qmud-appimage/*.AppImage
             release-assets/qmud-appimage/*.AppImage.zsync
-            release-assets/qmud-macos/*.zip
+            release-assets/qmud-macos/*.app.zip
+            release-assets/qmud-macos/*.dmg
             release-assets/qmud-windows/*.zip
             release-assets/qmud-windows/*.exe
 
@@ -1273,7 +1290,8 @@ jobs:
           files: |
             release-assets/qmud-appimage/*.AppImage
             release-assets/qmud-appimage/*.AppImage.zsync
-            release-assets/qmud-macos/*.zip
+            release-assets/qmud-macos/*.app.zip
+            release-assets/qmud-macos/*.dmg
             release-assets/qmud-windows/*.zip
             release-assets/qmud-windows/*.exe
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1128,8 +1128,30 @@ if (APPLE)
         endif ()
 
         set(QMUD_MACAPP_ICON_SOURCE "${QMUD_MACAPP_ICON_ICNS}")
+        set(QMUD_MACAPP_ICON_IS_GENERATED FALSE)
+        if (QMUD_MACAPP_ICON_SOURCE AND NOT EXISTS "${QMUD_MACAPP_ICON_SOURCE}")
+            message(FATAL_ERROR "Configured macOS app icon does not exist: ${QMUD_MACAPP_ICON_SOURCE}")
+        endif ()
         if (NOT QMUD_MACAPP_ICON_SOURCE)
             set(QMUD_MACAPP_ICON_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/qmud/res/QMud.icns")
+            if (NOT EXISTS "${QMUD_MACAPP_ICON_SOURCE}")
+                set(QMUD_MACAPP_ICON_PNG_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/qmud/res/QMud.png")
+                set(QMUD_MACAPP_ICON_GENERATOR "${CMAKE_CURRENT_SOURCE_DIR}/tools/scripts/png_to_icns.py")
+                if (NOT EXISTS "${QMUD_MACAPP_ICON_PNG_SOURCE}")
+                    message(FATAL_ERROR "Missing macOS app icon source: ${QMUD_MACAPP_ICON_PNG_SOURCE}")
+                endif ()
+                if (NOT Python3_Interpreter_FOUND)
+                    message(FATAL_ERROR "Python3 is required to generate the macOS app icon")
+                endif ()
+                set(QMUD_MACAPP_ICON_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/QMud.icns")
+                set(QMUD_MACAPP_ICON_IS_GENERATED TRUE)
+                add_custom_command(
+                        OUTPUT "${QMUD_MACAPP_ICON_SOURCE}"
+                        COMMAND "${Python3_EXECUTABLE}" "${QMUD_MACAPP_ICON_GENERATOR}"
+                                "${QMUD_MACAPP_ICON_PNG_SOURCE}" "${QMUD_MACAPP_ICON_SOURCE}"
+                        DEPENDS "${QMUD_MACAPP_ICON_GENERATOR}" "${QMUD_MACAPP_ICON_PNG_SOURCE}"
+                        VERBATIM)
+            endif ()
         endif ()
 
         set_target_properties(QMud PROPERTIES
@@ -1145,9 +1167,12 @@ if (APPLE)
                 INSTALL_RPATH_USE_LINK_PATH FALSE
         )
 
-        if (EXISTS "${QMUD_MACAPP_ICON_SOURCE}")
+        if (EXISTS "${QMUD_MACAPP_ICON_SOURCE}" OR QMUD_MACAPP_ICON_IS_GENERATED)
             get_filename_component(QMUD_MACAPP_ICON_NAME "${QMUD_MACAPP_ICON_SOURCE}" NAME)
             set_source_files_properties("${QMUD_MACAPP_ICON_SOURCE}" PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+            if (QMUD_MACAPP_ICON_IS_GENERATED)
+                set_source_files_properties("${QMUD_MACAPP_ICON_SOURCE}" PROPERTIES GENERATED TRUE)
+            endif ()
             target_sources(QMud PRIVATE "${QMUD_MACAPP_ICON_SOURCE}")
             set_target_properties(QMud PROPERTIES MACOSX_BUNDLE_ICON_FILE "${QMUD_MACAPP_ICON_NAME}")
         endif ()
@@ -1238,7 +1263,7 @@ if (UNIX AND NOT APPLE)
         if (DEFINED QMUD_MACAPP_DOCKER_NEW_IMAGE)
             if (NOT DEFINED QMUD_MAC_DOCKER_IMAGE)
                 set(QMUD_MAC_DOCKER_IMAGE "${QMUD_MACAPP_DOCKER_NEW_IMAGE}" CACHE STRING
-                        "Docker image for MacDocker (build from tools/docker/macos-qt610/Dockerfile)" FORCE)
+                        "Docker image for MacDocker (build from tools/docker/macos-qt611/Dockerfile)" FORCE)
             endif ()
             unset(QMUD_MACAPP_DOCKER_NEW_IMAGE CACHE)
         endif ()
@@ -1271,8 +1296,8 @@ if (UNIX AND NOT APPLE)
             unset(QMUD_MACAPP_DOCKER_NEW_BUILD_TYPE CACHE)
         endif ()
 
-        set(QMUD_MAC_DOCKER_IMAGE "qmud-macos-builder:qt6.10" CACHE STRING
-                "Docker image for MacDocker (build from tools/docker/macos-qt610/Dockerfile)")
+        set(QMUD_MAC_DOCKER_IMAGE "qmud-macos-builder:qt6.11" CACHE STRING
+                "Docker image for MacDocker (build from tools/docker/macos-qt611/Dockerfile)")
         set(QMUD_MAC_DOCKER_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/mac-docker-build" CACHE PATH
                 "Host build directory mounted into container for MacDocker")
         set(QMUD_MAC_DOCKER_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/mac-docker-out" CACHE PATH
@@ -1391,13 +1416,41 @@ if (UNIX AND NOT APPLE)
                     sh /home/user/project/tools/scripts/mac_docker_build.sh
                     COMMAND ${CMAKE_COMMAND} -E rm -rf "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
-                    COMMAND ${CMAKE_COMMAND} -E copy_directory
-                    "${QMUD_MAC_DOCKER_BUILD_DIR}/macapp-out"
+                    COMMAND /bin/cp -a
+                    "${QMUD_MAC_DOCKER_BUILD_DIR}/macapp-out/."
                     "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
                     COMMAND ${CMAKE_COMMAND} -E rm -f "${QMUD_MAC_DOCKER_OUTPUT_DIR}/QMud.app.zip"
                     COMMAND ${CMAKE_COMMAND} -E chdir "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
                     ${CMAKE_COMMAND} -E tar cf "QMud.app.zip" --format=zip "QMud.app"
-                    COMMENT "Cross-building macOS QMud.app via ${QMUD_MAC_DOCKER_IMAGE} (MacDocker)"
+                    COMMENT "Cross-building macOS QMud.app and QMud.dmg via ${QMUD_MAC_DOCKER_IMAGE} (MacDocker)"
+                    USES_TERMINAL
+            )
+            add_custom_target(MacDockerU
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_MAC_DOCKER_BUILD_DIR}"
+                    COMMAND /bin/chmod 0777 "${QMUD_MAC_DOCKER_BUILD_DIR}"
+                    COMMAND ${QMUD_DOCKER_EXECUTABLE_FOUND_NEW} run --rm
+                    ${QMUD_MAC_DOCKER_SECURITY_OPT}
+                    ${QMUD_MAC_DOCKER_USERNS_ARGS}
+                    ${QMUD_MAC_DOCKER_USER_ARGS}
+                    -e CCACHE_DISABLE=1
+                    -e QMUD_MAC_DOCKER_IMAGE=${QMUD_MAC_DOCKER_IMAGE}
+                    -e QMUD_MAC_DOCKER_BUILD_TYPE=${QMUD_MAC_DOCKER_BUILD_TYPE}
+                    -e QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET=${QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET}
+                    -e QMUD_MAC_DOCKER_QT_PREFIX=${QMUD_MAC_DOCKER_QT_PREFIX}
+                    -e QMUD_MAC_DOCKER_QT_HOST_PREFIX=${QMUD_MAC_DOCKER_QT_HOST_PREFIX}
+                    -v "${CMAKE_SOURCE_DIR}:/home/user/project:ro"
+                    -v "${QMUD_MAC_DOCKER_BUILD_DIR}:/home/user/build:rw"
+                    "${QMUD_MAC_DOCKER_IMAGE}"
+                    bash /home/user/project/tools/scripts/mac_docker_build_universal.sh
+                    COMMAND ${CMAKE_COMMAND} -E rm -rf "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
+                    COMMAND /bin/cp -a
+                    "${QMUD_MAC_DOCKER_BUILD_DIR}/macapp-out/."
+                    "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
+                    COMMAND ${CMAKE_COMMAND} -E rm -f "${QMUD_MAC_DOCKER_OUTPUT_DIR}/QMud.app.zip"
+                    COMMAND ${CMAKE_COMMAND} -E chdir "${QMUD_MAC_DOCKER_OUTPUT_DIR}"
+                    ${CMAKE_COMMAND} -E tar cf "QMud.app.zip" --format=zip "QMud.app"
+                    COMMENT "Cross-building universal macOS QMud.app and QMud.dmg via ${QMUD_MAC_DOCKER_IMAGE} (MacDockerU)"
                     USES_TERMINAL
             )
         else ()
@@ -1406,13 +1459,18 @@ if (UNIX AND NOT APPLE)
                     COMMAND ${CMAKE_COMMAND} -E echo "Set QMUD_DOCKER_EXECUTABLE to docker/podman and ensure it is available."
                     COMMAND ${CMAKE_COMMAND} -E false
             )
+            add_custom_target(MacDockerU
+                    COMMAND ${CMAKE_COMMAND} -E echo "MacDockerU requires a docker-compatible executable."
+                    COMMAND ${CMAKE_COMMAND} -E echo "Set QMUD_DOCKER_EXECUTABLE to docker/podman and ensure it is available."
+                    COMMAND ${CMAKE_COMMAND} -E false
+            )
         endif ()
     endif ()
 
     option(QMUD_ENABLE_WINDOCKER "Enable WinDocker target using a prebuilt custom Windows builder image" ON)
     if (QMUD_ENABLE_WINDOCKER)
-        set(QMUD_WINDOCKER_IMAGE "qmud-windows-builder:qt6.10" CACHE STRING
-                "Docker image for WinDocker (build from tools/docker/windows-qt610/Dockerfile)")
+        set(QMUD_WINDOCKER_IMAGE "qmud-windows-builder:qt6.11" CACHE STRING
+                "Docker image for WinDocker (build from tools/docker/windows-qt611/Dockerfile)")
         set(QMUD_WINDOCKER_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/windows-docker-build" CACHE PATH
                 "Host build directory mounted into container for WinDocker")
         set(QMUD_WINDOCKER_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/windows-docker-out" CACHE PATH
@@ -2042,8 +2100,8 @@ if (UNIX AND NOT APPLE)
 
     option(QMUD_ENABLE_APPIMAGE_DOCKER "Enable AppImageDocker target using a prebuilt custom Linux builder image" ON)
     if (QMUD_ENABLE_APPIMAGE_DOCKER)
-        set(QMUD_APPIMAGE_DOCKER_IMAGE "qmud-appimage-builder:qt6.10" CACHE STRING
-                "Docker image for AppImageDocker (build from tools/docker/appimage-qt610/Dockerfile)")
+        set(QMUD_APPIMAGE_DOCKER_IMAGE "qmud-appimage-builder:qt6.11" CACHE STRING
+                "Docker image for AppImageDocker (build from tools/docker/appimage-qt611/Dockerfile)")
         set(QMUD_APPIMAGE_DOCKER_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/appimage-docker-build" CACHE PATH
                 "Host build directory mounted into container for AppImageDocker")
         set(QMUD_APPIMAGE_DOCKER_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/appimage-docker-out" CACHE PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1243,6 +1243,16 @@ if (APPLE)
                     COMMAND ${CMAKE_COMMAND} -E copy_directory
                     "$<SHELL_PATH:${CMAKE_CURRENT_BINARY_DIR}/mime>"
                     "$<SHELL_PATH:${QMUD_MACAPP_STAGE_DIR}/Contents/MacOS/mime>"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<SHELL_PATH:${QMUD_MACAPP_STAGE_DIR}/Contents/MacOS/lua/native/linux-x86_64>"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<SHELL_PATH:${QMUD_MACAPP_STAGE_DIR}/Contents/MacOS/lua/native/macos-universal>"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<SHELL_PATH:${QMUD_MACAPP_STAGE_DIR}/Contents/MacOS/lua/native/macos-arm64>"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<SHELL_PATH:${QMUD_MACAPP_STAGE_DIR}/Contents/MacOS/lua/native/macos-x86_64>"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<SHELL_PATH:${QMUD_MACAPP_STAGE_DIR}/Contents/MacOS/lua/native/windows-x86_64>"
                     COMMENT "Copying skeleton into QMud.app resources"
             )
         endif ()
@@ -1858,6 +1868,11 @@ if (UNIX AND NOT APPLE)
                         COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_MIME_DIR}>"
                         COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_SSL_DIR}>"
                         COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_LUA_SSL_DIR}>"
+                        COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_LUA_DIR}/native/linux-x86_64>"
+                        COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_LUA_DIR}/native/macos-universal>"
+                        COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_LUA_DIR}/native/macos-arm64>"
+                        COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_LUA_DIR}/native/macos-x86_64>"
+                        COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_LUA_DIR}/native/windows-x86_64>"
                 )
             endif ()
             set(QMUD_APPIMAGE_QT_TLS_PLUGIN_DIR "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1648,8 +1648,10 @@ if (UNIX AND NOT APPLE)
         endif ()
         set(QMUD_APPIMAGE_APPDIR "${QMUD_APPIMAGE_WORK_DIR}/AppDir")
         set(QMUD_APPIMAGE_DESKTOP_SRC "${CMAKE_CURRENT_SOURCE_DIR}/resources/appimage/qmud.desktop")
-        set(QMUD_APPIMAGE_DESKTOP_DST "${QMUD_APPIMAGE_APPDIR}/usr/share/applications/qmud.desktop")
-        set(QMUD_APPIMAGE_DESKTOP_ROOT_DST "${QMUD_APPIMAGE_APPDIR}/QMud.desktop")
+        set(QMUD_APPIMAGE_DESKTOP_DST "${QMUD_APPIMAGE_APPDIR}/usr/share/applications/io.github.nodens.QMud.desktop")
+        set(QMUD_APPIMAGE_DESKTOP_ROOT_DST "${QMUD_APPIMAGE_APPDIR}/io.github.nodens.QMud.desktop")
+        set(QMUD_APPIMAGE_METAINFO_SRC "${CMAKE_CURRENT_SOURCE_DIR}/resources/appimage/io.github.nodens.QMud.appdata.xml")
+        set(QMUD_APPIMAGE_METAINFO_DST "${QMUD_APPIMAGE_APPDIR}/usr/share/metainfo/io.github.nodens.QMud.appdata.xml")
         set(QMUD_APPIMAGE_ICON_SRC "${CMAKE_CURRENT_SOURCE_DIR}/resources/qmud/res/QMud.png")
         set(QMUD_APPIMAGE_ICON_DST "${QMUD_APPIMAGE_APPDIR}/usr/share/icons/hicolor/256x256/apps/QMud.png")
         set(QMUD_APPIMAGE_ICON_ROOT_DST "${QMUD_APPIMAGE_APPDIR}/QMud.png")
@@ -1669,6 +1671,9 @@ if (UNIX AND NOT APPLE)
 
         if (NOT EXISTS "${QMUD_APPIMAGE_DESKTOP_SRC}")
             message(FATAL_ERROR "Missing desktop file template for AppImage: ${QMUD_APPIMAGE_DESKTOP_SRC}")
+        endif ()
+        if (NOT EXISTS "${QMUD_APPIMAGE_METAINFO_SRC}")
+            message(FATAL_ERROR "Missing AppStream metadata for AppImage: ${QMUD_APPIMAGE_METAINFO_SRC}")
         endif ()
         if (NOT EXISTS "${QMUD_APPIMAGE_ICON_SRC}")
             message(FATAL_ERROR "Missing AppImage icon source: ${QMUD_APPIMAGE_ICON_SRC}")
@@ -1708,62 +1713,12 @@ if (UNIX AND NOT APPLE)
         if (NOT QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR)
             message(FATAL_ERROR "Could not resolve Qt runtime library directory from Qt6::Core.")
         endif ()
-        file(GLOB QMUD_APPIMAGE_QT_RUNTIME_LIB_FILES
-                "${QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR}/libQt6*.so*")
-        list(LENGTH QMUD_APPIMAGE_QT_RUNTIME_LIB_FILES QMUD_APPIMAGE_QT_RUNTIME_LIB_COUNT)
-        if (QMUD_APPIMAGE_QT_RUNTIME_LIB_COUNT EQUAL 0)
-            message(FATAL_ERROR "No Qt runtime shared libraries found in ${QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR}")
+        file(GLOB QMUD_APPIMAGE_QT_CORE_RUNTIME_LIB_FILES
+                "${QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR}/libQt6Core.so*")
+        if (NOT QMUD_APPIMAGE_QT_CORE_RUNTIME_LIB_FILES)
+            message(FATAL_ERROR "No Qt Core runtime shared libraries found in ${QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR}")
         endif ()
-
-        if (COMMAND qt_generate_deploy_app_script)
-            set(QMUD_QT_DEPLOY_SCRIPT_KEYWORD OUTPUT_SCRIPT)
-            set(QMUD_QT_DEPLOY_SUPPORTS_NO_UNSUPPORTED_FLAG ON)
-            set(QMUD_QT_DEPLOY_SUPPORTS_PLUGIN_FILTERS ON)
-            if (DEFINED Qt6Core_DIR AND EXISTS "${Qt6Core_DIR}/Qt6CoreMacros.cmake")
-                file(READ "${Qt6Core_DIR}/Qt6CoreMacros.cmake" QMUD_QTCORE_MACROS_CONTENT)
-                if (QMUD_QTCORE_MACROS_CONTENT MATCHES "FILENAME_VARIABLE")
-                    set(QMUD_QT_DEPLOY_SCRIPT_KEYWORD FILENAME_VARIABLE)
-                endif ()
-                if (NOT QMUD_QTCORE_MACROS_CONTENT MATCHES "NO_UNSUPPORTED_PLATFORM_ERROR")
-                    set(QMUD_QT_DEPLOY_SUPPORTS_NO_UNSUPPORTED_FLAG OFF)
-                endif ()
-                if (NOT QMUD_QTCORE_MACROS_CONTENT MATCHES "INCLUDE_PLUGIN_TYPES")
-                    set(QMUD_QT_DEPLOY_SUPPORTS_PLUGIN_FILTERS OFF)
-                endif ()
-            endif ()
-
-            set(QMUD_APPIMAGE_QT_DEPLOY_ARGS
-                    TARGET QMud
-                    ${QMUD_QT_DEPLOY_SCRIPT_KEYWORD} QMUD_APPIMAGE_QT_DEPLOY_SCRIPT)
-            if (QMUD_QT_DEPLOY_SUPPORTS_NO_UNSUPPORTED_FLAG)
-                list(APPEND QMUD_APPIMAGE_QT_DEPLOY_ARGS NO_UNSUPPORTED_PLATFORM_ERROR)
-            endif ()
-            if (QMUD_QT_DEPLOY_SUPPORTS_PLUGIN_FILTERS)
-                list(APPEND QMUD_APPIMAGE_QT_DEPLOY_ARGS
-                        INCLUDE_PLUGIN_TYPES
-                        platforms
-                        tls
-                        sqldrivers
-                        platformthemes
-                        platforminputcontexts
-                        xcbglintegrations
-                        egldeviceintegrations
-                        texttospeech
-                        wayland-decoration-client
-                        wayland-graphics-integration-client
-                        wayland-shell-integration
-                        INCLUDE_PLUGINS
-                        qsqlite
-                        qopensslbackend
-                        qxcb
-                        qwayland
-                        qwayland-egl
-                        qwayland-generic)
-            endif ()
-            qt_generate_deploy_app_script(${QMUD_APPIMAGE_QT_DEPLOY_ARGS})
-        else ()
-            message(FATAL_ERROR "Qt deploy API is unavailable; cannot stage AppImage runtime dependencies.")
-        endif ()
+        get_filename_component(QMUD_APPIMAGE_QT_RUNTIME_ROOT "${QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR}" DIRECTORY)
 
         set(QMUD_APPIMAGE_LPEG_SO "${QMUD_SYSTEM_LPEG_SO}")
         if (NOT QMUD_APPIMAGE_LPEG_SO)
@@ -1864,10 +1819,12 @@ if (UNIX AND NOT APPLE)
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_APPIMAGE_APPDIR}/usr/lib"
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_APPIMAGE_APPDIR}/usr/glibc"
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_APPIMAGE_APPDIR}/usr/share/applications"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_APPIMAGE_APPDIR}/usr/share/metainfo"
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${QMUD_APPIMAGE_APPDIR}/usr/share/icons/hicolor/256x256/apps"
                     COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:QMud>" "${QMUD_APPIMAGE_EXE_DST}"
                     COMMAND ${CMAKE_COMMAND} -E copy "${QMUD_APPIMAGE_DESKTOP_SRC}" "${QMUD_APPIMAGE_DESKTOP_DST}"
                     COMMAND ${CMAKE_COMMAND} -E copy "${QMUD_APPIMAGE_DESKTOP_SRC}" "${QMUD_APPIMAGE_DESKTOP_ROOT_DST}"
+                    COMMAND ${CMAKE_COMMAND} -E copy "${QMUD_APPIMAGE_METAINFO_SRC}" "${QMUD_APPIMAGE_METAINFO_DST}"
                     COMMAND ${CMAKE_COMMAND} -E copy "${QMUD_APPIMAGE_ICON_SRC}" "${QMUD_APPIMAGE_ICON_DST}"
                     COMMAND ${CMAKE_COMMAND} -E copy "${QMUD_APPIMAGE_ICON_SRC}" "${QMUD_APPIMAGE_ICON_ROOT_DST}"
                     COMMAND ${CMAKE_COMMAND} -E copy "${QMUD_APPIMAGE_CUSTOM_APPRUN}" "${QMUD_APPIMAGE_APPDIR}/AppRun"
@@ -1903,27 +1860,6 @@ if (UNIX AND NOT APPLE)
                         COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${QMUD_APPIMAGE_SKELETON_LUA_SSL_DIR}>"
                 )
             endif ()
-            get_filename_component(QMUD_APPIMAGE_QT_RUNTIME_ROOT "${QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR}" DIRECTORY)
-            add_custom_command(TARGET AppImage POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E echo "Staging Qt runtime libraries/plugins into AppDir"
-                    COMMAND ${CMAKE_COMMAND} -E env
-                    "QT_PLUGIN_PATH=$<SHELL_PATH:${QMUD_APPIMAGE_QT_RUNTIME_ROOT}/plugins>"
-                    "QT_QPA_PLATFORM_PLUGIN_PATH=$<SHELL_PATH:${QMUD_APPIMAGE_QT_RUNTIME_ROOT}/plugins/platforms>"
-                    ${CMAKE_COMMAND}
-                    -DCMAKE_INSTALL_PREFIX="$<SHELL_PATH:${QMUD_APPIMAGE_APPDIR}>"
-                    -DQT_DEPLOY_PREFIX="$<SHELL_PATH:${QMUD_APPIMAGE_APPDIR}>"
-                    -DQT_DEPLOY_BIN_DIR=usr/bin
-                    -DQT_DEPLOY_LIB_DIR=usr/lib
-                    -DQT_DEPLOY_PLUGINS_DIR=usr/plugins
-                    -DQT_DEPLOY_QML_DIR=usr/qml
-                    -DQT_DEPLOY_TRANSLATIONS_DIR=usr/translations
-                    -P "$<SHELL_PATH:${QMUD_APPIMAGE_QT_DEPLOY_SCRIPT}>"
-            )
-            add_custom_command(TARGET AppImage POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E echo "Removing GTK3 platformtheme plugin from AppDir"
-                    COMMAND ${CMAKE_COMMAND} -E rm -f
-                    "$<SHELL_PATH:${QMUD_APPIMAGE_APPDIR}/usr/plugins/platformthemes/libqgtk3.so>"
-            )
             set(QMUD_APPIMAGE_QT_TLS_PLUGIN_DIR "")
             set(QMUD_APPIMAGE_QT_TLS_PLUGIN_FILES)
             set(QMUD_APPIMAGE_QT_TLS_PLUGIN_CANDIDATE_DIRS
@@ -1962,12 +1898,6 @@ if (UNIX AND NOT APPLE)
                         ${QMUD_APPIMAGE_QT_TLS_PLUGIN_CANDIDATE_DIRS})
                 message(WARNING "Qt TLS plugin libqopensslbackend.so was not found in candidate directories: ${QMUD_APPIMAGE_QT_TLS_PLUGIN_SEARCH_PATHS}. AppImage update checks may fail without a functional TLS backend.")
             endif ()
-            add_custom_command(TARGET AppImage POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E echo "Copying Qt shared libraries into AppDir/usr/lib"
-                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                    ${QMUD_APPIMAGE_QT_RUNTIME_LIB_FILES}
-                    "$<SHELL_PATH:${QMUD_APPIMAGE_APPDIR}/usr/lib>"
-            )
             if (QMUD_LUA_LIBRARY_FILES)
                 add_custom_command(TARGET AppImage POST_BUILD
                         COMMAND ${CMAKE_COMMAND} -E echo "Copying Lua shared library into AppDir/usr/lib"
@@ -2060,6 +1990,8 @@ if (UNIX AND NOT APPLE)
                     COMMAND ${CMAKE_COMMAND} -E echo "Collecting transitive runtime libraries into AppDir/usr/lib and AppDir/usr/glibc"
                     COMMAND ${CMAKE_COMMAND} -E env
                     QMUD_APPIMAGE_BUNDLE_GLIBC=1
+                    "QMUD_QT_LIB_DIR=$<SHELL_PATH:${QMUD_APPIMAGE_QT_RUNTIME_LIB_DIR}>"
+                    "QMUD_QT_PLUGIN_DIR=$<SHELL_PATH:${QMUD_APPIMAGE_QT_RUNTIME_ROOT}/plugins>"
                     /bin/sh
                     "$<SHELL_PATH:${QMUD_APPIMAGE_COLLECT_RUNTIME_SCRIPT}>"
                     "$<SHELL_PATH:${QMUD_APPIMAGE_APPDIR}>"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ process environment does not override them.
 If nothing is configured, defaults are:
 
 - AppImage: `$HOME/QMud`
-- macOS: `~/Library/Application Support/QMud`
+- macOS: `~/Documents/QMud`
 - Windows and non-AppImage Linux: executable directory
 
 ## Environment flags and CLI switches

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is compatible with existing MUSHclient files and plugins, but it will migrate
 its own format in order to maintain separation. As more features are implemented,
 things were bound to diverge, especially in data persistence, so, as a conscious
 choice, QMud diverges from the get-go.
-The active implementation in this repository is C++20 + Qt 6.10.
+The active implementation in this repository is C++20 + Qt 6.11.
 
 The official site and documentation of QMud is here: [qmud.dev](https://qmud.dev)
 
@@ -219,9 +219,9 @@ cmake --build cmake-build-release --target QMud -j"$(sysctl -n hw.ncpu)"
 Build the cross-build images first:
 
 ```bash
-docker build -t qmud-appimage-builder:qt6.10 -f tools/docker/appimage-qt610/Dockerfile tools/docker/appimage-qt610
-docker build -t qmud-macos-builder:qt6.10 -f tools/docker/macos-qt610/Dockerfile tools/docker/macos-qt610
-docker build -t qmud-windows-builder:qt6.10 -f tools/docker/windows-qt610/Dockerfile tools/docker/windows-qt610
+docker build -t qmud-appimage-builder:qt6.11 -f tools/docker/appimage-qt611/Dockerfile tools/docker/appimage-qt611
+docker build -t qmud-macos-builder:qt6.11 -f tools/docker/macos-qt611/Dockerfile tools/docker/macos-qt611
+docker build -t qmud-windows-builder:qt6.11 -f tools/docker/windows-qt611/Dockerfile tools/docker/windows-qt611
 ```
 
 Configure once (Docker targets are Linux-host only):
@@ -240,9 +240,21 @@ Build cross targets:
 
 ```bash
 cmake --build cmake-build-release --target AppImageDocker
-cmake --build cmake-build-release --target MacDocker
+cmake --build cmake-build-release --target MacDockerU
 cmake --build cmake-build-release --target WinDocker
 ```
+
+`MacDockerU` is the default macOS packaging target and produces universal `x86_64`/`arm64` binaries. To build a
+single-architecture macOS package manually, use `MacDocker` with `QMUD_MAC_DOCKER_ARCH` set at configure time:
+
+```bash
+cmake -S . -B cmake-build-release -DQMUD_MAC_DOCKER_ARCH=aarch64
+cmake --build cmake-build-release --target MacDocker
+```
+
+`QMUD_MAC_DOCKER_ARCH` accepts `x86_64` or `aarch64`.
+
+Notice that Qt is always universal as it is not customly built for QMud.
 
 Artifacts are written to:
 

--- a/resources/appimage/AppRun
+++ b/resources/appimage/AppRun
@@ -12,6 +12,10 @@ GLIBC_DIR="$APPDIR/usr/glibc"
 
 export QT_PLUGIN_PATH="$APPDIR/usr/plugins"
 export QT_QPA_PLATFORM_PLUGIN_PATH="$APPDIR/usr/plugins/platforms"
+
+if [ "${QT_QPA_PLATFORMTHEME:-}" = "gtk3" ]; then
+  unset QT_QPA_PLATFORMTHEME
+fi
 export QT_QPA_PLATFORMTHEME="${QT_QPA_PLATFORMTHEME:-xdgdesktopportal}"
 
 # Host-first run:

--- a/resources/appimage/io.github.nodens.QMud.appdata.xml
+++ b/resources/appimage/io.github.nodens.QMud.appdata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.nodens.QMud</id>
+  <name>QMud</name>
+  <summary>Qt MUD client</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <developer id="io.github.nodens">
+    <name>Nodens</name>
+  </developer>
+  <launchable type="desktop-id">io.github.nodens.QMud.desktop</launchable>
+  <url type="homepage">https://qmud.dev</url>
+  <description>
+    <p>QMud is a Qt client for connecting to and playing text-based MUD worlds, with scripting, triggers, aliases, mapper support, and packaged runtime support for desktop Linux systems.</p>
+  </description>
+  <content_rating type="oars-1.1" />
+  <provides>
+    <binary>QMud</binary>
+  </provides>
+</component>

--- a/resources/appimage/qmud.desktop
+++ b/resources/appimage/qmud.desktop
@@ -4,5 +4,5 @@ Name=QMud
 Comment=QMud MUD client
 Exec=QMud
 Icon=QMud
-Categories=Network;Game;
+Categories=Game;RolePlaying;
 Terminal=false

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -574,6 +574,7 @@ namespace
 		return kEntries;
 	}
 
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
 	QString makeReloadArgument(const QString &name, const QString &value)
 	{
 		return value.isEmpty() ? QString() : (name + QLatin1Char('=') + value);
@@ -585,6 +586,7 @@ namespace
 		const quint64 low  = QRandomGenerator::global()->generate64();
 		return QStringLiteral("%1%2").arg(high, 16, 16, QLatin1Char('0')).arg(low, 16, 16, QLatin1Char('0'));
 	}
+#endif
 
 	QString reloadWorldIdentity(const ReloadWorldState &worldState)
 	{

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -3835,7 +3835,7 @@ bool AppController::initialize()
 	//   Windows: %LOCALAPPDATA%/QMud/config
 	// - In multi-instance mode, config fallback is disabled and QMUD_HOME must be set explicitly in process env.
 	// - AppImage defaults to $HOME/QMud when QMUD_HOME is not set.
-	// - macOS defaults to ~/Library/Application Support/QMud when QMUD_HOME is not set.
+	// - macOS defaults to ~/Documents/QMud when QMUD_HOME is not set.
 	// - Windows/default keep executable directory when QMUD_HOME is not set.
 	const auto isAppImage                  = !qEnvironmentVariable("APPIMAGE").trimmed().isEmpty();
 	const bool hasQmudHomeFromEnv          = !qEnvironmentVariable("QMUD_HOME").trimmed().isEmpty();
@@ -3861,7 +3861,7 @@ bool AppController::initialize()
 			homeDir = QDir::homePath();
 		if (homeDir.isEmpty())
 			homeDir = QCoreApplication::applicationDirPath();
-		return QDir(homeDir).filePath(QStringLiteral("Library/Application Support/QMud"));
+		return QDir(homeDir).filePath(QStringLiteral("Documents/QMud"));
 #else
 		return QCoreApplication::applicationDirPath();
 #endif

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -143,6 +143,7 @@ extern "C"
 #include <QTimer>
 #include <QTranslator>
 #include <QUrl>
+#include <QVariant>
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlError>
 #include <QtSql/QSqlQuery>
@@ -11496,6 +11497,17 @@ void AppController::onCommandTriggered(const QString &cmdName)
 			}
 		}
 		auto *text = new TextChildWindow(title, QString());
+		if (auto *world = m_mainWindow->activeWorldChildWindow())
+		{
+			if (auto *runtime = world->runtime())
+			{
+				text->setProperty("worldRuntimeToken", QVariant::fromValue(static_cast<qulonglong>(
+				                                           reinterpret_cast<quintptr>(runtime))));
+				if (const auto worldId = runtime->worldAttributes().value(QStringLiteral("id")).trimmed();
+				    !worldId.isEmpty())
+					text->setProperty("worldId", worldId);
+			}
+		}
 		m_mainWindow->addMdiSubWindow(text);
 	}
 	else if (cmdName == QStringLiteral("FlipToNotepad"))

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -267,6 +267,9 @@ extern "C" int luaopen_lsqlite3(lua_State *L);
 #ifdef QMUD_BUNDLED_BC
 extern "C" int luaopen_bc(lua_State *L);
 #endif
+static QString          luaPackageBasePath(QString base);
+static void             extendLuaPackageCPath(lua_State *L, const QString &extraCPath);
+static void             extendLuaNativePackageCPath(lua_State *L, const QString &appDir);
 static void             extendLuaPackagePath(lua_State *L, const QString &appDir);
 static void             refreshLuaFunctionSetForState(lua_State *L, QSet<QString> &out);
 static bool             optBool(lua_State *L, int index, bool defaultValue);
@@ -43049,11 +43052,20 @@ bool LuaCallbackEngine::ensureState()
 		luaL_openlibs(m_state);
 		QMudLuaSupport::applyLua51Compat(m_state);
 		qmudLogLua51CompatState(m_state, "LuaCallbackEngine world state");
+#ifdef Q_OS_MACOS
+		const QString appDirBase = luaPackageBasePath(QCoreApplication::applicationDirPath());
+		extendLuaPackageCPath(m_state, appDirBase + QStringLiteral("?.so;") + appDirBase +
+		                                   QStringLiteral("lua/?.so;") + appDirBase +
+		                                   QStringLiteral("lua/?/core.so"));
+#endif
 		if (m_worldRuntime)
 		{
 			if (const QString startupDir = m_worldRuntime->startupDirectory();
 			    !startupDir.trimmed().isEmpty())
+			{
+				extendLuaNativePackageCPath(m_state, startupDir);
 				extendLuaPackagePath(m_state, startupDir);
+			}
 		}
 		extendLuaPackagePath(m_state, QCoreApplication::applicationDirPath());
 		m_worldBindingsReady         = false;
@@ -43154,11 +43166,8 @@ static void refreshLuaFunctionSetForState(lua_State *L, QSet<QString> &out)
 	lua_pop(L, 1);
 }
 
-static void extendLuaPackagePath(lua_State *L, const QString &appDir)
+static QString luaPackageBasePath(QString base)
 {
-	if (!L)
-		return;
-	QString base = appDir;
 	if (!base.endsWith('/') && !base.endsWith('\\'))
 		base += '/';
 #ifdef Q_OS_WIN
@@ -43166,50 +43175,108 @@ static void extendLuaPackagePath(lua_State *L, const QString &appDir)
 #else
 	base.replace(QLatin1Char('\\'), QLatin1Char('/'));
 #endif
-	const QString extraPath = base + QStringLiteral("lua/?.lua;") + base + QStringLiteral("lua/?/init.lua");
-	const QString extraCPath =
+	return base;
+}
+
+static void appendLuaPackageField(lua_State *L, const char *fieldName, const QString &extraPath)
+{
+	if (extraPath.isEmpty())
+		return;
+
+	lua_getfield(L, -1, fieldName);
+	const char *existing = lua_tostring(L, -1);
+	QString     current  = existing ? QString::fromUtf8(existing) : QString();
+	lua_pop(L, 1);
+
+	if (current.contains(extraPath))
+		return;
+
+	if (!current.isEmpty() && !current.endsWith(QLatin1Char(';')))
+		current += QLatin1Char(';');
+	current += extraPath;
+	const QByteArray bytes = current.toUtf8();
+	lua_pushlstring(L, bytes.constData(), bytes.size());
+	lua_setfield(L, -2, fieldName);
+}
+
+static QString luaNativeModuleSuffix()
+{
 #ifdef Q_OS_WIN
-	    base + QStringLiteral("?.dll;") + base + QStringLiteral("lua/?.dll;") + base +
-	    QStringLiteral("lua/?/core.dll");
+	return QStringLiteral(".dll");
 #else
-	    base + QStringLiteral("?.so;") + base + QStringLiteral("lua/?.so;") + base +
-	    QStringLiteral("lua/?/core.so");
+	return QStringLiteral(".so");
 #endif
+}
+
+static QStringList luaNativePlatformDirectories()
+{
+#ifdef Q_OS_WIN
+	return {QStringLiteral("windows-x86_64")};
+#elif defined(Q_OS_MACOS)
+	QStringList dirs;
+#if defined(Q_PROCESSOR_ARM_64)
+	dirs.push_back(QStringLiteral("macos-arm64"));
+#elif defined(Q_PROCESSOR_X86_64)
+	dirs.push_back(QStringLiteral("macos-x86_64"));
+#endif
+	dirs.push_back(QStringLiteral("macos-universal"));
+	return dirs;
+#else
+	return {QStringLiteral("linux-x86_64")};
+#endif
+}
+
+static void extendLuaPackageCPath(lua_State *L, const QString &extraCPath)
+{
+	if (!L)
+		return;
+
 	lua_getglobal(L, LUA_LOADLIBNAME); // package table
 	if (!lua_istable(L, -1))
 	{
 		lua_pop(L, 1);
 		return;
 	}
-	lua_getfield(L, -1, "path");
-	const char *existing = lua_tostring(L, -1);
-	QString     current  = existing ? QString::fromUtf8(existing) : QString();
-	lua_pop(L, 1);
+	appendLuaPackageField(L, "cpath", extraCPath);
+	lua_pop(L, 1); // package
+}
 
-	if (!current.contains(extraPath))
+static void extendLuaNativePackageCPath(lua_State *L, const QString &appDir)
+{
+	const QString base   = luaPackageBasePath(appDir);
+	const QString suffix = luaNativeModuleSuffix();
+	QString       extraCPath;
+	for (const QString &nativeDir : luaNativePlatformDirectories())
 	{
-		if (!current.isEmpty() && !current.endsWith(QLatin1Char(';')))
-			current += QLatin1Char(';');
-		current += extraPath;
-		const QByteArray bytes = current.toUtf8();
-		lua_pushlstring(L, bytes.constData(), bytes.size());
-		lua_setfield(L, -2, "path");
+		const QString nativeBase = base + QStringLiteral("lua/native/") + nativeDir + QLatin1Char('/');
+		if (!extraCPath.isEmpty())
+			extraCPath += QLatin1Char(';');
+		extraCPath += nativeBase + QLatin1Char('?') + suffix + QLatin1Char(';') + nativeBase +
+		              QStringLiteral("?/core") + suffix;
 	}
+	extendLuaPackageCPath(L, extraCPath);
+}
 
-	lua_getfield(L, -1, "cpath");
-	const char *existingCPath = lua_tostring(L, -1);
-	QString     currentCPath  = existingCPath ? QString::fromUtf8(existingCPath) : QString();
-	lua_pop(L, 1);
+static void extendLuaPackagePath(lua_State *L, const QString &appDir)
+{
+	if (!L)
+		return;
 
-	if (!currentCPath.contains(extraCPath))
+	const QString base       = luaPackageBasePath(appDir);
+	const QString extraPath  = base + QStringLiteral("lua/?.lua;") + base + QStringLiteral("lua/?/init.lua");
+	const QString suffix     = luaNativeModuleSuffix();
+	const QString extraCPath = base + QLatin1Char('?') + suffix + QLatin1Char(';') + base +
+	                           QStringLiteral("lua/?") + suffix + QLatin1Char(';') + base +
+	                           QStringLiteral("lua/?/core") + suffix;
+
+	lua_getglobal(L, LUA_LOADLIBNAME); // package table
+	if (!lua_istable(L, -1))
 	{
-		if (!currentCPath.isEmpty() && !currentCPath.endsWith(QLatin1Char(';')))
-			currentCPath += QLatin1Char(';');
-		currentCPath += extraCPath;
-		const QByteArray bytes = currentCPath.toUtf8();
-		lua_pushlstring(L, bytes.constData(), bytes.size());
-		lua_setfield(L, -2, "cpath");
+		lua_pop(L, 1);
+		return;
 	}
+	appendLuaPackageField(L, "path", extraPath);
+	appendLuaPackageField(L, "cpath", extraCPath);
 	lua_pop(L, 1); // package
 }
 #endif

--- a/src/LuaExecutor.cpp
+++ b/src/LuaExecutor.cpp
@@ -310,14 +310,16 @@ LuaBatchDispatchResult ILuaExecutor::dispatchBatch(const LuaBatchDispatchRequest
 		              { engine->setObservedPluginCallbacks(request.observedCallbackNamesArg); });
 		return result;
 	case LuaBatchDispatchKind::TeardownEnginesMany:
-		forEachEngine(
-		    [&](LuaCallbackEngine *engine)
-		    {
-			    engine->setCallbackCatalogObserver({});
-			    engine->setWorldRuntime(nullptr);
-			    engine->resetState();
-			    engine->clearExecutionThreadAffinity();
-		    });
+		for (const auto &engine : request.engines)
+		{
+			if (!engine)
+				continue;
+			engine->setCallbackCatalogObserver({});
+			engine->setWorldRuntime(nullptr);
+			engine->resetState();
+			result.deferredRuntimeMutationBatches += engine->takeDeferredRuntimeMutationBatches();
+			engine->clearExecutionThreadAffinity();
+		}
 		return result;
 	case LuaBatchDispatchKind::ApplyPackageRestrictionsMany:
 		forEachEngine([&](LuaCallbackEngine *engine)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -20,6 +20,7 @@
 #include <QLibraryInfo>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <cstring>
 #ifdef Q_OS_WIN
 #include <wchar.h>
 #include <windows.h>
@@ -33,6 +34,15 @@ namespace
 #else
 	constexpr DWORD kLoadLibrarySearchDefaultDirs = 0x00001000;
 #endif
+
+	template <typename Function> Function resolveKernel32Function(HMODULE kernel32, const char *name)
+	{
+		const FARPROC procedure = GetProcAddress(kernel32, name);
+		Function      function  = nullptr;
+		static_assert(sizeof(function) == sizeof(procedure));
+		std::memcpy(&function, &procedure, sizeof(function));
+		return function;
+	}
 #endif
 
 	QString singleInstanceServerName()
@@ -78,10 +88,9 @@ namespace
 		using AddDllDirectoryFn          = DLL_DIRECTORY_COOKIE(WINAPI *)(PCWSTR);
 		using SetDllDirectoryWFn         = BOOL(WINAPI *)(LPCWSTR);
 
-		auto setDefaultDllDirectoriesFn = reinterpret_cast<SetDefaultDllDirectoriesFn>(
-		    GetProcAddress(kernel32, "SetDefaultDllDirectories"));
-		auto addDllDirectoryFn =
-		    reinterpret_cast<AddDllDirectoryFn>(GetProcAddress(kernel32, "AddDllDirectory"));
+		auto setDefaultDllDirectoriesFn =
+		    resolveKernel32Function<SetDefaultDllDirectoriesFn>(kernel32, "SetDefaultDllDirectories");
+		auto addDllDirectoryFn = resolveKernel32Function<AddDllDirectoryFn>(kernel32, "AddDllDirectory");
 		if (setDefaultDllDirectoriesFn && addDllDirectoryFn)
 		{
 			setDefaultDllDirectoriesFn(kLoadLibrarySearchDefaultDirs);
@@ -89,8 +98,7 @@ namespace
 			return;
 		}
 
-		auto setDllDirectoryWFn =
-		    reinterpret_cast<SetDllDirectoryWFn>(GetProcAddress(kernel32, "SetDllDirectoryW"));
+		auto setDllDirectoryWFn = resolveKernel32Function<SetDllDirectoryWFn>(kernel32, "SetDllDirectoryW");
 		if (setDllDirectoryWFn)
 			setDllDirectoryWFn(libDirPath);
 	}

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -27,7 +27,6 @@
 #include <QGuiApplication>
 #include <QIcon>
 #include <QImageReader>
-#include <QInputDialog>
 #include <QLabel>
 #include <QMdiArea>
 #include <QMdiSubWindow>
@@ -2705,67 +2704,61 @@ void MainWindow::infoBarSetBackground(const QColor &color) const
 
 static WorldRuntime *resolveRelatedRuntime(const MainWindow *frame, WorldRuntime *explicitRuntime);
 static qulonglong    runtimeOwnerToken(WorldRuntime *runtime);
+static QString       defaultNotepadTitleForWorld(const WorldRuntime *runtime, const WorldChildWindow *world);
+static void          assignNotepadOwner(TextChildWindow *notepad, WorldRuntime *runtime);
+static WorldRuntime *resolveRuntimeForNotepad(const MainWindow *frame, const TextChildWindow *notepad);
 
 bool                 MainWindow::switchToNotepad()
 {
 	if (!m_mdiArea)
 		return false;
 
-	WorldRuntime    *owner      = resolveRelatedRuntime(this, nullptr);
+	if (const auto *activeText = activeTextChildWindow())
+	{
+		if (WorldRuntime *runtime = resolveRuntimeForNotepad(this, activeText))
+			return activateWorldRuntime(runtime);
+		return false;
+	}
+
+	WorldChildWindow *world = activeWorldChildWindow();
+	WorldRuntime     *owner = world ? world->runtime() : nullptr;
+	if (!owner)
+		return false;
+
 	const qulonglong ownerToken = runtimeOwnerToken(owner);
 	const QString    ownerWorldId =
 	    owner ? owner->worldAttributes().value(QStringLiteral("id")).trimmed() : QString();
+	const QString          defaultTitle = defaultNotepadTitleForWorld(owner, world);
 
-	QList<TextChildWindow *> notepads;
+	QList<QMdiSubWindow *> matchingCandidates;
+	TextChildWindow       *defaultTitleFallback = nullptr;
 	for (QMdiSubWindow *sub : m_mdiArea->subWindowList(QMdiArea::CreationOrder))
 	{
 		auto *text = qobject_cast<TextChildWindow *>(sub);
 		if (!text)
 			continue;
 
-		if (ownerToken != 0)
-		{
-			const qulonglong relatedToken = text->property("worldRuntimeToken").toULongLong();
-			if (relatedToken == ownerToken)
-			{
-				notepads.append(text);
-				continue;
-			}
-			if (relatedToken != 0 && relatedToken != ownerToken)
-				continue;
-			if (!ownerWorldId.isEmpty())
-			{
-				if (const QString related = text->property("worldId").toString().trimmed();
-				    !related.isEmpty() && related.compare(ownerWorldId, Qt::CaseInsensitive) != 0)
-					continue;
-			}
-		}
-		notepads.append(text);
+		matchingCandidates.append(text);
+		if (!defaultTitleFallback && text->windowTitle().compare(defaultTitle, Qt::CaseInsensitive) == 0)
+			defaultTitleFallback = text;
 	}
 
-	if (notepads.isEmpty())
-		return false;
-
-	if (notepads.size() == 1)
+	QMdiSubWindow *target = QMudMainFrameMdiUtils::firstWindowMatchingRuntimeIdentity(
+	    matchingCandidates, ownerToken, ownerWorldId, false);
+	if (!target)
+		target = defaultTitleFallback;
+	if (!target)
 	{
-		m_mdiArea->setActiveSubWindow(notepads.front());
-		notepads.front()->show();
-		notepads.front()->raise();
+		auto *created = new TextChildWindow(defaultTitle, QString());
+		assignNotepadOwner(created, owner);
+		addMdiSubWindow(created, true);
 		return true;
 	}
 
-	QStringList titles;
-	for (const TextChildWindow *text : notepads)
-		titles.append(text->windowTitle());
-
-	bool          ok = false;
-	const QString choice =
-	    QInputDialog::getItem(this, QStringLiteral("Choose Notepad"),
-	                          QStringLiteral("Choose a notepad to activate:"), titles, 0, false, &ok);
-	if (!ok || choice.isEmpty())
-		return false;
-
-	return activateNotepad(choice);
+	m_mdiArea->setActiveSubWindow(target);
+	target->show();
+	target->raise();
+	return true;
 }
 
 bool MainWindow::activateNotepad(const QString &title) const
@@ -2835,6 +2828,18 @@ static qulonglong runtimeOwnerToken(WorldRuntime *runtime)
 	return runtime ? reinterpret_cast<quintptr>(runtime) : 0;
 }
 
+static QString defaultNotepadTitleForWorld(const WorldRuntime *runtime, const WorldChildWindow *world)
+{
+	QString worldName;
+	if (runtime)
+		worldName = runtime->worldAttributes().value(QStringLiteral("name")).trimmed();
+	if (worldName.isEmpty() && world)
+		worldName = world->windowTitle().trimmed();
+	if (worldName.isEmpty())
+		worldName = QStringLiteral("World");
+	return QStringLiteral("Notepad: %1").arg(worldName);
+}
+
 static void assignNotepadOwner(TextChildWindow *notepad, WorldRuntime *runtime)
 {
 	if (!notepad || !runtime)
@@ -2843,6 +2848,37 @@ static void assignNotepadOwner(TextChildWindow *notepad, WorldRuntime *runtime)
 	if (const QString worldId = runtime->worldAttributes().value(QStringLiteral("id")).trimmed();
 	    !worldId.isEmpty())
 		notepad->setProperty("worldId", worldId);
+}
+
+static WorldRuntime *resolveRuntimeForNotepad(const MainWindow *frame, const TextChildWindow *notepad)
+{
+	if (!frame || !notepad)
+		return nullptr;
+
+	const qulonglong relatedToken   = notepad->property("worldRuntimeToken").toULongLong();
+	const QString    relatedWorldId = notepad->property("worldId").toString().trimmed();
+	const QString    notepadTitle   = notepad->windowTitle();
+	const QString    relatedName = notepadTitle.startsWith(QStringLiteral("Notepad: "), Qt::CaseInsensitive)
+	                                   ? notepadTitle.mid(QStringLiteral("Notepad: ").size()).trimmed()
+	                                   : QString();
+
+	for (const WorldWindowDescriptor &descriptor : frame->worldWindowDescriptors())
+	{
+		WorldRuntime *runtime = descriptor.runtime;
+		if (!runtime)
+			continue;
+		if (relatedToken != 0 && runtimeOwnerToken(runtime) == relatedToken)
+			return runtime;
+		const QMap<QString, QString> &attrs = runtime->worldAttributes();
+		if (!relatedWorldId.isEmpty() &&
+		    attrs.value(QStringLiteral("id")).trimmed().compare(relatedWorldId, Qt::CaseInsensitive) == 0)
+			return runtime;
+		if (!relatedName.isEmpty() &&
+		    attrs.value(QStringLiteral("name")).trimmed().compare(relatedName, Qt::CaseInsensitive) == 0)
+			return runtime;
+	}
+
+	return nullptr;
 }
 
 bool MainWindow::appendToNotepad(const QString &title, const QString &text, const bool replace,

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -3700,16 +3700,14 @@ namespace
 		return dir;
 	}
 
+#ifndef Q_OS_WIN
 	QString normalizeSeparators(const QString &input)
 	{
-#ifdef Q_OS_WIN
-		return QDir::fromNativeSeparators(input);
-#else
 		QString output = input;
 		output.replace(QLatin1Char('\\'), QLatin1Char('/'));
 		return output;
-#endif
 	}
+#endif
 
 	QString appendNumberBeforeExtension(const QString &filePath, int number)
 	{

--- a/src/helpers/MainFrameMdiUtils.cpp
+++ b/src/helpers/MainFrameMdiUtils.cpp
@@ -12,6 +12,7 @@
 #include <QList>
 #include <QMdiSubWindow>
 #include <QString>
+#include <QVariant>
 
 namespace QMudMainFrameMdiUtils
 {
@@ -33,6 +34,45 @@ namespace QMudMainFrameMdiUtils
 		if (!target || target == addedSubWindow)
 			return nullptr;
 		return target;
+	}
+
+	bool windowMatchesRuntimeIdentity(const QMdiSubWindow *window, const qulonglong ownerToken,
+	                                  const QString &ownerWorldId, const bool acceptUnowned)
+	{
+		if (!window)
+			return false;
+
+		const qulonglong relatedToken = window->property("worldRuntimeToken").toULongLong();
+		if (ownerToken != 0)
+		{
+			if (relatedToken == ownerToken)
+				return true;
+			if (relatedToken != 0)
+				return false;
+		}
+
+		const QString relatedWorldId = window->property("worldId").toString().trimmed();
+		if (!ownerWorldId.isEmpty())
+		{
+			if (!relatedWorldId.isEmpty())
+				return relatedWorldId.compare(ownerWorldId, Qt::CaseInsensitive) == 0;
+			return acceptUnowned;
+		}
+
+		return acceptUnowned || (ownerToken == 0 && relatedToken == 0 && relatedWorldId.isEmpty());
+	}
+
+	QMdiSubWindow *firstWindowMatchingRuntimeIdentity(const QList<QMdiSubWindow *> &windows,
+	                                                  const qulonglong              ownerToken,
+	                                                  const QString &ownerWorldId, const bool acceptUnowned)
+	{
+		for (QMdiSubWindow *window : windows)
+		{
+			if (windowMatchesRuntimeIdentity(window, ownerToken, ownerWorldId, acceptUnowned))
+				return window;
+		}
+
+		return nullptr;
 	}
 
 	bool prepareOpenWorldStateBeforeChildClose(const std::function<bool(QString *)> &saveOpenWorldState,

--- a/src/helpers/MainFrameMdiUtils.h
+++ b/src/helpers/MainFrameMdiUtils.h
@@ -13,6 +13,7 @@ class QMdiSubWindow;
 class QString;
 template <typename T> class QList;
 
+#include <QtGlobal>
 #include <functional>
 
 namespace QMudMainFrameMdiUtils
@@ -24,8 +25,8 @@ namespace QMudMainFrameMdiUtils
 	 * @param creationOrder Current QMdiArea creation-order window list.
 	 * @return Active/fallback subwindow when valid, otherwise `nullptr`.
 	 */
-	QMdiSubWindow *resolveCurrentOrLastActiveSubWindow(QMdiSubWindow *active, QMdiSubWindow *lastActive,
-	                                                   const QList<QMdiSubWindow *> &creationOrder);
+	QMdiSubWindow     *resolveCurrentOrLastActiveSubWindow(QMdiSubWindow *active, QMdiSubWindow *lastActive,
+	                                                       const QList<QMdiSubWindow *> &creationOrder);
 
 	/**
 	 * @brief Resolves which subwindow should be restored after adding a window with activation disabled.
@@ -35,9 +36,33 @@ namespace QMudMainFrameMdiUtils
 	 * @param addedSubWindow Newly added subwindow.
 	 * @return Restore target, or `nullptr` when no restore is needed.
 	 */
-	QMdiSubWindow *resolveBackgroundAddRestoreTarget(QMdiSubWindow *active, QMdiSubWindow *lastActive,
-	                                                 const QList<QMdiSubWindow *> &creationOrder,
-	                                                 const QMdiSubWindow          *addedSubWindow);
+	QMdiSubWindow     *resolveBackgroundAddRestoreTarget(QMdiSubWindow *active, QMdiSubWindow *lastActive,
+	                                                     const QList<QMdiSubWindow *> &creationOrder,
+	                                                     const QMdiSubWindow          *addedSubWindow);
+
+	/**
+	 * @brief Checks whether an MDI subwindow is related to a world runtime identity.
+	 * @param window Subwindow to inspect.
+	 * @param ownerToken Runtime identity token; `0` means no token constraint.
+	 * @param ownerWorldId Runtime world id; empty means no world-id constraint.
+	 * @param acceptUnowned Accept windows with no runtime identity properties when `true`.
+	 * @return `true` when the subwindow identity is compatible with the runtime identity.
+	 */
+	[[nodiscard]] bool windowMatchesRuntimeIdentity(const QMdiSubWindow *window, qulonglong ownerToken,
+	                                                const QString &ownerWorldId, bool acceptUnowned);
+
+	/**
+	 * @brief Resolves first subwindow matching a world runtime identity.
+	 * @param windows Candidate subwindows in desired priority order.
+	 * @param ownerToken Runtime identity token; `0` means no token constraint.
+	 * @param ownerWorldId Runtime world id; empty means no world-id constraint.
+	 * @param acceptUnowned Accept windows with no runtime identity properties when `true`.
+	 * @return First matching subwindow, or `nullptr`.
+	 */
+	[[nodiscard]] QMdiSubWindow *firstWindowMatchingRuntimeIdentity(const QList<QMdiSubWindow *> &windows,
+	                                                                qulonglong                    ownerToken,
+	                                                                const QString &ownerWorldId,
+	                                                                bool           acceptUnowned);
 
 	/**
 	 * @brief Runs open-world persistence before child windows are closed.

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -582,6 +582,38 @@ namespace
 		dispatchWorkerAndWait(executor, request, unusedResult);
 	}
 
+	void initializeWorkerEngine(const LuaExecutorWorker                 &executor,
+	                            const QSharedPointer<LuaCallbackEngine> &engine, const QString &script,
+	                            WorldRuntime *runtime = nullptr)
+	{
+		QVERIFY(engine);
+		LuaEngineObservedInitializationRequest initRequest;
+		initRequest.engine          = engine.data();
+		initRequest.runtime         = runtime;
+		initRequest.scriptText      = script;
+		initRequest.pluginId        = QStringLiteral("Plugin.Id");
+		initRequest.pluginName      = QStringLiteral("Plugin Name");
+		initRequest.pluginDirectory = QStringLiteral("/tmp/plugin");
+
+		auto initRequests = QSharedPointer<QVector<LuaEngineObservedInitializationRequest>>::create();
+		initRequests->push_back(std::move(initRequest));
+
+		LuaBatchDispatchRequest request;
+		request.kind            = LuaBatchDispatchKind::InitializeEnginesWithObservedCallbacksMany;
+		request.initRequestsArg = initRequests;
+		dispatchWorkerAndWait(executor, request);
+	}
+
+	void teardownWorkerEngine(const LuaExecutorWorker                 &executor,
+	                          const QSharedPointer<LuaCallbackEngine> &engine)
+	{
+		QVERIFY(engine);
+		LuaBatchDispatchRequest request;
+		request.kind    = LuaBatchDispatchKind::TeardownEnginesMany;
+		request.engines = {engine};
+		dispatchWorkerAndWait(executor, request);
+	}
+
 	void executeDeferredMutations(LuaBatchDispatchResult &result)
 	{
 		for (LuaDeferredRuntimeMutationBatch &batch : result.deferredRuntimeMutationBatches)
@@ -1223,8 +1255,9 @@ end
 
 void tst_LuaCallbackEngine::workerDispatchesPluginLifecycleCallbacksOnRealEngines()
 {
-	auto engine = QSharedPointer<LuaCallbackEngine>::create();
-	setEngineScript(*engine, QStringLiteral(R"lua(
+	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
+	LuaExecutorWorker executor;
+	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 lifecycle = {}
 function OnPluginInstall()
   table.insert(lifecycle, "install")
@@ -1243,7 +1276,6 @@ function lifecycle_join(value)
 end
 )lua"));
 
-	LuaExecutorWorker       executor;
 	LuaBatchDispatchRequest request;
 	request.engines = {engine};
 	request.kind    = LuaBatchDispatchKind::NoArgs;
@@ -1269,10 +1301,10 @@ end
 
 void tst_LuaCallbackEngine::workerCallbackBatchCapturesOutputMiniWindowAndSaveStateMutations()
 {
-	WorldRuntime runtime;
-	auto         engine = QSharedPointer<LuaCallbackEngine>::create();
-	engine->setWorldRuntime(&runtime);
-	setEngineScript(*engine, QStringLiteral(R"lua(
+	WorldRuntime      runtime;
+	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
+	LuaExecutorWorker executor;
+	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 batch_seen = ""
 function OnPluginEnable()
   Note("batch-note")
@@ -1293,9 +1325,9 @@ end
 function batch_status(value)
   return batch_seen
 end
-)lua"));
+)lua"),
+	                       &runtime);
 
-	LuaExecutorWorker       executor;
 	LuaBatchDispatchRequest request;
 	request.engines      = {engine};
 	request.kind         = LuaBatchDispatchKind::NoArgs;
@@ -1325,14 +1357,15 @@ end
 	QCOMPARE(state.windowInfo.value(QStringLiteral("batch")).value(4).toInt(), 32);
 	QVERIFY(state.hotspotIds.value(QStringLiteral("batch")).contains(QStringLiteral("drag")));
 	QCOMPARE(state.savePluginStateCalls, 1);
+	teardownWorkerEngine(executor, engine);
 }
 
 void tst_LuaCallbackEngine::workerColourOutputMatchesMushclientGroupingAndNewlineSemantics()
 {
-	WorldRuntime runtime;
-	auto         engine = QSharedPointer<LuaCallbackEngine>::create();
-	engine->setWorldRuntime(&runtime);
-	setEngineScript(*engine, QStringLiteral(R"lua(
+	WorldRuntime      runtime;
+	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
+	LuaExecutorWorker executor;
+	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 function OnPluginEnable()
   ColourNote("red", "black", "note-a",
              "green", "black", "note-b",
@@ -1340,9 +1373,9 @@ function OnPluginEnable()
   ColourTell("cyan", "black", "tell-a",
              "yellow", "black", "tell-b")
 end
-)lua"));
+)lua"),
+	                       &runtime);
 
-	LuaExecutorWorker       executor;
 	LuaBatchDispatchRequest request;
 	request.engines      = {engine};
 	request.kind         = LuaBatchDispatchKind::NoArgs;
@@ -1356,23 +1389,24 @@ end
 	         QStringList({QStringLiteral("note-a"), QStringLiteral("note-b"), QStringLiteral("note-c"),
 	                      QStringLiteral("tell-a"), QStringLiteral("tell-b")}));
 	QCOMPARE(state.outputNewLines, QList<bool>({false, false, true, false, false}));
+	teardownWorkerEngine(executor, engine);
 }
 
 void tst_LuaCallbackEngine::colourTellIgnoresTrailingLuaGsubReturnAndKeepsFollowingNote()
 {
-	WorldRuntime runtime;
-	auto         engine = QSharedPointer<LuaCallbackEngine>::create();
-	engine->setWorldRuntime(&runtime);
-	setEngineScript(*engine, QStringLiteral(R"lua(
+	WorldRuntime      runtime;
+	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
+	LuaExecutorWorker executor;
+	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 function OnPluginEnable()
   local profit = 10000
   Tell("You made ")
   ColourTell("yellow", "black", tostring(profit):reverse():gsub("(%d%d%d)", "%1,"):reverse():gsub("^,", ""))
   Note(" gold!")
 end
-)lua"));
+)lua"),
+	                       &runtime);
 
-	LuaExecutorWorker       executor;
 	LuaBatchDispatchRequest request;
 	request.engines      = {engine};
 	request.kind         = LuaBatchDispatchKind::NoArgs;
@@ -1387,14 +1421,15 @@ end
 	QCOMPARE(state.outputNewLines, QList<bool>({false, false, true}));
 	QCOMPARE(logicalOutputLinesFromEntries(state.lineEntries),
 	         QStringList({QStringLiteral("You made 10,000 gold!")}));
+	teardownWorkerEngine(executor, engine);
 }
 
 void tst_LuaCallbackEngine::triggerAnchoredColourOutputKeepsNativePromptText()
 {
-	WorldRuntime runtime;
-	auto         engine = QSharedPointer<LuaCallbackEngine>::create();
-	engine->setWorldRuntime(&runtime);
-	setEngineScript(*engine, QStringLiteral(R"lua(
+	WorldRuntime      runtime;
+	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
+	LuaExecutorWorker executor;
+	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 function prompt_cb(name, line)
   Tell("[")
   ColourTell("white", "black", "435")
@@ -1402,7 +1437,8 @@ function prompt_cb(name, line)
   ColourTell("white", "black", "1226")
   Note("]")
 end
-)lua"));
+)lua"),
+	                       &runtime);
 
 	const QString           prompt = QStringLiteral("[Library][SAFE]<2084hp 1806sp 1695st> ");
 	RuntimeStubState       &state  = runtimeStubState(&runtime);
@@ -1413,7 +1449,6 @@ end
 	promptEntry.lineNumber = 42;
 	state.lineEntries.push_back(promptEntry);
 
-	LuaExecutorWorker       executor;
 	LuaBatchDispatchRequest request;
 	request.engines        = {engine};
 	request.kind           = LuaBatchDispatchKind::StringsAndWildcards;
@@ -1436,6 +1471,7 @@ end
 
 	const QStringList logicalLines = logicalOutputLinesFromEntries(state.lineEntries);
 	QCOMPARE(logicalLines, QStringList({QStringLiteral("[435, 1226]"), prompt}));
+	teardownWorkerEngine(executor, engine);
 }
 
 void tst_LuaCallbackEngine::callbackSnapshotSuppliesGetInfoAndMiniWindowReads()
@@ -1492,16 +1528,16 @@ end
 
 void tst_LuaCallbackEngine::deferredRuntimeMutationSkipsDestroyedRuntime()
 {
-	auto runtime = std::make_unique<WorldRuntime>();
-	auto engine  = QSharedPointer<LuaCallbackEngine>::create();
-	engine->setWorldRuntime(runtime.get());
-	setEngineScript(*engine, QStringLiteral(R"lua(
+	auto              runtime = std::make_unique<WorldRuntime>();
+	auto              engine  = QSharedPointer<LuaCallbackEngine>::create();
+	LuaExecutorWorker executor;
+	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 function OnPluginEnable()
   SaveState()
 end
-)lua"));
+)lua"),
+	                       runtime.get());
 
-	LuaExecutorWorker       executor;
 	LuaBatchDispatchRequest request;
 	request.engines      = {engine};
 	request.kind         = LuaBatchDispatchKind::NoArgs;
@@ -1516,6 +1552,7 @@ end
 		for (const std::function<void()> &mutation : batch.mutations)
 			mutation();
 	}
+	teardownWorkerEngine(executor, engine);
 }
 // NOLINTEND(readability-convert-member-functions-to-static)
 

--- a/tests/unit/tst_MainFrameMdiUtils.cpp
+++ b/tests/unit/tst_MainFrameMdiUtils.cpp
@@ -9,6 +9,7 @@
 #include "MainFrameMdiUtils.h"
 
 #include <QMdiSubWindow>
+#include <QVariant>
 #include <QtTest/QTest>
 
 /**
@@ -62,6 +63,59 @@ class tst_MainFrameMdiUtils : public QObject
 			QCOMPARE(
 			    QMudMainFrameMdiUtils::resolveBackgroundAddRestoreTarget(&added, &added, windows, &added),
 			    nullptr);
+		}
+
+		void windowMatchesRuntimeIdentityPrefersRuntimeToken()
+		{
+			QMdiSubWindow notepad;
+			notepad.setProperty("worldRuntimeToken", QVariant::fromValue<qulonglong>(42));
+			notepad.setProperty("worldId", QStringLiteral("other-world"));
+
+			QVERIFY(QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&notepad, 42,
+			                                                            QStringLiteral("world-a"), false));
+		}
+
+		void windowMatchesRuntimeIdentityRejectsMismatchedRuntimeToken()
+		{
+			QMdiSubWindow notepad;
+			notepad.setProperty("worldRuntimeToken", QVariant::fromValue<qulonglong>(7));
+
+			QVERIFY(!QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&notepad, 42,
+			                                                             QStringLiteral("world-a"), true));
+		}
+
+		void windowMatchesRuntimeIdentityUsesWorldIdWhenTokenIsAbsent()
+		{
+			QMdiSubWindow notepad;
+			notepad.setProperty("worldId", QStringLiteral("WORLD-A"));
+
+			QVERIFY(QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&notepad, 42,
+			                                                            QStringLiteral("world-a"), false));
+		}
+
+		void windowMatchesRuntimeIdentityKeepsUnownedOutOfStrictMatches()
+		{
+			QMdiSubWindow notepad;
+
+			QVERIFY(!QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&notepad, 42,
+			                                                             QStringLiteral("world-a"), false));
+			QVERIFY(QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&notepad, 42,
+			                                                            QStringLiteral("world-a"), true));
+		}
+
+		void firstWindowMatchingRuntimeIdentityUsesCreationOrder()
+		{
+			QMdiSubWindow unrelated;
+			unrelated.setProperty("worldRuntimeToken", QVariant::fromValue<qulonglong>(7));
+			QMdiSubWindow first;
+			first.setProperty("worldRuntimeToken", QVariant::fromValue<qulonglong>(42));
+			QMdiSubWindow second;
+			second.setProperty("worldRuntimeToken", QVariant::fromValue<qulonglong>(42));
+
+			const QList<QMdiSubWindow *> windows{&unrelated, &first, &second};
+			QCOMPARE(QMudMainFrameMdiUtils::firstWindowMatchingRuntimeIdentity(
+			             windows, 42, QStringLiteral("world-a"), false),
+			         &first);
 		}
 
 		void prepareOpenWorldStateBeforeChildCloseAllowsCloseWithoutController()

--- a/tools/docker/appimage-qt611/Dockerfile
+++ b/tools/docker/appimage-qt611/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -21,6 +21,7 @@ RUN dnf -y upgrade && \
       glibc-langpack-en \
       libglvnd-devel \
       libxkbcommon \
+      libxkbcommon-devel \
       lua \
       lua-devel \
       lua-json \
@@ -41,6 +42,7 @@ RUN dnf -y upgrade && \
       speech-dispatcher-devel \
       tar \
       unzip \
+      vulkan-headers \
       which \
       xz \
       zlib-devel \
@@ -50,12 +52,31 @@ RUN dnf -y upgrade && \
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip install --no-cache-dir --upgrade aqtinstall
 
-ARG QT_SERIES=6.10
+RUN mkdir -p /etc/aqt && \
+    printf '%s\n' \
+      '[aqt]' \
+      'baseurl: https://download.qt.io' \
+      '' \
+      '[requests]' \
+      'hash_algorithm: sha256' \
+      'INSECURE_NOT_FOR_PRODUCTION_ignore_hash: False' \
+      '' \
+      '[mirrors]' \
+      'trusted_mirrors:' \
+      '    https://download.qt.io' \
+      'blacklist:' \
+      'fallbacks:' \
+      '    https://download.qt.io' \
+      > /etc/aqt/settings.ini
+
+ENV AQT_CONFIG=/etc/aqt/settings.ini
+
+ARG QT_SERIES=6.11
 ARG QT_ARCH=linux_gcc_64
 
 RUN set -eux; \
     QT_VERSION="$(aqt list-qt linux desktop --spec "${QT_SERIES}" --latest-version)"; \
-    aqt install-qt -O /opt/Qt linux desktop "${QT_VERSION}" "${QT_ARCH}" -m qtmultimedia; \
+    aqt install-qt -O /opt/Qt linux desktop "${QT_VERSION}" "${QT_ARCH}" -m qtmultimedia qttasktree; \
     ln -sfn "/opt/Qt/${QT_VERSION}" /opt/Qt/latest
 
 RUN set -eux; \

--- a/tools/docker/appimage-qt611/Dockerfile
+++ b/tools/docker/appimage-qt611/Dockerfile
@@ -6,6 +6,7 @@ ENV LC_ALL=C.UTF-8
 RUN dnf -y upgrade && \
     dnf -y install \
       bash \
+      appstream \
       ca-certificates \
       cmake \
       curl \
@@ -46,6 +47,7 @@ RUN dnf -y upgrade && \
       which \
       xz \
       zlib-devel \
+      zsync \
       zip && \
     dnf clean all
 

--- a/tools/docker/appimage-qt611/Dockerfile
+++ b/tools/docker/appimage-qt611/Dockerfile
@@ -6,7 +6,6 @@ ENV LC_ALL=C.UTF-8
 RUN dnf -y upgrade && \
     dnf -y install \
       bash \
-      appstream \
       ca-certificates \
       cmake \
       curl \

--- a/tools/docker/macos-qt611/Dockerfile
+++ b/tools/docker/macos-qt611/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -21,6 +21,7 @@ RUN dnf -y upgrade && \
       flex \
       git \
       glibc-langpack-en \
+      hfsplus-tools \
       libarchive \
       libarchive-devel \
       libxml2-devel \
@@ -50,6 +51,18 @@ RUN dnf -y upgrade && \
       zip && \
     dnf clean all
 
+RUN git clone --depth 1 https://github.com/mozilla/libdmg-hfsplus.git /tmp/libdmg-hfsplus && \
+    cmake -S /tmp/libdmg-hfsplus -B /tmp/libdmg-hfsplus-build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_FLAGS="-UHAVE_CRYPT" && \
+    cmake --build /tmp/libdmg-hfsplus-build -j"$(nproc)" && \
+    test -x /tmp/libdmg-hfsplus-build/dmg/dmg && \
+    test -x /tmp/libdmg-hfsplus-build/hfs/hfsplus && \
+    install -m 0755 /tmp/libdmg-hfsplus-build/dmg/dmg /usr/local/bin/dmg && \
+    install -m 0755 /tmp/libdmg-hfsplus-build/hfs/hfsplus /usr/local/bin/hfsplus && \
+    if [ -x /tmp/libdmg-hfsplus-build/hdutil/hdutil ]; then install -m 0755 /tmp/libdmg-hfsplus-build/hdutil/hdutil /usr/local/bin/hdutil; fi && \
+    rm -rf /tmp/libdmg-hfsplus /tmp/libdmg-hfsplus-build
+
 RUN if ! command -v xml2-config >/dev/null 2>&1 && pkg-config --exists libxml-2.0; then \
       printf '%s\n' \
         '#!/usr/bin/env bash' \
@@ -66,6 +79,25 @@ RUN if ! command -v xml2-config >/dev/null 2>&1 && pkg-config --exists libxml-2.
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip install --no-cache-dir --upgrade aqtinstall
+
+RUN mkdir -p /etc/aqt && \
+    printf '%s\n' \
+      '[aqt]' \
+      'baseurl: https://download.qt.io' \
+      '' \
+      '[requests]' \
+      'hash_algorithm: sha256' \
+      'INSECURE_NOT_FOR_PRODUCTION_ignore_hash: False' \
+      '' \
+      '[mirrors]' \
+      'trusted_mirrors:' \
+      '    https://download.qt.io' \
+      'blacklist:' \
+      'fallbacks:' \
+      '    https://download.qt.io' \
+      > /etc/aqt/settings.ini
+
+ENV AQT_CONFIG=/etc/aqt/settings.ini
 
 # osxcross requires a macOS SDK archive.
 # Default points to the requested 14.5 SDK release URL and can be overridden
@@ -86,7 +118,7 @@ ENV OSXCROSS_ROOT=/opt/osxcross
 ENV OSXCROSS_BIN_DIR=/opt/osxcross/target/bin
 ENV PATH=/opt/osxcross/target/bin:/opt/osxcross/bin:${PATH}
 
-ARG QT_SERIES=6.10
+ARG QT_SERIES=6.11
 ARG QT_ARCH=clang_64
 
 RUN dnf -y install qt6-qtbase-devel && \

--- a/tools/docker/windows-qt611/Dockerfile
+++ b/tools/docker/windows-qt611/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -58,9 +58,28 @@ RUN dnf -y upgrade && \
     dnf clean all
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    python3 -m pip install --no-cache-dir --upgrade aqtinstall
+    python3 -m pip install --no-cache-dir --upgrade git+https://github.com/miurahr/aqtinstall.git@refs/pull/1000/head
 
-ARG QT_SERIES=6.10
+RUN mkdir -p /etc/aqt && \
+    printf '%s\n' \
+      '[aqt]' \
+      'baseurl: https://download.qt.io' \
+      '' \
+      '[requests]' \
+      'hash_algorithm: sha256' \
+      'INSECURE_NOT_FOR_PRODUCTION_ignore_hash: False' \
+      '' \
+      '[mirrors]' \
+      'trusted_mirrors:' \
+      '    https://download.qt.io' \
+      'blacklist:' \
+      'fallbacks:' \
+      '    https://download.qt.io' \
+      > /etc/aqt/settings.ini
+
+ENV AQT_CONFIG=/etc/aqt/settings.ini
+
+ARG QT_SERIES=6.11
 ARG QT_ARCH=win64_mingw
 
 RUN set -eux; \

--- a/tools/scripts/collect_runtime_libs.sh
+++ b/tools/scripts/collect_runtime_libs.sh
@@ -104,7 +104,14 @@ ensure_runpath() {
 collect_deps_for() {
   item="$1"
   [ -e "$item" ] || return 0
-  ldd "$item" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^\//) print $i}' | while IFS= read -r dep; do
+  dep_library_path="$APP_LIB_DIR"
+  if [ -n "${QMUD_QT_LIB_DIR:-}" ]; then
+    dep_library_path="$dep_library_path:$QMUD_QT_LIB_DIR"
+  fi
+  if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+    dep_library_path="$dep_library_path:$LD_LIBRARY_PATH"
+  fi
+  LD_LIBRARY_PATH="$dep_library_path" ldd "$item" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^\//) print $i}' | while IFS= read -r dep; do
     [ -n "$dep" ] || continue
     copy_lib "$dep"
   done
@@ -140,18 +147,26 @@ if [ -n "${QMUD_QT_PLUGIN_DIR:-}" ] && [ -d "${QMUD_QT_PLUGIN_DIR}" ]; then
     cp -L "$src" "$APP_PLUGIN_DIR/$sub/"
   }
 
-  # Keep plugin set minimal and Qt-native. Avoid platformtheme extras that can
-  # drag in large host/KDE stacks and unstable portal behavior.
+  # Keep plugin set minimal and Qt-native. Keep the desktop portal platform
+  # theme, but avoid platformtheme extras that can drag in large host/KDE stacks.
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/platforms/libqxcb.so" platforms
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/platforms/libqwayland.so" platforms
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/platforms/libqwayland-egl.so" platforms
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/platforms/libqwayland-generic.so" platforms
+  copy_plugin "${QMUD_QT_PLUGIN_DIR}/platformthemes/libqxdgdesktopportal.so" platformthemes
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/sqldrivers/libqsqlite.so" sqldrivers
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/tls/libqopensslbackend.so" tls
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/iconengines/libqsvgicon.so" iconengines
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/styles/libqfusionstyle.so" styles
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/xcbglintegrations/libqxcb-glx-integration.so" xcbglintegrations
   copy_plugin "${QMUD_QT_PLUGIN_DIR}/xcbglintegrations/libqxcb-egl-integration.so" xcbglintegrations
+  copy_plugin "${QMUD_QT_PLUGIN_DIR}/texttospeech/libqtexttospeech_flite.so" texttospeech
+  copy_plugin "${QMUD_QT_PLUGIN_DIR}/texttospeech/libqtexttospeech_speechd.so" texttospeech
+
+  if [ -d "${QMUD_QT_PLUGIN_DIR}/multimedia" ]; then
+    mkdir -p "$APP_PLUGIN_DIR/multimedia"
+    find "${QMUD_QT_PLUGIN_DIR}/multimedia" -maxdepth 1 -type f -name '*.so*' -exec cp -L {} "$APP_PLUGIN_DIR/multimedia/" \;
+  fi
 
   for sub in wayland-decoration-client wayland-graphics-integration-client wayland-shell-integration; do
     if [ -d "${QMUD_QT_PLUGIN_DIR}/${sub}" ]; then

--- a/tools/scripts/mac_docker_build.sh
+++ b/tools/scripts/mac_docker_build.sh
@@ -210,6 +210,12 @@ cp "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.5.4.dylib" "$APP_FRAMEWORKS_DIR/"
 ln -sf liblua.5.4.dylib "$APP_FRAMEWORKS_DIR/liblua.dylib"
 
 mkdir -p "$APP_MACOS_DIR/socket" "$APP_MACOS_DIR/mime" "$APP_MACOS_DIR/ssl" "$APP_MACOS_DIR/lua/json" "$APP_MACOS_DIR/lua/ssl"
+mkdir -p \
+  "$APP_MACOS_DIR/lua/native/linux-x86_64" \
+  "$APP_MACOS_DIR/lua/native/macos-universal" \
+  "$APP_MACOS_DIR/lua/native/macos-arm64" \
+  "$APP_MACOS_DIR/lua/native/macos-x86_64" \
+  "$APP_MACOS_DIR/lua/native/windows-x86_64"
 cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/core.so" "$APP_MACOS_DIR/socket/core.so"
 cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime/core.so" "$APP_MACOS_DIR/mime/core.so"
 if [ ! -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so" ]; then

--- a/tools/scripts/mac_docker_build.sh
+++ b/tools/scripts/mac_docker_build.sh
@@ -4,7 +4,7 @@ set -eu
 PROJECT_DIR=${PROJECT_DIR:-/home/user/project}
 BUILD_DIR=${BUILD_DIR:-/home/user/build}
 BUILD_ARCH=${BUILD_ARCH:-x86_64}
-QMUD_MAC_DOCKER_IMAGE=${QMUD_MAC_DOCKER_IMAGE:-qmud-macos-builder:qt6.10}
+QMUD_MAC_DOCKER_IMAGE=${QMUD_MAC_DOCKER_IMAGE:-qmud-macos-builder:qt6.11}
 QMUD_MAC_DOCKER_BUILD_TYPE=${QMUD_MAC_DOCKER_BUILD_TYPE:-Release}
 QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET=${QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET:-13.0.0}
 QMUD_MAC_DOCKER_QT_PREFIX=${QMUD_MAC_DOCKER_QT_PREFIX:-/opt/Qt/latest/macos}
@@ -140,6 +140,25 @@ APP_FRAMEWORKS_DIR="$APP_STAGE_DIR/Contents/Frameworks"
 APP_PLUGINS_DIR="$APP_STAGE_DIR/Contents/PlugIns"
 APP_TLS_DIR="$APP_PLUGINS_DIR/tls"
 
+copy_qt_framework() {
+  framework_name=$1
+  framework_source="$QMUD_MAC_DOCKER_QT_PREFIX/lib/${framework_name}.framework"
+  framework_target="$APP_FRAMEWORKS_DIR/${framework_name}.framework"
+
+  if [ ! -d "$framework_source" ]; then
+    echo "Error: required Qt framework is missing at $framework_source." >&2
+    exit 1
+  fi
+
+  rm -rf "$framework_target"
+  cp -a "$framework_source" "$APP_FRAMEWORKS_DIR/"
+  rm -rf "$framework_target/Headers" "$framework_target/Sources"
+  if [ -d "$framework_target/Versions" ]; then
+    find "$framework_target/Versions" -mindepth 2 -maxdepth 2 \( -name Headers -o -name Sources \) -type d -prune -exec rm -rf {} +
+  fi
+  find "$framework_target" -type f -name '*.prl' -delete
+}
+
 mkdir -p "$APP_MACOS_DIR" "$APP_FRAMEWORKS_DIR" "$APP_PLUGINS_DIR/platforms" "$APP_PLUGINS_DIR/sqldrivers"
 if [ -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/multimedia" ]; then
   mkdir -p "$APP_PLUGINS_DIR/multimedia"
@@ -148,7 +167,18 @@ if [ -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/texttospeech" ]; then
   mkdir -p "$APP_PLUGINS_DIR/texttospeech"
 fi
 
-cp -R "$QMUD_MAC_DOCKER_QT_PREFIX"/lib/Qt*.framework "$APP_FRAMEWORKS_DIR/"
+for QT_FRAMEWORK in \
+  QtCore \
+  QtGui \
+  QtWidgets \
+  QtNetwork \
+  QtSql \
+  QtPrintSupport \
+  QtMultimedia \
+  QtTextToSpeech
+do
+  copy_qt_framework "$QT_FRAMEWORK"
+done
 cp "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/platforms/libqcocoa.dylib" "$APP_PLUGINS_DIR/platforms/"
 cp "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/sqldrivers/libqsqlite.dylib" "$APP_PLUGINS_DIR/sqldrivers/"
 if [ -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/multimedia" ]; then
@@ -177,7 +207,7 @@ if ! find "$APP_TLS_DIR" -maxdepth 1 -type f \( -name 'libqsecuretransportbacken
 fi
 
 cp "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.5.4.dylib" "$APP_FRAMEWORKS_DIR/"
-cp "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.dylib" "$APP_FRAMEWORKS_DIR/"
+ln -sf liblua.5.4.dylib "$APP_FRAMEWORKS_DIR/liblua.dylib"
 
 mkdir -p "$APP_MACOS_DIR/socket" "$APP_MACOS_DIR/mime" "$APP_MACOS_DIR/ssl" "$APP_MACOS_DIR/lua/json" "$APP_MACOS_DIR/lua/ssl"
 cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/core.so" "$APP_MACOS_DIR/socket/core.so"
@@ -220,3 +250,5 @@ if [ -d "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl" ]; then
   cp -R "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/." "$APP_MACOS_DIR/ssl/"
   cp -R "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/." "$APP_MACOS_DIR/lua/ssl/"
 fi
+
+bash "$PROJECT_DIR/tools/scripts/package_mac_dmg.sh" "$APP_STAGE_DIR" "$BUILD_DIR/macapp-out/QMud.dmg"

--- a/tools/scripts/mac_docker_build_universal.sh
+++ b/tools/scripts/mac_docker_build_universal.sh
@@ -1,0 +1,607 @@
+#!/usr/bin/env bash
+## @file mac_docker_build_universal.sh
+## @brief Builds a universal macOS QMud.app inside the MacDocker builder image.
+
+set -euo pipefail
+
+PROJECT_DIR=${PROJECT_DIR:-/home/user/project}
+BUILD_DIR=${BUILD_DIR:-/home/user/build}
+QMUD_MAC_DOCKER_IMAGE=${QMUD_MAC_DOCKER_IMAGE:-qmud-macos-builder:qt6.11}
+QMUD_MAC_DOCKER_BUILD_TYPE=${QMUD_MAC_DOCKER_BUILD_TYPE:-Release}
+QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET=${QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET:-13.0.0}
+QMUD_MAC_DOCKER_QT_PREFIX=${QMUD_MAC_DOCKER_QT_PREFIX:-/opt/Qt/latest/macos}
+QMUD_MAC_DOCKER_QT_HOST_PREFIX=${QMUD_MAC_DOCKER_QT_HOST_PREFIX:-/usr/lib64/qt6}
+
+LUA_VERSION=${LUA_VERSION:-5.4.7}
+LUASOCKET_VERSION=${LUASOCKET_VERSION:-3.1.0}
+LPEG_VERSION=${LPEG_VERSION:-1.1.0}
+LUASEC_VERSION=${LUASEC_VERSION:-1.3.2}
+OPENSSL_VERSION=${OPENSSL_VERSION:-3.3.2}
+
+UNIVERSAL_DEPS_DIR="$BUILD_DIR/universal-deps"
+QMUD_MAC_DOCKER_LUA_PREFIX="$UNIVERSAL_DEPS_DIR/lua"
+QMUD_MAC_DOCKER_LUA_MODULES_PREFIX="$UNIVERSAL_DEPS_DIR/lua-modules"
+QMUD_MAC_DOCKER_OPENSSL_PREFIX="$UNIVERSAL_DEPS_DIR/openssl"
+
+rm -f "$BUILD_DIR/CMakeCache.txt"
+rm -rf "$BUILD_DIR/CMakeFiles"
+export PATH="$QMUD_MAC_DOCKER_QT_PREFIX/bin:$PATH"
+
+QT_HOST_PREFIX="$QMUD_MAC_DOCKER_QT_HOST_PREFIX"
+if [ ! -x "$QT_HOST_PREFIX/libexec/moc" ]; then
+  for QT_HOST_CANDIDATE in /usr/lib64/qt6 /usr/lib/qt6 /opt/Qt/latest/gcc_64 /opt/Qt/latest/linux_gcc_64; do
+    if [ -x "$QT_HOST_CANDIDATE/libexec/moc" ]; then
+      QT_HOST_PREFIX="$QT_HOST_CANDIDATE"
+      break
+    fi
+  done
+fi
+if [ -d "$QT_HOST_PREFIX/bin" ]; then
+  export PATH="$QT_HOST_PREFIX/bin:$PATH"
+fi
+QT_HOST_MOC="$QT_HOST_PREFIX/libexec/moc"
+QT_HOST_UIC="$QT_HOST_PREFIX/libexec/uic"
+QT_HOST_RCC="$QT_HOST_PREFIX/libexec/rcc"
+if [ ! -x "$QT_HOST_MOC" ] && command -v moc >/dev/null 2>&1; then
+  QT_HOST_MOC="$(command -v moc)"
+fi
+if [ ! -x "$QT_HOST_UIC" ] && command -v uic >/dev/null 2>&1; then
+  QT_HOST_UIC="$(command -v uic)"
+fi
+if [ ! -x "$QT_HOST_RCC" ] && command -v rcc >/dev/null 2>&1; then
+  QT_HOST_RCC="$(command -v rcc)"
+fi
+if [ ! -x "$QT_HOST_MOC" ] || [ ! -x "$QT_HOST_UIC" ] || [ ! -x "$QT_HOST_RCC" ]; then
+  echo "Error: runnable host Qt tools missing (moc/uic/rcc)." >&2
+  echo "Install Qt host tools in ${QMUD_MAC_DOCKER_IMAGE} (for example: dnf install qt6-qtbase-devel)." >&2
+  exit 1
+fi
+
+if command -v osxcross-conf >/dev/null 2>&1; then
+  eval "$(osxcross-conf)"
+fi
+if [ -z "${OSXCROSS_TARGET_DIR:-}" ]; then
+  OSXCROSS_TARGET_DIR=/opt/osxcross/target
+fi
+if [ -z "${OSXCROSS_SDK:-}" ]; then
+  OSXCROSS_SDK=$(find "${OSXCROSS_TARGET_DIR}/SDK" -maxdepth 1 -type d -name 'MacOSX*.sdk' | sort | tail -n 1)
+fi
+
+find_osxcross_host() {
+  local pattern=$1
+  local host
+  host=$(find -L /opt/osxcross/bin "${OSXCROSS_TARGET_DIR}/bin" -maxdepth 1 \( -type f -o -type l \) -name "${pattern}-apple-darwin*-clang" 2>/dev/null | sort | head -n 1 | awk -F/ '{print $NF}' | sed 's/-clang$//')
+  printf '%s' "$host"
+}
+
+OSXCROSS_X86_HOST=$(find_osxcross_host x86_64)
+OSXCROSS_ARM_HOST=$(find_osxcross_host aarch64)
+if [ -z "$OSXCROSS_ARM_HOST" ]; then
+  OSXCROSS_ARM_HOST=$(find_osxcross_host arm64)
+fi
+if [ -z "$OSXCROSS_X86_HOST" ] || [ -z "$OSXCROSS_ARM_HOST" ]; then
+  echo "Error: universal macOS build requires both x86_64 and arm64 osxcross clang toolchains." >&2
+  echo "Resolved x86_64 host: ${OSXCROSS_X86_HOST:-<missing>}" >&2
+  echo "Resolved arm64 host: ${OSXCROSS_ARM_HOST:-<missing>}" >&2
+  exit 1
+fi
+
+resolve_tool() {
+  local tool_name=$1
+  local candidate
+  for candidate in \
+    "/opt/osxcross/bin/${tool_name}" \
+    "${OSXCROSS_TARGET_DIR}/bin/${tool_name}" \
+    "/opt/osxcross/bin/${OSXCROSS_X86_HOST}-${tool_name}" \
+    "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_X86_HOST}-${tool_name}" \
+    "/opt/osxcross/bin/x86_64-apple-darwin-${tool_name}" \
+    "${OSXCROSS_TARGET_DIR}/bin/x86_64-apple-darwin-${tool_name}"; do
+    if [ -x "$candidate" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    command -v "$tool_name"
+    return 0
+  fi
+  return 1
+}
+
+resolve_host_tool() {
+  local host=$1
+  local tool_name=$2
+  local candidate
+  for candidate in \
+    "/opt/osxcross/bin/${host}-${tool_name}" \
+    "${OSXCROSS_TARGET_DIR}/bin/${host}-${tool_name}" \
+    "/opt/osxcross/bin/${tool_name}" \
+    "${OSXCROSS_TARGET_DIR}/bin/${tool_name}"; do
+    if [ -x "$candidate" ]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+LIPO=$(resolve_tool lipo || true)
+if [ -z "$LIPO" ]; then
+  LIPO=$(resolve_tool llvm-lipo || true)
+fi
+if [ -z "$LIPO" ]; then
+  echo "Error: could not resolve lipo or llvm-lipo for universal macOS binaries." >&2
+  exit 1
+fi
+
+export OSXCROSS_TARGET_DIR
+export OSXCROSS_SDK
+export OSXCROSS_HOST="$OSXCROSS_X86_HOST"
+export QT_CHAINLOAD_TOOLCHAIN_FILE=/opt/osxcross/target/toolchain.cmake
+export CCACHE_DISABLE=1
+unset CCACHE_DIR CCACHE_TEMPDIR
+
+QT_TOOLCHAIN="$QMUD_MAC_DOCKER_QT_PREFIX/lib/cmake/Qt6/qt.toolchain.cmake"
+if [ ! -f "$QT_TOOLCHAIN" ]; then
+  echo "Error: Qt toolchain file is missing at $QT_TOOLCHAIN" >&2
+  exit 1
+fi
+
+QT_HOST_PATH_ROOT="$QT_HOST_PREFIX"
+QT_HOST_CMAKE_DIR="$QT_HOST_PREFIX/lib/cmake"
+if [ "$QT_HOST_PREFIX" = "/usr/lib64/qt6" ] || [ "$QT_HOST_PREFIX" = "/usr/lib/qt6" ]; then
+  QT_HOST_PATH_ROOT=/usr
+fi
+if [ -d "$QT_HOST_PREFIX/lib64/cmake/Qt6" ]; then
+  QT_HOST_CMAKE_DIR="$QT_HOST_PREFIX/lib64/cmake"
+elif [ -d "$QT_HOST_PREFIX/lib/cmake/Qt6" ]; then
+  QT_HOST_CMAKE_DIR="$QT_HOST_PREFIX/lib/cmake"
+elif [ -d /usr/lib64/cmake/Qt6 ]; then
+  QT_HOST_CMAKE_DIR=/usr/lib64/cmake
+elif [ -d /usr/lib/cmake/Qt6 ]; then
+  QT_HOST_CMAKE_DIR=/usr/lib/cmake
+fi
+
+X86_CC="/opt/osxcross/bin/${OSXCROSS_X86_HOST}-clang"
+X86_CXX="/opt/osxcross/bin/${OSXCROSS_X86_HOST}-clang++"
+ARM_CC="/opt/osxcross/bin/${OSXCROSS_ARM_HOST}-clang"
+X86_AR=$(resolve_host_tool "$OSXCROSS_X86_HOST" ar || true)
+X86_RANLIB=$(resolve_host_tool "$OSXCROSS_X86_HOST" ranlib || true)
+ARM_AR=$(resolve_host_tool "$OSXCROSS_ARM_HOST" ar || true)
+ARM_RANLIB=$(resolve_host_tool "$OSXCROSS_ARM_HOST" ranlib || true)
+if [ -z "$X86_AR" ] || [ -z "$X86_RANLIB" ] || [ -z "$ARM_AR" ] || [ -z "$ARM_RANLIB" ]; then
+  echo "Error: could not resolve osxcross ar/ranlib for both universal architectures." >&2
+  echo "x86_64 ar: ${X86_AR:-<missing>}" >&2
+  echo "x86_64 ranlib: ${X86_RANLIB:-<missing>}" >&2
+  echo "arm64 ar: ${ARM_AR:-<missing>}" >&2
+  echo "arm64 ranlib: ${ARM_RANLIB:-<missing>}" >&2
+  exit 1
+fi
+UNIVERSAL_CFLAGS=(-O2 -fPIC -mmacosx-version-min="$QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET" -arch x86_64 -arch arm64)
+
+download_sources() {
+  local src_root=$1
+  mkdir -p "$src_root"
+
+  curl -fsSL "https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz" -o "$src_root/lua.tar.gz"
+  tar -xf "$src_root/lua.tar.gz" -C "$src_root"
+
+  curl -fsSL "https://github.com/lunarmodules/luasocket/archive/refs/tags/v${LUASOCKET_VERSION}.tar.gz" -o "$src_root/luasocket.tar.gz" || \
+  curl -fsSL "https://github.com/lunarmodules/luasocket/archive/refs/tags/${LUASOCKET_VERSION}.tar.gz" -o "$src_root/luasocket.tar.gz"
+  tar -xf "$src_root/luasocket.tar.gz" -C "$src_root"
+
+  curl -fsSL "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" -o "$src_root/openssl.tar.gz" || \
+  curl -fsSL "https://www.openssl.org/source/old/3.3/openssl-${OPENSSL_VERSION}.tar.gz" -o "$src_root/openssl.tar.gz"
+  tar -xf "$src_root/openssl.tar.gz" -C "$src_root"
+
+  curl -fsSL "https://github.com/brunoos/luasec/archive/refs/tags/v${LUASEC_VERSION}.tar.gz" -o "$src_root/luasec.tar.gz" || \
+  curl -fsSL "https://github.com/brunoos/luasec/archive/refs/tags/${LUASEC_VERSION}.tar.gz" -o "$src_root/luasec.tar.gz"
+  tar -xf "$src_root/luasec.tar.gz" -C "$src_root"
+
+  curl -fsSL "https://www.inf.puc-rio.br/~roberto/lpeg/lpeg-${LPEG_VERSION}.tar.gz" -o "$src_root/lpeg.tar.gz"
+  tar -xf "$src_root/lpeg.tar.gz" -C "$src_root"
+}
+
+copy_lua_file() {
+  local src_dir=$1
+  local c_dir=$2
+  local name=$3
+  if [[ -f "${c_dir}/${name}" ]]; then
+    cp "${c_dir}/${name}" "${QMUD_MAC_DOCKER_LUA_MODULES_PREFIX}/${name}"
+    return 0
+  fi
+  if [[ -f "${src_dir}/${name}" ]]; then
+    cp "${src_dir}/${name}" "${QMUD_MAC_DOCKER_LUA_MODULES_PREFIX}/${name}"
+    return 0
+  fi
+  return 1
+}
+
+copy_socket_lua_file() {
+  local src_dir=$1
+  local c_dir=$2
+  local name=$3
+  if [[ -f "${c_dir}/${name}.lua" ]]; then
+    cp "${c_dir}/${name}.lua" "${QMUD_MAC_DOCKER_LUA_MODULES_PREFIX}/socket/${name}.lua"
+    return 0
+  fi
+  if [[ -f "${src_dir}/${name}.lua" ]]; then
+    cp "${src_dir}/${name}.lua" "${QMUD_MAC_DOCKER_LUA_MODULES_PREFIX}/socket/${name}.lua"
+    return 0
+  fi
+  return 1
+}
+
+build_openssl_slice() {
+  local source_dir=$1
+  local build_root=$2
+  local arch_name=$3
+  local cc=$4
+  local ar=$5
+  local ranlib=$6
+  local openssl_target=$7
+  local prefix=$8
+
+  rm -rf "$build_root/openssl-${arch_name}"
+  cp -R "$source_dir" "$build_root/openssl-${arch_name}"
+  cd "$build_root/openssl-${arch_name}"
+  CC="$cc" AR="$ar" RANLIB="$ranlib" ./Configure "$openssl_target" no-shared no-tests no-apps no-module no-legacy \
+    --prefix="$prefix" \
+    --openssldir="$prefix"
+  make -j"$(nproc)" AR="$ar" RANLIB="$ranlib"
+  make install_sw AR="$ar" RANLIB="$ranlib"
+}
+
+verify_arch() {
+  local path=$1
+  local arch=$2
+  local info
+  if [ ! -e "$path" ]; then
+    echo "Error: expected binary is missing at $path." >&2
+    exit 1
+  fi
+  info=$("$LIPO" -info "$path")
+  case "$info" in
+    *"$arch"*) ;;
+    *)
+      echo "Error: $path does not contain ${arch}: $info" >&2
+      exit 1
+      ;;
+  esac
+}
+
+build_universal_lua_deps() {
+  local src_root="$BUILD_DIR/universal-src"
+  local openssl_slices="$UNIVERSAL_DEPS_DIR/openssl-slices"
+  rm -rf "$src_root" "$UNIVERSAL_DEPS_DIR"
+  mkdir -p "$QMUD_MAC_DOCKER_LUA_PREFIX/include" "$QMUD_MAC_DOCKER_LUA_PREFIX/lib"
+  mkdir -p "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl"
+  mkdir -p "$openssl_slices" "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/include" "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib"
+
+  download_sources "$src_root"
+
+  local lua_src
+  lua_src="$(find "$src_root" -maxdepth 1 -type d -name "lua-${LUA_VERSION}*" | head -n 1 || true)"
+  [[ -n "$lua_src" ]]
+  cd "$lua_src/src"
+  "$X86_CC" "${UNIVERSAL_CFLAGS[@]}" -DLUA_USE_MACOSX -I. -dynamiclib \
+    lapi.c lauxlib.c lbaselib.c lcode.c lcorolib.c lctype.c ldblib.c ldebug.c ldo.c ldump.c lfunc.c lgc.c \
+    linit.c liolib.c llex.c lmathlib.c lmem.c loadlib.c lobject.c lopcodes.c loslib.c lparser.c lstate.c \
+    lstring.c lstrlib.c ltable.c ltablib.c ltm.c lundump.c lutf8lib.c lvm.c lzio.c \
+    -Wl,-install_name,@rpath/liblua.5.4.dylib -o "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.5.4.dylib" -lm
+  ln -sf liblua.5.4.dylib "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.dylib"
+  cp lua.h lauxlib.h lualib.h luaconf.h "$QMUD_MAC_DOCKER_LUA_PREFIX/include/"
+
+  local luasocket_src luasocket_c_dir
+  luasocket_src="$(find "$src_root" -maxdepth 1 -type d -name "luasocket*${LUASOCKET_VERSION}*" | head -n 1 || true)"
+  [[ -n "$luasocket_src" ]]
+  luasocket_c_dir="$luasocket_src/src"
+  [[ -d "$luasocket_c_dir" ]]
+  cd "$luasocket_c_dir"
+  "$X86_CC" "${UNIVERSAL_CFLAGS[@]}" -I"$QMUD_MAC_DOCKER_LUA_PREFIX/include" -bundle -undefined dynamic_lookup \
+    auxiliar.c buffer.c compat.c except.c inet.c io.c luasocket.c options.c select.c tcp.c timeout.c udp.c usocket.c \
+    -o "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/core.so"
+  "$X86_CC" "${UNIVERSAL_CFLAGS[@]}" -I"$QMUD_MAC_DOCKER_LUA_PREFIX/include" -bundle -undefined dynamic_lookup \
+    mime.c compat.c -o "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime/core.so"
+
+  copy_lua_file "$luasocket_src" "$luasocket_c_dir" socket.lua
+  copy_lua_file "$luasocket_src" "$luasocket_c_dir" mime.lua
+  copy_lua_file "$luasocket_src" "$luasocket_c_dir" ltn12.lua
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/socket.lua"
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/mime.lua"
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ltn12.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/ltn12.lua"
+  for f in ftp headers http smtp tp url; do
+    copy_socket_lua_file "$luasocket_src" "$luasocket_c_dir" "$f"
+  done
+  copy_socket_lua_file "$luasocket_src" "$luasocket_c_dir" socket || true
+  copy_socket_lua_file "$luasocket_src" "$luasocket_c_dir" mbox || true
+
+  local openssl_src
+  openssl_src="$(find "$src_root" -maxdepth 1 -type d -name "openssl-${OPENSSL_VERSION}*" | head -n 1 || true)"
+  [[ -n "$openssl_src" ]]
+  build_openssl_slice "$openssl_src" "$openssl_slices" x86_64 "$X86_CC" "$X86_AR" "$X86_RANLIB" darwin64-x86_64-cc "$openssl_slices/x86_64"
+  build_openssl_slice "$openssl_src" "$openssl_slices" arm64 "$ARM_CC" "$ARM_AR" "$ARM_RANLIB" darwin64-arm64-cc "$openssl_slices/arm64"
+  verify_arch "$openssl_slices/x86_64/lib/libssl.a" x86_64
+  verify_arch "$openssl_slices/x86_64/lib/libcrypto.a" x86_64
+  verify_arch "$openssl_slices/arm64/lib/libssl.a" arm64
+  verify_arch "$openssl_slices/arm64/lib/libcrypto.a" arm64
+  cp -R "$openssl_slices/x86_64/include/." "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/include/"
+  "$LIPO" -create "$openssl_slices/x86_64/lib/libssl.a" "$openssl_slices/arm64/lib/libssl.a" -output "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libssl.a"
+  "$LIPO" -create "$openssl_slices/x86_64/lib/libcrypto.a" "$openssl_slices/arm64/lib/libcrypto.a" -output "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libcrypto.a"
+  verify_arch "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libssl.a" x86_64
+  verify_arch "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libssl.a" arm64
+  verify_arch "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libcrypto.a" x86_64
+  verify_arch "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libcrypto.a" arm64
+
+  local luasec_src luasec_c_dir luasec_c_sources luasec_socket_sources
+  luasec_src="$(find "$src_root" -maxdepth 1 -type d -name "luasec*${LUASEC_VERSION}*" | head -n 1 || true)"
+  [[ -n "$luasec_src" ]]
+  luasec_c_dir="$luasec_src/src"
+  [[ -d "$luasec_c_dir" ]]
+  cd "$luasec_c_dir"
+  luasec_c_sources=""
+  for src in config.c context.c ec.c options.c ssl.c x509.c; do
+    if [[ -f "$src" ]]; then
+      luasec_c_sources="$luasec_c_sources $src"
+    fi
+  done
+  if [[ -z "$luasec_c_sources" ]]; then
+    echo "Error: could not resolve LuaSec C sources in ${luasec_c_dir}" >&2
+    exit 1
+  fi
+  luasec_socket_sources=""
+  for src in luasocket/buffer.c luasocket/io.c luasocket/timeout.c; do
+    if [[ -f "$src" ]]; then
+      luasec_socket_sources="$luasec_socket_sources $src"
+    fi
+  done
+  if [[ -f "luasocket/usocket.c" ]]; then
+    luasec_socket_sources="$luasec_socket_sources luasocket/usocket.c"
+  elif [[ -f "luasocket/wsocket.c" ]]; then
+    luasec_socket_sources="$luasec_socket_sources luasocket/wsocket.c"
+  fi
+  if [[ -z "$luasec_socket_sources" ]]; then
+    echo "Error: could not resolve bundled LuaSocket sources in ${luasec_c_dir}/luasocket" >&2
+    exit 1
+  fi
+  "$X86_CC" "${UNIVERSAL_CFLAGS[@]}" \
+    -I"$QMUD_MAC_DOCKER_LUA_PREFIX/include" \
+    -I"$QMUD_MAC_DOCKER_OPENSSL_PREFIX/include" \
+    -I"$luasec_c_dir" \
+    -bundle -undefined dynamic_lookup \
+    $luasec_c_sources $luasec_socket_sources \
+    "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libssl.a" \
+    "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libcrypto.a" \
+    -lz \
+    -o "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so"
+
+  if [[ -f "$luasec_src/ssl.lua" ]]; then
+    cp "$luasec_src/ssl.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl.lua"
+  elif [[ -f "$luasec_c_dir/ssl.lua" ]]; then
+    cp "$luasec_c_dir/ssl.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl.lua"
+  fi
+  for name in config.lua https.lua options.lua; do
+    if [[ -f "$luasec_c_dir/$name" ]]; then
+      cp "$luasec_c_dir/$name" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/$name"
+    fi
+  done
+  if [[ -d "$luasec_c_dir/ssl" ]]; then
+    cp -R "$luasec_c_dir/ssl/." "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/"
+  elif [[ -d "$luasec_src/ssl" ]]; then
+    cp -R "$luasec_src/ssl/." "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/"
+  fi
+
+  local lpeg_src lpeg_c_dir
+  lpeg_src="$(find "$src_root" -maxdepth 1 -type d -name "lpeg*${LPEG_VERSION}*" | head -n 1 || true)"
+  [[ -n "$lpeg_src" ]]
+  if [[ -f "$lpeg_src/lpcap.c" ]]; then
+    lpeg_c_dir="$lpeg_src"
+  else
+    lpeg_c_dir="$lpeg_src/src"
+  fi
+  [[ -f "$lpeg_c_dir/lpcap.c" ]]
+  cd "$lpeg_c_dir"
+  "$X86_CC" "${UNIVERSAL_CFLAGS[@]}" -I"$QMUD_MAC_DOCKER_LUA_PREFIX/include" -bundle -undefined dynamic_lookup \
+    lpcap.c lpcode.c lptree.c lpvm.c -o "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/lpeg.so"
+  if [[ -f "$lpeg_src/re.lua" ]]; then
+    cp "$lpeg_src/re.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/re.lua"
+  elif [[ -f "$lpeg_c_dir/re.lua" ]]; then
+    cp "$lpeg_c_dir/re.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/re.lua"
+  fi
+
+  curl -fsSL "https://raw.githubusercontent.com/rxi/json.lua/master/json.lua" -o "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json.lua"
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json.lua" "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json/init.lua"
+
+  test -f "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.5.4.dylib"
+  test -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/core.so"
+  test -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime/core.so"
+  test -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so"
+  test -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl.lua"
+  test -f "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/include/openssl/ssl.h"
+  test -f "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libssl.a"
+  test -f "$QMUD_MAC_DOCKER_OPENSSL_PREFIX/lib/libcrypto.a"
+}
+
+verify_universal() {
+  local path=$1
+  local info
+  if [ ! -e "$path" ]; then
+    echo "Error: expected universal binary is missing at $path." >&2
+    exit 1
+  fi
+  info=$("$LIPO" -info "$path")
+  case "$info" in
+    *x86_64*arm64*|*arm64*x86_64*) ;;
+    *)
+      echo "Error: $path is not universal: $info" >&2
+      exit 1
+      ;;
+  esac
+}
+
+build_universal_lua_deps
+
+CMAKE_EXE=cmake
+if [ -x /opt/Qt/Tools/CMake/bin/cmake ]; then
+  CMAKE_EXE=/opt/Qt/Tools/CMake/bin/cmake
+fi
+
+"$CMAKE_EXE" -S "$PROJECT_DIR" -G Ninja -B "$BUILD_DIR" \
+  -DCMAKE_TOOLCHAIN_FILE="$QT_TOOLCHAIN" \
+  -DQT_CHAINLOAD_TOOLCHAIN_FILE=/opt/osxcross/target/toolchain.cmake \
+  -DCMAKE_SYSTEM_NAME=Darwin \
+  -DCMAKE_C_COMPILER="$X86_CC" \
+  -DCMAKE_CXX_COMPILER="$X86_CXX" \
+  -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="$QMUD_MAC_DOCKER_OSX_DEPLOYMENT_TARGET" \
+  -DOSXCROSS_HOST="$OSXCROSS_X86_HOST" \
+  -DOSXCROSS_TARGET_DIR="$OSXCROSS_TARGET_DIR" \
+  -DOSXCROSS_SDK="$OSXCROSS_SDK" \
+  -DCMAKE_BUILD_TYPE="$QMUD_MAC_DOCKER_BUILD_TYPE" \
+  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
+  -DQMUD_PROBE_IPO=OFF \
+  -DQMUD_MACAPP_FORCE_NO_MACDEPLOYQT=ON \
+  -DQMUD_MACAPP_ALLOW_NO_MACDEPLOYQT=ON \
+  -DQMUD_MACAPP_MACDEPLOYQT_NO_PLUGINS=ON \
+  -DQt6_DIR="$QMUD_MAC_DOCKER_QT_PREFIX/lib/cmake/Qt6" \
+  -DQt6Multimedia_DIR="$QMUD_MAC_DOCKER_QT_PREFIX/lib/cmake/Qt6Multimedia" \
+  -DQt6TextToSpeech_DIR="$QMUD_MAC_DOCKER_QT_PREFIX/lib/cmake/Qt6TextToSpeech" \
+  -DQT_HOST_PATH="$QT_HOST_PATH_ROOT" \
+  -DQT_HOST_PATH_CMAKE_DIR="$QT_HOST_CMAKE_DIR" \
+  -DCMAKE_AUTOMOC_EXECUTABLE="$QT_HOST_MOC" \
+  -DQMUD_SYSTEM_LUA_MODULES_PREFIX="$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX" \
+  -DLUA_INCLUDE_DIR="$QMUD_MAC_DOCKER_LUA_PREFIX/include" \
+  -DLUA_LIBRARY="$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.dylib" \
+  -DQMUD_LPEG_PROVIDER=SYSTEM \
+  -DQMUD_BC_PROVIDER=BUNDLED \
+  -DQMUD_LUASOCKET_PROVIDER=SYSTEM
+
+cmake --build "$BUILD_DIR" --target MacApp -j 6
+
+APP_STAGE_DIR="$BUILD_DIR/macapp-out/QMud.app"
+APP_MACOS_DIR="$APP_STAGE_DIR/Contents/MacOS"
+APP_FRAMEWORKS_DIR="$APP_STAGE_DIR/Contents/Frameworks"
+APP_PLUGINS_DIR="$APP_STAGE_DIR/Contents/PlugIns"
+APP_TLS_DIR="$APP_PLUGINS_DIR/tls"
+
+copy_qt_framework() {
+  local framework_name=$1
+  local framework_source="$QMUD_MAC_DOCKER_QT_PREFIX/lib/${framework_name}.framework"
+  local framework_target="$APP_FRAMEWORKS_DIR/${framework_name}.framework"
+
+  if [ ! -d "$framework_source" ]; then
+    echo "Error: required Qt framework is missing at $framework_source." >&2
+    exit 1
+  fi
+
+  rm -rf "$framework_target"
+  cp -a "$framework_source" "$APP_FRAMEWORKS_DIR/"
+  rm -rf "$framework_target/Headers" "$framework_target/Sources"
+  if [ -d "$framework_target/Versions" ]; then
+    find "$framework_target/Versions" -mindepth 2 -maxdepth 2 \( -name Headers -o -name Sources \) -type d -prune -exec rm -rf {} +
+  fi
+  find "$framework_target" -type f -name '*.prl' -delete
+}
+
+mkdir -p "$APP_MACOS_DIR" "$APP_FRAMEWORKS_DIR" "$APP_PLUGINS_DIR/platforms" "$APP_PLUGINS_DIR/sqldrivers"
+if [ -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/multimedia" ]; then
+  mkdir -p "$APP_PLUGINS_DIR/multimedia"
+fi
+if [ -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/texttospeech" ]; then
+  mkdir -p "$APP_PLUGINS_DIR/texttospeech"
+fi
+
+for QT_FRAMEWORK in \
+  QtCore \
+  QtGui \
+  QtWidgets \
+  QtNetwork \
+  QtSql \
+  QtPrintSupport \
+  QtMultimedia \
+  QtTextToSpeech
+do
+  copy_qt_framework "$QT_FRAMEWORK"
+done
+cp "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/platforms/libqcocoa.dylib" "$APP_PLUGINS_DIR/platforms/"
+cp "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/sqldrivers/libqsqlite.dylib" "$APP_PLUGINS_DIR/sqldrivers/"
+if [ -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/multimedia" ]; then
+  cp -R "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/multimedia/." "$APP_PLUGINS_DIR/multimedia/"
+fi
+if [ ! -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/texttospeech" ]; then
+  echo "Error: Qt TextToSpeech plugins directory is missing at $QMUD_MAC_DOCKER_QT_PREFIX/plugins/texttospeech." >&2
+  exit 1
+fi
+cp -R "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/texttospeech/." "$APP_PLUGINS_DIR/texttospeech/"
+if ! find "$APP_PLUGINS_DIR/texttospeech" -maxdepth 1 -type f -name '*.dylib' | grep -q .; then
+  echo "Error: macOS package is missing Qt TextToSpeech engine plugins." >&2
+  echo "Expected at least one plugin dylib in $APP_PLUGINS_DIR/texttospeech." >&2
+  exit 1
+fi
+if [ ! -d "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/tls" ]; then
+  echo "Error: Qt TLS plugins directory is missing at $QMUD_MAC_DOCKER_QT_PREFIX/plugins/tls." >&2
+  exit 1
+fi
+mkdir -p "$APP_TLS_DIR"
+cp -R "$QMUD_MAC_DOCKER_QT_PREFIX/plugins/tls/." "$APP_TLS_DIR/"
+if ! find "$APP_TLS_DIR" -maxdepth 1 -type f \( -name 'libqsecuretransportbackend*.dylib' -o -name 'libqopensslbackend*.dylib' \) | grep -q .; then
+  echo "Error: macOS package is missing a functional Qt TLS backend plugin." >&2
+  echo "Expected libqsecuretransportbackend*.dylib or libqopensslbackend*.dylib in $APP_TLS_DIR." >&2
+  exit 1
+fi
+
+cp "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.5.4.dylib" "$APP_FRAMEWORKS_DIR/"
+ln -sf liblua.5.4.dylib "$APP_FRAMEWORKS_DIR/liblua.dylib"
+
+mkdir -p "$APP_MACOS_DIR/socket" "$APP_MACOS_DIR/mime" "$APP_MACOS_DIR/ssl" "$APP_MACOS_DIR/lua/json" "$APP_MACOS_DIR/lua/ssl"
+cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/core.so" "$APP_MACOS_DIR/socket/core.so"
+cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime/core.so" "$APP_MACOS_DIR/mime/core.so"
+if [ ! -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so" ]; then
+  echo "Error: expected LuaSec core module at $QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so, but it was not found." >&2
+  exit 1
+fi
+cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so" "$APP_MACOS_DIR/ssl/core.so"
+cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so" "$APP_MACOS_DIR/lua/ssl/core.so"
+
+if [ -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/lpeg.so" ]; then
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/lpeg.so" "$APP_MACOS_DIR/lua/lpeg.so"
+fi
+if [ -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/re.lua" ]; then
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/re.lua" "$APP_MACOS_DIR/lua/re.lua"
+fi
+if [ -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket.lua" ]; then
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket.lua" "$APP_MACOS_DIR/lua/socket.lua"
+fi
+if [ -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime.lua" ]; then
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime.lua" "$APP_MACOS_DIR/lua/mime.lua"
+fi
+if [ -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ltn12.lua" ]; then
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ltn12.lua" "$APP_MACOS_DIR/lua/ltn12.lua"
+fi
+if [ -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl.lua" ]; then
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl.lua" "$APP_MACOS_DIR/lua/ssl.lua"
+else
+  echo "Error: expected LuaSec top-level module ssl.lua at $QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl.lua, but it was not found." >&2
+  exit 1
+fi
+if [ -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json.lua" ]; then
+  cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json.lua" "$APP_MACOS_DIR/lua/json.lua"
+fi
+if [ -d "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json" ]; then
+  cp -R "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/json/." "$APP_MACOS_DIR/lua/json/"
+fi
+if [ -d "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl" ]; then
+  cp -R "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/." "$APP_MACOS_DIR/ssl/"
+  cp -R "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/." "$APP_MACOS_DIR/lua/ssl/"
+fi
+
+verify_universal "$APP_MACOS_DIR/QMud"
+verify_universal "$APP_FRAMEWORKS_DIR/liblua.5.4.dylib"
+verify_universal "$APP_MACOS_DIR/socket/core.so"
+verify_universal "$APP_MACOS_DIR/mime/core.so"
+verify_universal "$APP_MACOS_DIR/ssl/core.so"
+if [ -f "$APP_MACOS_DIR/lua/lpeg.so" ]; then
+  verify_universal "$APP_MACOS_DIR/lua/lpeg.so"
+fi
+
+bash "$PROJECT_DIR/tools/scripts/package_mac_dmg.sh" "$APP_STAGE_DIR" "$BUILD_DIR/macapp-out/QMud.dmg"

--- a/tools/scripts/mac_docker_build_universal.sh
+++ b/tools/scripts/mac_docker_build_universal.sh
@@ -554,6 +554,12 @@ cp "$QMUD_MAC_DOCKER_LUA_PREFIX/lib/liblua.5.4.dylib" "$APP_FRAMEWORKS_DIR/"
 ln -sf liblua.5.4.dylib "$APP_FRAMEWORKS_DIR/liblua.dylib"
 
 mkdir -p "$APP_MACOS_DIR/socket" "$APP_MACOS_DIR/mime" "$APP_MACOS_DIR/ssl" "$APP_MACOS_DIR/lua/json" "$APP_MACOS_DIR/lua/ssl"
+mkdir -p \
+  "$APP_MACOS_DIR/lua/native/linux-x86_64" \
+  "$APP_MACOS_DIR/lua/native/macos-universal" \
+  "$APP_MACOS_DIR/lua/native/macos-arm64" \
+  "$APP_MACOS_DIR/lua/native/macos-x86_64" \
+  "$APP_MACOS_DIR/lua/native/windows-x86_64"
 cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/socket/core.so" "$APP_MACOS_DIR/socket/core.so"
 cp "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/mime/core.so" "$APP_MACOS_DIR/mime/core.so"
 if [ ! -f "$QMUD_MAC_DOCKER_LUA_MODULES_PREFIX/ssl/core.so" ]; then

--- a/tools/scripts/package_mac_dmg.sh
+++ b/tools/scripts/package_mac_dmg.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+## @file package_mac_dmg.sh
+## @brief Packages QMud.app into a macOS-mountable disk image from Linux.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: package_mac_dmg.sh /path/to/QMud.app /path/to/QMud.dmg" >&2
+  exit 2
+fi
+
+APP_BUNDLE=$1
+DMG_OUTPUT=$2
+VOLUME_NAME=${QMUD_DMG_VOLUME_NAME:-QMud}
+
+if [ ! -d "$APP_BUNDLE/Contents" ]; then
+  echo "Error: app bundle is missing or invalid: $APP_BUNDLE" >&2
+  exit 1
+fi
+
+if ! command -v mkfs.hfsplus >/dev/null 2>&1; then
+  echo "Error: mkfs.hfsplus is required to create the macOS HFS+ image." >&2
+  exit 1
+fi
+if ! command -v hfsplus >/dev/null 2>&1; then
+  echo "Error: hfsplus from libdmg-hfsplus is required to populate the macOS DMG image." >&2
+  exit 1
+fi
+if ! command -v dmg >/dev/null 2>&1; then
+  echo "Error: dmg from libdmg-hfsplus is required to compress the macOS DMG image." >&2
+  exit 1
+fi
+
+OUTPUT_DIR=$(dirname "$DMG_OUTPUT")
+STAGE_DIR="$OUTPUT_DIR/.qmud-dmg-stage"
+HFS_IMAGE="$OUTPUT_DIR/.qmud-dmg-stage.hfs"
+
+cleanup() {
+  rm -rf "$STAGE_DIR"
+  rm -f "$HFS_IMAGE"
+}
+trap cleanup EXIT
+
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+cp -a "$APP_BUNDLE" "$STAGE_DIR/"
+
+STAGE_SIZE_KIB=$(du -sk "$STAGE_DIR" | awk '{print $1}')
+HFS_SIZE_MIB=$(((STAGE_SIZE_KIB * 102 + 99999) / 100000))
+if [ "$HFS_SIZE_MIB" -lt 1 ]; then
+  HFS_SIZE_MIB=1
+fi
+
+rm -f "$DMG_OUTPUT" "$HFS_IMAGE"
+dd if=/dev/zero of="$HFS_IMAGE" bs=1M count="$HFS_SIZE_MIB" status=none
+mkfs.hfsplus -v "$VOLUME_NAME" "$HFS_IMAGE"
+hfsplus "$HFS_IMAGE" --symlinks clone_link addall "$STAGE_DIR"
+hfsplus "$HFS_IMAGE" symlink /Applications /Applications
+dmg build "$HFS_IMAGE" "$DMG_OUTPUT" --compression lzma --level 5 --run-sectors 2048
+
+if [ ! -s "$DMG_OUTPUT" ]; then
+  echo "Error: DMG image was not created: $DMG_OUTPUT" >&2
+  exit 1
+fi

--- a/tools/scripts/png_to_icns.py
+++ b/tools/scripts/png_to_icns.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""!
+@file png_to_icns.py
+@brief Wraps a square PNG image into a minimal macOS ICNS file.
+"""
+
+from pathlib import Path
+import struct
+import sys
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+ICNS_TYPES_BY_SIZE = {
+    16: b"icp4",
+    32: b"icp5",
+    64: b"icp6",
+    128: b"ic07",
+    256: b"ic08",
+    512: b"ic09",
+    1024: b"ic10",
+}
+
+
+def png_dimensions(data: bytes) -> tuple[int, int]:
+    if not data.startswith(PNG_SIGNATURE):
+        raise ValueError("input is not a PNG file")
+    if data[12:16] != b"IHDR":
+        raise ValueError("PNG IHDR chunk is missing")
+    return struct.unpack(">II", data[16:24])
+
+
+def write_icns(source: Path, destination: Path) -> None:
+    data = source.read_bytes()
+    width, height = png_dimensions(data)
+    if width != height:
+        raise ValueError(f"PNG must be square, got {width}x{height}")
+    icon_type = ICNS_TYPES_BY_SIZE.get(width)
+    if icon_type is None:
+        supported = ", ".join(str(size) for size in sorted(ICNS_TYPES_BY_SIZE))
+        raise ValueError(f"unsupported PNG size {width}x{height}; supported sizes: {supported}")
+
+    chunk_length = 8 + len(data)
+    total_length = 8 + chunk_length
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(
+        b"icns"
+        + struct.pack(">I", total_length)
+        + icon_type
+        + struct.pack(">I", chunk_length)
+        + data
+    )
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: png_to_icns.py SOURCE.png DESTINATION.icns", file=sys.stderr)
+        return 2
+
+    try:
+        write_icns(Path(sys.argv[1]), Path(sys.argv[2]))
+    except OSError as error:
+        print(f"png_to_icns.py: {error}", file=sys.stderr)
+        return 1
+    except ValueError as error:
+        print(f"png_to_icns.py: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/win_docker_build.sh
+++ b/tools/scripts/win_docker_build.sh
@@ -331,6 +331,12 @@ else
 fi
 
 mkdir -p "$STAGE_DIR/lua" "$STAGE_DIR/socket" "$STAGE_DIR/mime"
+mkdir -p \
+  "$STAGE_DIR/lua/native/linux-x86_64" \
+  "$STAGE_DIR/lua/native/macos-universal" \
+  "$STAGE_DIR/lua/native/macos-arm64" \
+  "$STAGE_DIR/lua/native/macos-x86_64" \
+  "$STAGE_DIR/lua/native/windows-x86_64"
 
 if [ ! -f "$BUILD_DIR/socket/core.dll" ]; then
   echo "Error: expected generated LuaSocket core module at $BUILD_DIR/socket/core.dll, but it was not found." >&2

--- a/tools/scripts/win_docker_build.sh
+++ b/tools/scripts/win_docker_build.sh
@@ -24,9 +24,14 @@ LUA_MODULES_PREFIX="$QMUD_WINDOCKER_LUA_MODULES_PREFIX"
 MINGW_TRIPLET="$QMUD_WINDOCKER_MINGW_TRIPLET"
 MINGW_INCLUDE_DIR="$MINGW_PREFIX/include"
 MINGW_LIB_DIR="$MINGW_PREFIX/lib"
+PE_OBJDUMP="${MINGW_TRIPLET}-objdump"
 
 if [ "$MINGW_TRIPLET" != "x86_64-w64-mingw32" ]; then
   echo "Error: unsupported MinGW triplet '$MINGW_TRIPLET'. Only x86_64-w64-mingw32 is supported." >&2
+  exit 1
+fi
+if ! command -v "$PE_OBJDUMP" >/dev/null 2>&1; then
+  echo "Error: ${PE_OBJDUMP} was not found; Windows dependency staging requires mingw64-binutils." >&2
   exit 1
 fi
 
@@ -132,12 +137,165 @@ mkdir -p "$STAGE_DIR"
 cp "$QMUD_EXE" "$STAGE_DIR/QMud.exe"
 mkdir -p "$STAGE_DIR/lib"
 
-if [ -d "$QT_PREFIX/bin" ]; then
-  cp "$QT_PREFIX/bin/"*.dll "$STAGE_DIR/lib/" || true
+lower_name() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_packaged_dependency_dll() {
+  dll_lower="$(lower_name "$1")"
+  case "$dll_lower" in
+    qt6*.dll | lua54.dll | lua.dll | libgcc_s_seh-1.dll | libstdc++-6.dll | libwinpthread-1.dll | \
+      zlib1.dll | libatomic-1.dll | libssp-0.dll | libssl-*.dll | libcrypto-*.dll | avcodec-*.dll | \
+      avformat-*.dll | avutil-*.dll | swresample-*.dll | swscale-*.dll | d3dcompiler_47.dll | opengl32sw.dll)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+find_dependency_dll() {
+  dll="$1"
+  dll_lower="$(lower_name "$dll")"
+
+  case "$dll_lower" in
+    qt6*.dll | avcodec-*.dll | avformat-*.dll | avutil-*.dll | swresample-*.dll | swscale-*.dll | \
+      d3dcompiler_47.dll | opengl32sw.dll)
+      search_dirs="$STAGE_DIR
+$STAGE_DIR/lib
+$QT_PREFIX/bin
+$MINGW_PREFIX/bin
+$LUA_PREFIX/bin
+$LUA_PREFIX/lib"
+      ;;
+    lua54.dll | lua.dll)
+      search_dirs="$STAGE_DIR
+$STAGE_DIR/lib
+$LUA_PREFIX/bin
+$LUA_PREFIX/lib
+$MINGW_PREFIX/bin
+$QT_PREFIX/bin"
+      ;;
+    libgcc_s_seh-1.dll | libstdc++-6.dll | libwinpthread-1.dll | zlib1.dll | libatomic-1.dll | \
+      libssp-0.dll | libssl-*.dll | libcrypto-*.dll)
+      search_dirs="$STAGE_DIR
+$STAGE_DIR/lib
+$MINGW_PREFIX/bin
+$QT_PREFIX/bin
+$LUA_PREFIX/bin
+$LUA_PREFIX/lib"
+      ;;
+    *)
+      search_dirs="$STAGE_DIR
+$STAGE_DIR/lib
+$QT_PREFIX/bin
+$MINGW_PREFIX/bin
+$LUA_PREFIX/bin
+$LUA_PREFIX/lib"
+      ;;
+  esac
+
+  printf '%s\n' "$search_dirs" | while IFS= read -r search_dir; do
+    [ -d "$search_dir" ] || continue
+    found="$(find "$search_dir" -maxdepth 1 -type f -iname "$dll" | sort | head -n 1 || true)"
+    if [ -n "$found" ]; then
+      printf '%s\n' "$found"
+      return 0
+    fi
+  done
+}
+
+dependency_is_staged() {
+  dll="$1"
+  find "$STAGE_DIR" "$STAGE_DIR/lib" -maxdepth 1 -type f -iname "$dll" | grep -q .
+}
+
+collect_dll_closure() {
+  destination="$1"
+  shift
+  mkdir -p "$destination"
+
+  queue_file="$BUILD_DIR/windocker-deps-queue.$$"
+  seen_file="$BUILD_DIR/windocker-deps-seen.$$"
+  : >"$queue_file"
+  : >"$seen_file"
+  for binary in "$@"; do
+    [ -f "$binary" ] || continue
+    printf '%s\n' "$binary" >>"$queue_file"
+  done
+
+  while [ -s "$queue_file" ]; do
+    binary="$(sed -n '1p' "$queue_file")"
+    sed '1d' "$queue_file" >"$queue_file.next"
+    mv "$queue_file.next" "$queue_file"
+    [ -f "$binary" ] || continue
+
+    "$PE_OBJDUMP" -p "$binary" 2>/dev/null | sed -n 's/^[[:space:]]*DLL Name: //p' | while IFS= read -r dependency; do
+      [ -n "$dependency" ] || continue
+      dependency_lower="$(lower_name "$dependency")"
+      if grep -Fxq "$dependency_lower" "$seen_file"; then
+        continue
+      fi
+      printf '%s\n' "$dependency_lower" >>"$seen_file"
+
+      if ! is_packaged_dependency_dll "$dependency"; then
+        continue
+      fi
+      if dependency_is_staged "$dependency"; then
+        continue
+      fi
+
+      source_path="$(find_dependency_dll "$dependency" || true)"
+      if [ -z "$source_path" ]; then
+        echo "Error: unresolved packaged Windows dependency '$dependency' required by $binary." >&2
+        exit 1
+      fi
+
+      target_path="$destination/$(basename "$source_path")"
+      cp -f "$source_path" "$target_path"
+      printf '%s\n' "$target_path" >>"$queue_file"
+    done
+  done
+
+  rm -f "$queue_file" "$seen_file"
+}
+
+copy_qt_plugin() {
+  relative_path="$1"
+  required="$2"
+  source_path="$QT_PREFIX/plugins/$relative_path"
+  target_path="$STAGE_DIR/qtplugins/$relative_path"
+  if [ ! -f "$source_path" ]; then
+    if [ "$required" = "required" ]; then
+      echo "Error: required Qt plugin is missing: $source_path" >&2
+      exit 1
+    fi
+    return 0
+  fi
+  mkdir -p "$(dirname "$target_path")"
+  cp -f "$source_path" "$target_path"
+}
+
+copy_qt_plugin platforms/qwindows.dll required
+copy_qt_plugin sqldrivers/qsqlite.dll required
+copy_qt_plugin tls/qcertonlybackend.dll optional
+copy_qt_plugin tls/qopensslbackend.dll optional
+copy_qt_plugin tls/qschannelbackend.dll optional
+copy_qt_plugin texttospeech/qtexttospeech_sapi.dll required
+copy_qt_plugin iconengines/qsvgicon.dll required
+copy_qt_plugin imageformats/qgif.dll required
+copy_qt_plugin imageformats/qico.dll required
+copy_qt_plugin imageformats/qjpeg.dll required
+copy_qt_plugin imageformats/qsvg.dll required
+copy_qt_plugin styles/qmodernwindowsstyle.dll optional
+copy_qt_plugin networkinformation/qnetworklistmanager.dll optional
+
+if [ ! -d "$QT_PREFIX/plugins/multimedia" ]; then
+  echo "Error: Qt Multimedia plugins directory is missing: $QT_PREFIX/plugins/multimedia" >&2
+  exit 1
 fi
-if [ -d "$QT_PREFIX/plugins" ]; then
-  cp -R "$QT_PREFIX/plugins" "$STAGE_DIR/qtplugins"
-fi
+mkdir -p "$STAGE_DIR/qtplugins/multimedia"
+find "$QT_PREFIX/plugins/multimedia" -maxdepth 1 -type f -iname '*.dll' -exec cp -f {} "$STAGE_DIR/qtplugins/multimedia/" \;
+
 TLS_PLUGIN_DIR="$STAGE_DIR/qtplugins/tls"
 if [ ! -d "$TLS_PLUGIN_DIR" ]; then
   echo "Error: Qt TLS plugins directory is missing from staged package: $TLS_PLUGIN_DIR" >&2
@@ -158,20 +316,8 @@ if ! find "$TTS_PLUGIN_DIR" -maxdepth 1 -type f -iname '*.dll' | grep -q .; then
   echo "Expected at least one plugin DLL in $TTS_PLUGIN_DIR." >&2
   exit 1
 fi
-if [ -d "$MINGW_PREFIX/bin" ]; then
-  cp "$MINGW_PREFIX/bin/"*.dll "$STAGE_DIR/lib/" || true
-fi
-if [ -d "$LUA_PREFIX/bin" ]; then
-  cp "$LUA_PREFIX/bin/"*.dll "$STAGE_DIR/lib/" || true
-fi
 
-STARTUP_DLLS='Qt6Core.dll Qt6Gui.dll Qt6Multimedia.dll Qt6Network.dll Qt6PrintSupport.dll Qt6Sql.dll Qt6TextToSpeech.dll Qt6Widgets.dll lua54.dll libgcc_s_seh-1.dll libstdc++-6.dll zlib1.dll libwinpthread-1.dll'
-for dll in $STARTUP_DLLS; do
-  src="$(find "$STAGE_DIR/lib" -maxdepth 1 -type f -iname "$dll" | head -n 1)"
-  if [ -n "$src" ]; then
-    mv -f "$src" "$STAGE_DIR/$dll"
-  fi
-done
+collect_dll_closure "$STAGE_DIR" "$STAGE_DIR/QMud.exe"
 
 printf '%s\n' '[Paths]' 'Plugins = qtplugins' > "$STAGE_DIR/qt.conf"
 
@@ -247,6 +393,11 @@ if [ ! -f "$STAGE_DIR/lua/ssl.lua" ]; then
   echo "Error: expected LuaSec top-level module ssl.lua at $LUA_MODULES_PREFIX/ssl.lua, but it was not found." >&2
   exit 1
 fi
+
+PLUGIN_DLLS="$(find "$STAGE_DIR/qtplugins" -type f -iname '*.dll' | sort)"
+MODULE_DLLS="$(find "$STAGE_DIR/lua" "$STAGE_DIR/socket" "$STAGE_DIR/mime" "$STAGE_DIR/ssl" -type f -iname '*.dll' | sort)"
+# shellcheck disable=SC2086
+collect_dll_closure "$STAGE_DIR/lib" $PLUGIN_DLLS $MODULE_DLLS
 
 cmake -E rm -f "$STAGE_ROOT/$PACKAGE_NAME.zip"
 cmake -E chdir "$STAGE_ROOT" cmake -E tar cf "$PACKAGE_NAME.zip" --format=zip "$PACKAGE_NAME"


### PR DESCRIPTION
## Summary

- Upgrade Qt to 6.11.
- Cleanup release packages. Fixes #92 
- Add missing icon for Mac. Fixes #91 
- Mac build is now universal and builds dmg. Fixes #93
- Change default QMUD_HOME for Mac to ~/Documents/QMud. Fixes #93
- Platform/arch QMUD_HOME portability for lua native libs.
- Tighten MUSHclient parity for FlipToNotepad.
- Fix LuaCallbackEngine tests/CI coverage job.
- Update README.

## Scope

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- QMUD_HOME default or Mac is ~/Documents/QMud. Existing directories will need manual moving.
- FlipToNotepad behavior was not identical, breaking some VI workflows.
- All packages are now a LOT leaner.
- Introduced per arch native lib cpath directories so there are no portability conflicts between Linux and Mac for native lua libs.
- We now build .dmg for initial Mac installs so it is the common Mac workflow. .zip bundle is still used by the auto-updater.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

