### PR TITLE
Fix QAction metadata on Mac. Persist and display printing font size and style. Fix Note() color setting via scripting world preferences. Additional parity for Notepads handling. Mark plugins as disabled when they fail to load. Stop hardcoding shortcut text in tooltips.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ set(QMUD_SOURCES
         Accelerators.cpp
         helpers/AliasMatchUtils.cpp
         helpers/HyperlinkActionUtils.cpp
+        helpers/NoteColourUtils.cpp
         helpers/WorldCommandProcessorUtils.cpp
         helpers/LuaExecutionUtils.cpp
         helpers/AccessibleTextUtils.cpp
@@ -270,6 +271,7 @@ set(QMUD_HEADERS
         Accelerators.h
         helpers/AcceleratorUtils.h
         helpers/AliasMatchUtils.h
+        helpers/NoteColourUtils.h
         CommandMappingTypes.h
         helpers/WorldCommandProcessorUtils.h
         ErrorDescriptions.h

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -1955,6 +1955,8 @@ static const struct
     {"ActivityWindowRefreshType",       2                       },
     {"ParenMatchFlags",                 0x0001 | 0x0020 | 0x0040},
     {"PrinterFontSize",                 10                      },
+    {"PrinterFontItalic",               0                       },
+    {"PrinterFontWeight",               400                     },
     {"PrinterLeftMargin",               15                      },
     {"PrinterLinesPerPage",             60                      },
     {"PrinterTopMargin",                15                      },
@@ -13392,13 +13394,26 @@ void AppController::onCommandTriggered(const QString &cmdName)
 		                        : textWindow ? textWindow->windowTitle()
 		                                     : QStringLiteral("QMud");
 
-		const int     printerFontSize  = getGlobalOption(QStringLiteral("PrinterFontSize")).toInt();
-		const int     leftMarginMm     = getGlobalOption(QStringLiteral("PrinterLeftMargin")).toInt();
-		const int     topMarginMm      = getGlobalOption(QStringLiteral("PrinterTopMargin")).toInt();
-		const int     linesPerPagePref = getGlobalOption(QStringLiteral("PrinterLinesPerPage")).toInt();
-		QString       printerFontName  = getGlobalOption(QStringLiteral("PrinterFont")).toString();
+		const int     printerFontSize   = getGlobalOption(QStringLiteral("PrinterFontSize")).toInt();
+		const int     printerFontWeight = getGlobalOption(QStringLiteral("PrinterFontWeight")).toInt();
+		const int     printerFontItalic = getGlobalOption(QStringLiteral("PrinterFontItalic")).toInt();
+		const int     leftMarginMm      = getGlobalOption(QStringLiteral("PrinterLeftMargin")).toInt();
+		const int     topMarginMm       = getGlobalOption(QStringLiteral("PrinterTopMargin")).toInt();
+		const int     linesPerPagePref  = getGlobalOption(QStringLiteral("PrinterLinesPerPage")).toInt();
+		QString       printerFontName   = getGlobalOption(QStringLiteral("PrinterFont")).toString();
 		if (printerFontName.trimmed().isEmpty())
 			printerFontName = QStringLiteral("Courier");
+		const auto printerWeight = static_cast<QFont::Weight>(
+		    qBound(static_cast<int>(QFont::Thin), printerFontWeight, static_cast<int>(QFont::Black)));
+		const auto makePrinterFont = [&](const bool bold = false, const bool underline = false)
+		{
+			QFont font(printerFontName, printerFontSize);
+			font.setWeight(printerWeight);
+			font.setItalic(printerFontItalic != 0);
+			font.setBold(font.bold() || bold);
+			font.setUnderline(underline);
+			return font;
+		};
 
 		QPrinter printer(QPrinter::HighResolution);
 		if (m_hasPrintSetup)
@@ -13435,9 +13450,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 
 		auto       drawHeader = [&](QPainter &painter, const QRect &pageRect, const int pageNumber)
 		{
-			QFont headerFont(printerFontName, printerFontSize);
-			headerFont.setBold(true);
-			headerFont.setUnderline(true);
+			QFont headerFont = makePrinterFont(true, true);
 			painter.setFont(headerFont);
 			const QString timeText =
 			    QDateTime::currentDateTime().toString(QStringLiteral("dddd, MMMM dd, yyyy, h:mm AP"));
@@ -13445,9 +13458,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 			const int     x      = pageRect.left();
 			const int     y      = pageRect.top() + painter.fontMetrics().ascent();
 			painter.drawText(x, y, header);
-			QFont footerFont(printerFontName, printerFontSize);
-			footerFont.setBold(true);
-			footerFont.setUnderline(false);
+			QFont footerFont = makePrinterFont(true);
 			painter.setFont(footerFont);
 			const QString footer  = QStringLiteral("Page %1").arg(pageNumber);
 			const int     footerY = pageRect.bottom() - painter.fontMetrics().descent();
@@ -13459,7 +13470,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 			if (lines.isEmpty())
 				return;
 			QPainter    painter(&printer);
-			const QFont font(printerFontName, printerFontSize);
+			const QFont font = makePrinterFont();
 			painter.setFont(font);
 			const QFontMetrics metrics(font);
 			const int          lineHeight = metrics.lineSpacing();
@@ -13494,7 +13505,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 			if (lines.isEmpty())
 				return;
 			QPainter    painter(&printer);
-			const QFont baseFont(printerFontName, printerFontSize);
+			const QFont baseFont = makePrinterFont();
 			painter.setFont(baseFont);
 			const QFontMetrics baseMetrics(baseFont);
 			const int          lineHeight = baseMetrics.lineSpacing();
@@ -13535,8 +13546,8 @@ void AppController::onCommandTriggered(const QString &cmdName)
 							continue;
 						const QString chunk = entry.text.mid(offset, span.length);
 						QFont         font  = baseFont;
-						font.setBold(span.bold);
-						font.setItalic(span.italic);
+						font.setBold(baseFont.bold() || span.bold);
+						font.setItalic(baseFont.italic() || span.italic);
 						font.setUnderline(span.underline);
 						painter.setFont(font);
 						const QColor fore = span.fore.isValid() ? span.fore : QColor(Qt::black);

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -38,6 +38,7 @@
 #include "WorldView.h"
 #include "dialogs/SpellCheckDialog.h"
 #include "helpers/LuaExecutionUtils.h"
+#include "helpers/MainFrameMdiUtils.h"
 #include "helpers/MiniWindowUtils.h"
 #include "helpers/PluginPathUtils.h"
 #include "helpers/WorldCommandProcessorUtils.h"
@@ -18760,8 +18761,8 @@ static TextChildWindow *findNotepadWindow(const QString &title, WorldRuntime *ow
 	auto *mdi = frame->findChild<QMdiArea *>();
 	if (!mdi)
 		return nullptr;
-	const qulonglong ownerToken           = ownerRuntime ? reinterpret_cast<quintptr>(ownerRuntime) : 0;
-	TextChildWindow *unnamedOwnerFallback = nullptr;
+	const qulonglong ownerToken = ownerRuntime ? reinterpret_cast<quintptr>(ownerRuntime) : 0;
+	const bool       hasOwner   = ownerRuntime || !worldId.isEmpty();
 	for (const QList<QMdiSubWindow *> windows = mdi->subWindowList(QMdiArea::CreationOrder);
 	     QMdiSubWindow *sub : windows)
 	{
@@ -18770,21 +18771,15 @@ static TextChildWindow *findNotepadWindow(const QString &title, WorldRuntime *ow
 			continue;
 		if (text->windowTitle().compare(title, Qt::CaseInsensitive) == 0)
 		{
-			const qulonglong relatedToken = text->property("worldRuntimeToken").toULongLong();
-			if (ownerToken != 0 && relatedToken == ownerToken)
+			const bool matchesOwner =
+			    hasOwner
+			        ? QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(text, ownerToken, worldId, false)
+			        : QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(text, 0, QString(), false);
+			if (matchesOwner)
 				return text;
-			if (ownerToken != 0 && relatedToken != 0 && relatedToken != ownerToken)
-				continue;
-			if (worldId.isEmpty())
-				return text;
-			const QString related = text->property("worldId").toString().trimmed();
-			if (related.compare(worldId, Qt::CaseInsensitive) == 0)
-				return text;
-			if (related.isEmpty() && !unnamedOwnerFallback)
-				unnamedOwnerFallback = text;
 		}
 	}
-	return unnamedOwnerFallback;
+	return nullptr;
 }
 
 static int luaMoveWorldWindow(lua_State *L)

--- a/src/LuaExecutor.cpp
+++ b/src/LuaExecutor.cpp
@@ -60,12 +60,19 @@ LuaBatchDispatchResult ILuaExecutor::dispatchBatch(const LuaBatchDispatchRequest
 	switch (request.kind)
 	{
 	case LuaBatchDispatchKind::NoArgs:
+		result.boolResult  = true;
+		result.hasFunction = false;
 		forEachEngine(
 		    [&](LuaCallbackEngine *engine)
 		    {
-			    static_cast<void>(
-			        engine->callFunctionNoArgs(request.functionName, nullptr, request.defaultResult));
+			    bool       hasFunction = false;
+			    const bool ok =
+			        engine->callFunctionNoArgs(request.functionName, &hasFunction, request.defaultResult);
+			    result.boolResult  = result.boolResult && ok;
+			    result.hasFunction = result.hasFunction || hasFunction;
 		    });
+		result.boolResultValid  = true;
+		result.hasFunctionValid = true;
 		return result;
 	case LuaBatchDispatchKind::HasFunction:
 	{

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -2733,7 +2733,6 @@ bool                 MainWindow::switchToNotepad()
 	const QString          defaultTitle = defaultNotepadTitleForWorld(owner, world);
 
 	QList<QMdiSubWindow *> matchingCandidates;
-	TextChildWindow       *defaultTitleFallback = nullptr;
 	for (QMdiSubWindow *sub : m_mdiArea->subWindowList(QMdiArea::CreationOrder))
 	{
 		auto *text = qobject_cast<TextChildWindow *>(sub);
@@ -2741,14 +2740,10 @@ bool                 MainWindow::switchToNotepad()
 			continue;
 
 		matchingCandidates.append(text);
-		if (!defaultTitleFallback && text->windowTitle().compare(defaultTitle, Qt::CaseInsensitive) == 0)
-			defaultTitleFallback = text;
 	}
 
 	QMdiSubWindow *target = QMudMainFrameMdiUtils::firstWindowMatchingRuntimeIdentity(
 	    matchingCandidates, ownerToken, ownerWorldId, false);
-	if (!target)
-		target = defaultTitleFallback;
 	if (!target)
 	{
 		auto *created = new TextChildWindow(defaultTitle, QString());
@@ -2777,6 +2772,7 @@ bool MainWindow::activateNotepad(const QString &title, WorldRuntime *relatedRunt
 	const qulonglong ownerToken = runtimeOwnerToken(owner);
 	const QString    ownerWorldId =
 	    owner ? owner->worldAttributes().value(QStringLiteral("id")).trimmed() : QString();
+	const bool hasOwner = owner != nullptr;
 	for (QMdiSubWindow *sub : m_mdiArea->subWindowList(QMdiArea::CreationOrder))
 	{
 		auto *text = qobject_cast<TextChildWindow *>(sub);
@@ -2785,25 +2781,14 @@ bool MainWindow::activateNotepad(const QString &title, WorldRuntime *relatedRunt
 		if (text->windowTitle().compare(title, Qt::CaseInsensitive) != 0)
 			continue;
 
-		if (ownerToken != 0)
+		if (hasOwner)
 		{
-			const qulonglong relatedToken = text->property("worldRuntimeToken").toULongLong();
-			if (relatedToken == ownerToken)
-			{
-				m_mdiArea->setActiveSubWindow(text);
-				text->show();
-				text->raise();
-				return true;
-			}
-			if (relatedToken != 0 && relatedToken != ownerToken)
+			if (!QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(text, ownerToken, ownerWorldId, false))
 				continue;
-			if (!ownerWorldId.isEmpty())
-			{
-				if (const QString related = text->property("worldId").toString().trimmed();
-				    !related.isEmpty() && related.compare(ownerWorldId, Qt::CaseInsensitive) != 0)
-					continue;
-			}
 		}
+		else if (!QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(text, 0, QString(), false))
+			continue;
+
 		m_mdiArea->setActiveSubWindow(text);
 		text->show();
 		text->raise();
@@ -2896,40 +2881,26 @@ bool MainWindow::appendToNotepad(const QString &title, const QString &text, cons
 	const qulonglong ownerToken = runtimeOwnerToken(owner);
 	const QString    ownerWorldId =
 	    owner ? owner->worldAttributes().value(QStringLiteral("id")).trimmed() : QString();
-	TextChildWindow *target       = nullptr;
-	TextChildWindow *unnamedMatch = nullptr;
+	const bool       hasOwner = owner != nullptr;
+	TextChildWindow *target   = nullptr;
 	for (QMdiSubWindow *sub : m_mdiArea->subWindowList(QMdiArea::CreationOrder))
 	{
 		auto *textWindow = qobject_cast<TextChildWindow *>(sub);
 		if (!textWindow)
 			continue;
-		if (textWindow->windowTitle().compare(title, Qt::CaseInsensitive) == 0)
-		{
-			const qulonglong relatedToken = textWindow->property("worldRuntimeToken").toULongLong();
-			if (ownerToken != 0 && relatedToken == ownerToken)
-			{
-				target = textWindow;
-				break;
-			}
-			if (ownerToken != 0 && relatedToken != 0 && relatedToken != ownerToken)
-				continue;
-			if (ownerWorldId.isEmpty())
-			{
-				target = textWindow;
-				break;
-			}
-			const QString related = textWindow->property("worldId").toString().trimmed();
-			if (related.compare(ownerWorldId, Qt::CaseInsensitive) == 0)
-			{
-				target = textWindow;
-				break;
-			}
-			if (related.isEmpty() && !unnamedMatch)
-				unnamedMatch = textWindow;
-		}
+		if (textWindow->windowTitle().compare(title, Qt::CaseInsensitive) != 0)
+			continue;
+
+		const bool matchesOwner =
+		    hasOwner ? QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(textWindow, ownerToken,
+		                                                                   ownerWorldId, false)
+		             : QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(textWindow, 0, QString(), false);
+		if (!matchesOwner)
+			continue;
+
+		target = textWindow;
+		break;
 	}
-	if (!target && unnamedMatch)
-		target = unnamedMatch;
 
 	if (!target)
 	{

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -200,6 +200,32 @@ QAction *MainWindow::actionForCommand(const QString &cmdName) const
 	return m_actions.value(cmdName, nullptr);
 }
 
+static void applyExplicitMacMenuRole(QAction *action)
+{
+#ifdef Q_OS_MACOS
+	if (action)
+		action->setMenuRole(QAction::NoRole);
+#else
+	Q_UNUSED(action);
+#endif
+}
+
+static QMenu *addMainFrameMenu(QMenuBar *menuBar, const QString &title)
+{
+	QMenu *menu = menuBar ? menuBar->addMenu(title) : nullptr;
+	if (menu)
+		applyExplicitMacMenuRole(menu->menuAction());
+	return menu;
+}
+
+static QMenu *addMainFrameSubMenu(QMenu *parent, const QString &title)
+{
+	QMenu *menu = parent ? parent->addMenu(title) : nullptr;
+	if (menu)
+		applyExplicitMacMenuRole(menu->menuAction());
+	return menu;
+}
+
 QAction *MainWindow::addActionToMenu(QMenu *menu, const QString &cmdName, const QString &text,
                                      const QKeySequence &shortcut)
 {
@@ -227,7 +253,7 @@ QAction *MainWindow::addActionToMenu(QMenu *menu, const QString &cmdName, const 
 void MainWindow::buildMenus()
 {
 	// File menu
-	m_fileMenu = menuBar()->addMenu(QStringLiteral("&File"));
+	m_fileMenu = addMainFrameMenu(menuBar(), QStringLiteral("&File"));
 	addActionToMenu(m_fileMenu, QStringLiteral("New"), QStringLiteral("&New World...\tCtrl+N"),
 	                QKeySequence::New);
 	addActionToMenu(m_fileMenu, QStringLiteral("Open"), QStringLiteral("&Open World...\tCtrl+O"),
@@ -289,7 +315,7 @@ void MainWindow::buildMenus()
 	addActionToMenu(m_fileMenu, QStringLiteral("ExitClient"), QStringLiteral("E&xit"));
 
 	// Edit menu
-	QMenu *editMenu = menuBar()->addMenu(QStringLiteral("&Edit"));
+	QMenu *editMenu = addMainFrameMenu(menuBar(), QStringLiteral("&Edit"));
 	addActionToMenu(editMenu, QStringLiteral("Undo"), QStringLiteral("&Undo\tCtrl+Z"), QKeySequence::Undo);
 	editMenu->addSeparator();
 	addActionToMenu(editMenu, QStringLiteral("Cut"), QStringLiteral("Cu&t\tCtrl+X"), QKeySequence::Cut);
@@ -350,7 +376,7 @@ void MainWindow::buildMenus()
 	                QStringLiteral("&Refresh Recalled Data"));
 
 	// View menu
-	QMenu *viewMenu    = menuBar()->addMenu(QStringLiteral("&View"));
+	QMenu *viewMenu    = addMainFrameMenu(menuBar(), QStringLiteral("&View"));
 	auto  *viewToolbar = addActionToMenu(viewMenu, QStringLiteral("ViewToolbar"), QStringLiteral("&Toolbar"));
 	viewToolbar->setCheckable(true);
 	viewToolbar->setChecked(true);
@@ -402,7 +428,7 @@ void MainWindow::buildMenus()
 	fullScreen->setCheckable(true);
 
 	// Connection menu
-	QMenu *connectionMenu = menuBar()->addMenu(QStringLiteral("&Connection"));
+	QMenu *connectionMenu = addMainFrameMenu(menuBar(), QStringLiteral("&Connection"));
 	addActionToMenu(connectionMenu, QStringLiteral("QuickConnect"),
 	                QStringLiteral("&Quick Connect...\tCtrl+Alt+Shift+K"),
 	                QKeySequence(QStringLiteral("Ctrl+Alt+Shift+K")));
@@ -426,7 +452,7 @@ void MainWindow::buildMenus()
 	                QStringLiteral("Connect To Worlds &In Startup List"));
 
 	// Input menu
-	QMenu *inputMenu = menuBar()->addMenu(QStringLiteral("&Input"));
+	QMenu *inputMenu = addMainFrameMenu(menuBar(), QStringLiteral("&Input"));
 	addActionToMenu(inputMenu, QStringLiteral("ActivateInputArea"),
 	                QStringLiteral("Activate &Input Area\tTab"), QKeySequence(QStringLiteral("Tab")));
 	inputMenu->addSeparator();
@@ -459,7 +485,7 @@ void MainWindow::buildMenus()
 	addActionToMenu(inputMenu, QStringLiteral("KeyName"), QStringLiteral("&Key Name..."));
 
 	// Display menu
-	QMenu *displayMenu = menuBar()->addMenu(QStringLiteral("&Display"));
+	QMenu *displayMenu = addMainFrameMenu(menuBar(), QStringLiteral("&Display"));
 	addActionToMenu(displayMenu, QStringLiteral("DisplayStart"), QStringLiteral("&Start\tCtrl+Home"),
 	                QKeySequence(QStringLiteral("Ctrl+Home")));
 	addActionToMenu(displayMenu, QStringLiteral("DisplayPageUp"), QStringLiteral("Page &Up\tPageUp"),
@@ -518,8 +544,8 @@ void MainWindow::buildMenus()
 	                QKeySequence(QStringLiteral("Ctrl+Alt+E")));
 
 	// Game / World menu
-	QMenu   *gameMenu               = menuBar()->addMenu(QStringLiteral("&Game"));
-	QMenu   *configureMenu          = gameMenu->addMenu(QStringLiteral("&Configure"));
+	QMenu   *gameMenu               = addMainFrameMenu(menuBar(), QStringLiteral("&Game"));
+	QMenu   *configureMenu          = addMainFrameSubMenu(gameMenu, QStringLiteral("&Configure"));
 	QAction *allConfigurationAction = addActionToMenu(configureMenu, QStringLiteral("Preferences"),
 	                                                  QStringLiteral("All &Configuration...\tAlt+Enter"),
 	                                                  QKeySequence(QStringLiteral("Alt+Return")));
@@ -624,7 +650,7 @@ void MainWindow::buildMenus()
 	                QKeySequence(QStringLiteral("Ctrl+Alt+Shift+D")));
 
 	// Window menu
-	m_windowMenu = menuBar()->addMenu(QStringLiteral("&Window"));
+	m_windowMenu = addMainFrameMenu(menuBar(), QStringLiteral("&Window"));
 	addActionToMenu(m_windowMenu, QStringLiteral("NewWindow"), QStringLiteral("&New Window"));
 	addActionToMenu(m_windowMenu, QStringLiteral("CascadeWindows"), QStringLiteral("&Cascade"));
 	addActionToMenu(m_windowMenu, QStringLiteral("TileWindows"), QStringLiteral("&Tile Horizontally"));
@@ -639,7 +665,7 @@ void MainWindow::buildMenus()
 	connect(m_windowMenu, &QMenu::aboutToShow, this, &MainWindow::updateWindowMenu);
 
 	// Help menu
-	QMenu *helpMenu = menuBar()->addMenu(QStringLiteral("&Help"));
+	QMenu *helpMenu = addMainFrameMenu(menuBar(), QStringLiteral("&Help"));
 	addActionToMenu(helpMenu, QStringLiteral("TipOfTheDay"), QStringLiteral("&Tip Of The Day..."));
 	helpMenu->addSeparator();
 	addActionToMenu(helpMenu, QStringLiteral("GettingStarted"), QStringLiteral("&Getting Started..."));

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -870,45 +870,53 @@ void MainWindow::buildToolbars()
 	// Main and game toolbars now use standalone PNG icons from resources/qmud/res/toolbar/.
 
 	const QHash<QString, QString> tooltipOverrides = {
-	    {QStringLiteral("New"),                  QStringLiteral("New world")                   },
-	    {QStringLiteral("Open"),                 QStringLiteral("Open world")                  },
-	    {QStringLiteral("Save"),                 QStringLiteral("Save world")                  },
-	    {QStringLiteral("Print"),                QStringLiteral("Print")                       },
-	    {QStringLiteral("NotesWorkArea"),        QStringLiteral("Notepad")                     },
-	    {QStringLiteral("Cut"),                  QStringLiteral("Cut")                         },
-	    {QStringLiteral("Copy"),                 QStringLiteral("Copy")                        },
-	    {QStringLiteral("Paste"),                QStringLiteral("Paste")                       },
-	    {QStringLiteral("About"),                QStringLiteral("About")                       },
-	    {QStringLiteral("ContextHelp"),          QStringLiteral("Help")                        },
-	    {QStringLiteral("GameWrapLines"),        QStringLiteral("Line wrap")                   },
-	    {QStringLiteral("LogSession"),           QStringLiteral("Log session (Shift+Ctrl+J)")  },
-	    {QStringLiteral("Connect_Or_Reconnect"), QStringLiteral("Connect / Disconnect")        },
-	    {QStringLiteral("Preferences"),          QStringLiteral("World details (Ctrl+G)")      },
-	    {QStringLiteral("ConfigureTriggers"),    QStringLiteral("Triggers (Shift+Ctrl+8)")     },
-	    {QStringLiteral("ConfigureAliases"),     QStringLiteral("Aliases (Shift+Ctrl+9)")      },
-	    {QStringLiteral("ConfigureTimers"),      QStringLiteral("Timers (Shift+Ctrl+0)")       },
-	    {QStringLiteral("ConfigureOutput"),      QStringLiteral("Output (Alt+5)")              },
-	    {QStringLiteral("ConfigureCommands"),    QStringLiteral("Commands (Alt+0)")            },
-	    {QStringLiteral("ConfigureScripting"),   QStringLiteral("Scripting (Shift+Ctrl+6)")    },
-	    {QStringLiteral("ConfigureNotes"),       QStringLiteral("Notes (Alt+4)")               },
-	    {QStringLiteral("ConfigureVariables"),   QStringLiteral("Variables (Shift+Ctrl+7)")    },
-	    {QStringLiteral("ResetAllTimers"),       QStringLiteral("Reset timers (Shift+Ctrl+T)") },
-	    {QStringLiteral("ReloadScriptFile"),     QStringLiteral("Reload script (Shift+Ctrl+R)")},
-	    {QStringLiteral("AutoSay"),              QStringLiteral("Auto Say (Shift+Ctrl+A)")     },
-	    {QStringLiteral("FreezeOutput"),         QStringLiteral("Pause (Ctrl+Space)")          },
-	    {QStringLiteral("Find"),                 QStringLiteral("Find (Ctrl+F)")               },
-	    {QStringLiteral("FindAgain"),            QStringLiteral("Find again (Shift+Ctrl+F)")   },
-	    {QStringLiteral("FindAgainBackwards"),   QStringLiteral("Find again backwards")        },
-	    {QStringLiteral("World1"),               QStringLiteral("Activates world #1 (Ctrl+1)") },
-	    {QStringLiteral("World2"),               QStringLiteral("Activates world #2 (Ctrl+2)") },
-	    {QStringLiteral("World3"),               QStringLiteral("Activates world #3 (Ctrl+3)") },
-	    {QStringLiteral("World4"),               QStringLiteral("Activates world #4 (Ctrl+4)") },
-	    {QStringLiteral("World5"),               QStringLiteral("Activates world #5 (Ctrl+5)") },
-	    {QStringLiteral("World6"),               QStringLiteral("Activates world #6 (Ctrl+6)") },
-	    {QStringLiteral("World7"),               QStringLiteral("Activates world #7 (Ctrl+7)") },
-	    {QStringLiteral("World8"),               QStringLiteral("Activates world #8 (Ctrl+8)") },
-	    {QStringLiteral("World9"),               QStringLiteral("Activates world #9 (Ctrl+9)") },
-	    {QStringLiteral("World10"),              QStringLiteral("Activates world #10 (Ctrl+0)")}
+	    {QStringLiteral("New"),                  QStringLiteral("New world")           },
+	    {QStringLiteral("Open"),                 QStringLiteral("Open world")          },
+	    {QStringLiteral("Save"),                 QStringLiteral("Save world")          },
+	    {QStringLiteral("Print"),                QStringLiteral("Print")               },
+	    {QStringLiteral("NotesWorkArea"),        QStringLiteral("Notepad")             },
+	    {QStringLiteral("Cut"),                  QStringLiteral("Cut")                 },
+	    {QStringLiteral("Copy"),                 QStringLiteral("Copy")                },
+	    {QStringLiteral("Paste"),                QStringLiteral("Paste")               },
+	    {QStringLiteral("About"),                QStringLiteral("About")               },
+	    {QStringLiteral("ContextHelp"),          QStringLiteral("Help")                },
+	    {QStringLiteral("GameWrapLines"),        QStringLiteral("Line wrap")           },
+	    {QStringLiteral("LogSession"),           QStringLiteral("Log session")         },
+	    {QStringLiteral("Connect_Or_Reconnect"), QStringLiteral("Connect / Disconnect")},
+	    {QStringLiteral("Preferences"),          QStringLiteral("World details")       },
+	    {QStringLiteral("ConfigureTriggers"),    QStringLiteral("Triggers")            },
+	    {QStringLiteral("ConfigureAliases"),     QStringLiteral("Aliases")             },
+	    {QStringLiteral("ConfigureTimers"),      QStringLiteral("Timers")              },
+	    {QStringLiteral("ConfigureOutput"),      QStringLiteral("Output")              },
+	    {QStringLiteral("ConfigureCommands"),    QStringLiteral("Commands")            },
+	    {QStringLiteral("ConfigureScripting"),   QStringLiteral("Scripting")           },
+	    {QStringLiteral("ConfigureNotes"),       QStringLiteral("Notes")               },
+	    {QStringLiteral("ConfigureVariables"),   QStringLiteral("Variables")           },
+	    {QStringLiteral("ResetAllTimers"),       QStringLiteral("Reset timers")        },
+	    {QStringLiteral("ReloadScriptFile"),     QStringLiteral("Reload script")       },
+	    {QStringLiteral("AutoSay"),              QStringLiteral("Auto Say")            },
+	    {QStringLiteral("FreezeOutput"),         QStringLiteral("Pause")               },
+	    {QStringLiteral("Find"),                 QStringLiteral("Find")                },
+	    {QStringLiteral("FindAgainForwards"),    QStringLiteral("Find again")          },
+	    {QStringLiteral("FindAgainBackwards"),   QStringLiteral("Find again backwards")}
+    };
+	const QHash<QString, QString> tooltipShortcutOverrides = {
+	    {QStringLiteral("LogSession"),         QStringLiteral("Shift+Ctrl+J")},
+	    {QStringLiteral("Preferences"),        QStringLiteral("Ctrl+G")      },
+	    {QStringLiteral("ConfigureTriggers"),  QStringLiteral("Shift+Ctrl+8")},
+	    {QStringLiteral("ConfigureAliases"),   QStringLiteral("Shift+Ctrl+9")},
+	    {QStringLiteral("ConfigureTimers"),    QStringLiteral("Shift+Ctrl+0")},
+	    {QStringLiteral("ConfigureOutput"),    QStringLiteral("Alt+5")       },
+	    {QStringLiteral("ConfigureCommands"),  QStringLiteral("Alt+0")       },
+	    {QStringLiteral("ConfigureScripting"), QStringLiteral("Shift+Ctrl+6")},
+	    {QStringLiteral("ConfigureNotes"),     QStringLiteral("Alt+4")       },
+	    {QStringLiteral("ConfigureVariables"), QStringLiteral("Shift+Ctrl+7")},
+	    {QStringLiteral("ResetAllTimers"),     QStringLiteral("Shift+Ctrl+T")},
+	    {QStringLiteral("ReloadScriptFile"),   QStringLiteral("Shift+Ctrl+R")},
+	    {QStringLiteral("AutoSay"),            QStringLiteral("Shift+Ctrl+A")},
+	    {QStringLiteral("FreezeOutput"),       QStringLiteral("Ctrl+Space")  },
+	    {QStringLiteral("Find"),               QStringLiteral("Ctrl+F")      },
+	    {QStringLiteral("FindAgainForwards"),  QStringLiteral("Shift+Ctrl+F")}
     };
 
 	auto prettyName = [](const QString &cmd) -> QString
@@ -941,8 +949,8 @@ void MainWindow::buildToolbars()
 		return text.trimmed();
 	};
 
-	auto applyTooltip = [tooltipOverrides, prettyName, sanitizeTip](QAction *action, const QString &cmdName,
-	                                                                const QString &fallback)
+	auto applyTooltip = [tooltipOverrides, tooltipShortcutOverrides, prettyName,
+	                     sanitizeTip](QAction *action, const QString &cmdName, const QString &fallback)
 	{
 		if (!action)
 			return;
@@ -952,6 +960,9 @@ void MainWindow::buildToolbars()
 		else
 			tip = fallback.isEmpty() ? prettyName(cmdName) : fallback;
 		tip = sanitizeTip(tip);
+		if (tooltipShortcutOverrides.contains(cmdName))
+			tip = QMudMainFrameActionUtils::toolbarTooltipWithShortcut(
+			    tip, tooltipShortcutOverrides.value(cmdName));
 		if (tip.isEmpty())
 			return;
 		action->setToolTip(tip);

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -203,10 +203,12 @@ QAction *MainWindow::actionForCommand(const QString &cmdName) const
 QAction *MainWindow::addActionToMenu(QMenu *menu, const QString &cmdName, const QString &text,
                                      const QKeySequence &shortcut)
 {
-	auto *a = new QAction(text, this);
-	if (!shortcut.isEmpty())
-		a->setShortcut(shortcut);
+	auto              *a                = new QAction(text, this);
+	const QKeySequence resolvedShortcut = QMudMainFrameActionUtils::shortcutForCommand(cmdName, shortcut);
+	if (!resolvedShortcut.isEmpty())
+		a->setShortcut(resolvedShortcut);
 	a->setShortcutContext(Qt::ApplicationShortcut);
+	a->setMenuRole(QMudMainFrameActionUtils::menuRoleForCommand(cmdName));
 	a->setObjectName(cmdName); // preserve original command-name for lookup
 	a->setIconVisibleInMenu(false);
 	QString tipText = text;

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -24,6 +24,7 @@
 #include "LuaHeaders.h"
 #include "MainFrame.h"
 #include "MainFrameActionUtils.h"
+#include "MainFrameMdiUtils.h"
 #include "MainWindowHostResolver.h"
 #include "MiniWindowUtils.h"
 #include "MxpDiagnostics.h"
@@ -233,39 +234,19 @@ namespace
 			    if (!main)
 				    return false;
 
-			    TextChildWindow               *target          = nullptr;
-			    TextChildWindow               *unnamedFallback = nullptr;
-			    const QList<TextChildWindow *> notepads        = main->findChildren<TextChildWindow *>();
+			    TextChildWindow               *target   = nullptr;
+			    const QList<TextChildWindow *> notepads = main->findChildren<TextChildWindow *>();
 			    for (TextChildWindow *text : notepads)
 			    {
 				    if (!text || text->windowTitle().compare(trimmedTitle, Qt::CaseInsensitive) != 0)
 					    continue;
 
-				    const qulonglong relatedToken = text->property("worldRuntimeToken").toULongLong();
-				    if (relatedToken == ownerToken)
+				    if (QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(text, ownerToken, worldId, false))
 				    {
 					    target = text;
 					    break;
 				    }
-				    if (relatedToken != 0)
-					    continue;
-
-				    if (worldId.isEmpty())
-				    {
-					    target = text;
-					    break;
-				    }
-				    const QString related = text->property("worldId").toString().trimmed();
-				    if (related.compare(worldId, Qt::CaseInsensitive) == 0)
-				    {
-					    target = text;
-					    break;
-				    }
-				    if (related.isEmpty() && !unnamedFallback)
-					    unnamedFallback = text;
 			    }
-			    if (!target)
-				    target = unnamedFallback;
 
 			    if (!target)
 				    return false;
@@ -23674,7 +23655,7 @@ void WorldRuntime::continuePendingPluginInstallAsync(QVector<QString> pendingPlu
 		queuePluginCallbackDispatchAsync(
 		    installRequest,
 		    [this, pluginId, pendingPluginIds = std::move(pendingPluginIds)](
-		        const LuaBatchDispatchResult & /*unused*/) mutable
+		        const LuaBatchDispatchResult &dispatchResult) mutable
 		    {
 			    const int currentIndex = findPluginIndex(m_plugins, pluginId);
 			    if (currentIndex < 0)
@@ -23692,6 +23673,19 @@ void WorldRuntime::continuePendingPluginInstallAsync(QVector<QString> pendingPlu
 				    currentPlugin.installPending = false;
 				    invalidatePluginCallbackPresenceCache();
 			    };
+			    if (dispatchResult.boolResultValid && !dispatchResult.boolResult)
+			    {
+				    currentPlugin.enabled = false;
+				    currentPlugin.attributes.insert(QStringLiteral("enabled"), QStringLiteral("0"));
+				    currentPlugin.disableAfterInstall = false;
+				    clearInstallPending();
+				    invalidateLuaCallbackDispatchSnapshot();
+				    if (!m_loadingDocument)
+					    m_worldFileModified = true;
+				    popForceScriptErrorOutputToWorld();
+				    continuePendingPluginInstallAsync(std::move(pendingPluginIds), true);
+				    return;
+			    }
 			    if (!currentPlugin.disableAfterInstall)
 			    {
 				    clearInstallPending();

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -45,6 +45,7 @@
 #include "WorldSocket.h"
 #include "WorldView.h"
 #include "helpers/LuaExecutionUtils.h"
+#include "helpers/NoteColourUtils.h"
 #include "helpers/OutputWrapUtils.h"
 #include "helpers/PluginPathUtils.h"
 #include "scripting/ScriptingErrors.h"
@@ -120,6 +121,9 @@ static int         colourSeqFromAttributes(const QMap<QString, QString> &attribu
 static QString     convertToRegularExpression(const QString &text);
 static void        buildCustomColours(const QList<WorldRuntime::Colour> &colours, QVector<QColor> &normalAnsi,
                                       QVector<QColor> &customText, QVector<QColor> &customBack);
+static int         publicNoteColourIndexFromWorldAttribute(const QString                     &value,
+                                                           const QList<WorldRuntime::Colour> &colours,
+                                                           int                                fallbackPublicIndex);
 static QStringList macroDescriptionList();
 static QStringList keypadNameList();
 
@@ -12034,6 +12038,17 @@ static void buildCustomColours(const QList<WorldRuntime::Colour> &colours, QVect
 	}
 }
 
+static int publicNoteColourIndexFromWorldAttribute(const QString                     &value,
+                                                   const QList<WorldRuntime::Colour> &colours,
+                                                   const int                          fallbackPublicIndex)
+{
+	QVector<QColor> normalAnsi;
+	QVector<QColor> customText;
+	QVector<QColor> customBack;
+	buildCustomColours(colours, normalAnsi, customText, customBack);
+	return QMudNoteColour::publicIndexFromWorldAttribute(value, customText, fallbackPublicIndex);
+}
+
 static long colorToLong(const QColor &color)
 {
 	if (!color.isValid())
@@ -12111,8 +12126,11 @@ void WorldRuntime::setNoteTextColour(int value)
 	qmudAssertObjectThreadAffinity(this, "WorldRuntime::setNoteTextColour");
 	if (value < 0 || value > MAX_CUSTOM)
 		return;
+	if (m_noteTextColour == value - 1 && !m_notesInRgb)
+		return;
 	m_noteTextColour = value - 1;
 	m_notesInRgb     = false;
+	invalidateLuaCallbackDispatchSnapshot();
 }
 
 long WorldRuntime::noteColourFore() const
@@ -14604,9 +14622,13 @@ void WorldRuntime::outputAnsiText(const QString &text, bool note)
 	QColor defaultBack = parseColorValue(m_worldAttributes.value(QStringLiteral("output_background_colour")));
 	if (note)
 	{
-		const QColor noteFore = parseColorValue(m_worldAttributes.value(QStringLiteral("note_text_colour")));
-		if (noteFore.isValid())
-			defaultFore = noteFore;
+		const auto colourFromLong = [](const long value) -> QColor
+		{
+			return {static_cast<int>(value & 0xFF), static_cast<int>((value >> 8) & 0xFF),
+			        static_cast<int>((value >> 16) & 0xFF)};
+		};
+		defaultFore = colourFromLong(noteColourFore());
+		defaultBack = colourFromLong(noteColourBack());
 	}
 	if (!defaultFore.isValid())
 		defaultFore = normalAnsi.value(7);
@@ -15956,6 +15978,9 @@ void WorldRuntime::applyFromDocument(const WorldDocument &doc)
 			rc.attributes.insert(QStringLiteral("seq_index"), QString::number(seq - 1));
 		m_colours.push_back(rc);
 	}
+	setNoteTextColour(
+	    publicNoteColourIndexFromWorldAttribute(m_worldAttributes.value(QStringLiteral("note_text_colour")),
+	                                            m_colours, QMudNoteColour::kDefaultPublicIndex));
 	m_keypadEntries.clear();
 	const QStringList keypadNames = keypadNameList();
 	for (const auto &k : doc.keypadEntries())
@@ -16219,6 +16244,11 @@ void WorldRuntime::setWorldAttribute(const QString &key, const QString &value)
 		normalizedValue = normalizePathForRuntime(normalizedValue);
 	if (key == QStringLiteral("auto_log_file_name"))
 		normalizedValue = normalizeAutoLogFileNameValue(normalizedValue);
+	if (key == QStringLiteral("note_text_colour"))
+	{
+		const int fallbackIndex = QMudNoteColour::publicIndexFromRuntimeIndex(m_noteTextColour);
+		setNoteTextColour(publicNoteColourIndexFromWorldAttribute(normalizedValue, m_colours, fallbackIndex));
+	}
 	const auto existing = m_worldAttributes.constFind(key);
 	if (existing != m_worldAttributes.constEnd() && existing.value() == normalizedValue)
 	{

--- a/src/dialogs/GlobalPreferencesDialog.cpp
+++ b/src/dialogs/GlobalPreferencesDialog.cpp
@@ -282,7 +282,7 @@ namespace
 
 	QString preferredQmudHomeRelativePath(const QString &value)
 	{
-		const QString normalized = storagePath(value);
+		QString normalized = storagePath(value);
 		if (normalized.isEmpty())
 			return normalized;
 
@@ -290,7 +290,7 @@ namespace
 		if (!app)
 			return normalized;
 
-		const QString absolute = QDir::cleanPath(app->makeAbsolutePath(normalized));
+		QString       absolute = QDir::cleanPath(app->makeAbsolutePath(normalized));
 		const QString qmudHome = qmudHomeDirectory(app);
 		if (qmudHome.isEmpty())
 			return absolute;
@@ -760,6 +760,8 @@ QWidget *GlobalPreferencesDialog::buildPrintingPage()
 	m_printerFontLabel = new QLabel(QStringLiteral("Font name"));
 	registerLabel(QStringLiteral("PrinterFont"), m_printerFontLabel);
 	layout->addWidget(m_printerFontLabel);
+	m_printerFontStyleLabel = new QLabel(QStringLiteral("10 pt. Regular"));
+	layout->addWidget(m_printerFontStyleLabel);
 
 	auto *grid = new QGridLayout;
 	grid->addWidget(new QLabel(QStringLiteral("Top margin:")), 0, 0, Qt::AlignRight);
@@ -792,12 +794,18 @@ QWidget *GlobalPreferencesDialog::buildPrintingPage()
 		                 QFont current(m_printerFontLabel->text());
 		                 if (m_printerFontSize > 0)
 			                 current.setPointSize(m_printerFontSize);
+		                 if (m_printerFontWeight > 0)
+			                 current.setWeight(static_cast<QFont::Weight>(m_printerFontWeight));
+		                 current.setItalic(m_printerFontItalic != 0);
 		                 QFont chosen =
 		                     QFontDialog::getFont(&ok, current, this, QStringLiteral("Select Printer Font"));
 		                 if (!ok)
 			                 return;
 		                 m_printerFontLabel->setText(chosen.family());
-		                 m_printerFontSize = chosen.pointSize();
+		                 m_printerFontSize   = chosen.pointSize();
+		                 m_printerFontWeight = chosen.weight();
+		                 m_printerFontItalic = chosen.italic() ? 1 : 0;
+		                 updatePrinterFontStyleLabel();
 	                 });
 	return page;
 }
@@ -1721,7 +1729,10 @@ void GlobalPreferencesDialog::loadPreferences()
 
 	if (m_printerFontLabel)
 		m_printerFontLabel->setText(app->getGlobalOption(QStringLiteral("PrinterFont")).toString());
-	m_printerFontSize = app->getGlobalOption(QStringLiteral("PrinterFontSize")).toInt();
+	m_printerFontSize   = app->getGlobalOption(QStringLiteral("PrinterFontSize")).toInt();
+	m_printerFontWeight = app->getGlobalOption(QStringLiteral("PrinterFontWeight")).toInt();
+	m_printerFontItalic = app->getGlobalOption(QStringLiteral("PrinterFontItalic")).toInt();
+	updatePrinterFontStyleLabel();
 
 	m_outputFontHeight = app->getGlobalOption(QStringLiteral("DefaultOutputFontHeight")).toInt();
 	m_inputFontHeight  = app->getGlobalOption(QStringLiteral("DefaultInputFontHeight")).toInt();
@@ -1814,6 +1825,13 @@ void GlobalPreferencesDialog::refreshUpdateCheckControlsEnabledState() const
 		m_checkNowButton->setEnabled(m_updateMechanismAvailable);
 }
 
+void GlobalPreferencesDialog::updatePrinterFontStyleLabel() const
+{
+	if (m_printerFontStyleLabel)
+		m_printerFontStyleLabel->setText(
+		    fontStyleSummary(m_printerFontSize, m_printerFontWeight, m_printerFontItalic != 0));
+}
+
 bool GlobalPreferencesDialog::applyPreferences()
 {
 	AppController *app = AppController::instance();
@@ -1900,6 +1918,8 @@ bool GlobalPreferencesDialog::applyPreferences()
 	app->setGlobalOptionInt(QStringLiteral("ActivityWindowRefreshInterval"), m_activityPeriod->value());
 
 	app->setGlobalOptionInt(QStringLiteral("PrinterFontSize"), m_printerFontSize);
+	app->setGlobalOptionInt(QStringLiteral("PrinterFontWeight"), m_printerFontWeight);
+	app->setGlobalOptionInt(QStringLiteral("PrinterFontItalic"), m_printerFontItalic);
 	app->setGlobalOptionInt(QStringLiteral("DefaultOutputFontHeight"), m_outputFontHeight);
 	app->setGlobalOptionInt(QStringLiteral("DefaultInputFontHeight"), m_inputFontHeight);
 	app->setGlobalOptionInt(QStringLiteral("DefaultInputFontWeight"), m_inputFontWeight);

--- a/src/dialogs/GlobalPreferencesDialog.h
+++ b/src/dialogs/GlobalPreferencesDialog.h
@@ -10,6 +10,7 @@
 #define QMUD_GLOBALPREFERENCESDIALOG_H
 
 #include <QDialog>
+#include <QFont>
 #include <QHash>
 #include <QVector>
 
@@ -69,7 +70,10 @@ class GlobalPreferencesDialog : public QDialog
 
 		QPushButton                *m_printerFontButton{nullptr};
 		QLabel                     *m_printerFontLabel{nullptr};
+		QLabel                     *m_printerFontStyleLabel{nullptr};
 		int                         m_printerFontSize{0};
+		int                         m_printerFontWeight{QFont::Normal};
+		int                         m_printerFontItalic{0};
 		QSpinBox                   *m_printerTopMargin{nullptr};
 		QSpinBox                   *m_printerLeftMargin{nullptr};
 		QSpinBox                   *m_printerLinesPerPage{nullptr};
@@ -213,6 +217,10 @@ class GlobalPreferencesDialog : public QDialog
 		 * @brief Applies enabled/disabled state for update-check controls.
 		 */
 		void                        refreshUpdateCheckControlsEnabledState() const;
+		/**
+		 * @brief Updates printer font style summary from stored dialog state.
+		 */
+		void                        updatePrinterFontStyleLabel() const;
 
 		/**
 		 * @brief Creates a small color swatch button control.
@@ -275,7 +283,7 @@ class GlobalPreferencesDialog : public QDialog
 		/**
 		 * @brief Converts legacy color-ref integer to QColor.
 		 * @param colorRef Legacy COLORREF value.
-		 * @return Converted colour value.
+		 * @return Converted color value.
 		 */
 		static QColor               colorFromColorRef(int colorRef);
 		/**

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -20,6 +20,7 @@
 #include "dialogs/WorldAliasDialog.h"
 #include "dialogs/WorldTimerDialog.h"
 #include "dialogs/WorldTriggerDialog.h"
+#include "helpers/NoteColourUtils.h"
 #include "scripting/ScriptingErrors.h"
 
 #include <QApplication>
@@ -716,8 +717,8 @@ static void browseSoundFile(WorldRuntime *runtime, QWidget *parent, QLineEdit *t
 	const QString startDir    = runtime ? runtime->fileBrowsingDirectory() : QString();
 	const QString initialPath = start.isEmpty() ? startDir : start;
 	const QString fileName    = QFileDialog::getOpenFileName(
-        parent, QStringLiteral("Select sound to play"), initialPath,
-        QStringLiteral("Waveaudio files (*.wav);;MIDI files (*.mid);;Sequencer files (*.rmi)"));
+	    parent, QStringLiteral("Select sound to play"), initialPath,
+	    QStringLiteral("Waveaudio files (*.wav);;MIDI files (*.mid);;Sequencer files (*.rmi)"));
 	if (!fileName.isEmpty())
 	{
 		if (runtime)
@@ -1771,11 +1772,10 @@ void WorldPreferencesDialog::accept()
 			                             QString::number(m_scriptReloadOption->currentData().toInt()));
 		if (m_scriptTextColour && m_scriptTextColour->currentIndex() >= 0)
 		{
-			int noteValue = m_scriptTextColour->currentIndex() - 1;
-			if (noteValue < 0)
-				noteValue = WorldRuntime::kSameColour;
-			const QString encoded = fromColourRef(noteValue).name(QColor::HexRgb);
+			const int     notePublicIndex = qBound(0, m_scriptTextColour->currentIndex(), MAX_CUSTOM);
+			const QString encoded         = QMudNoteColour::worldAttributeFromPublicIndex(notePublicIndex);
 			m_runtime->setWorldAttribute(QStringLiteral("note_text_colour"), encoded);
+			m_runtime->setNoteTextColour(notePublicIndex);
 		}
 		if (m_warnIfScriptingInactive)
 			m_runtime->setWorldAttribute(QStringLiteral("warn_if_scripting_inactive"),
@@ -5700,8 +5700,13 @@ void WorldPreferencesDialog::buildUi()
 		m_echoColour->setItemText(itemIndex, text.isEmpty() ? fallback : text);
 		if (m_scriptTextColour && index >= 0 && index < m_scriptTextColour->count())
 		{
-			const QString scriptFallback = QStringLiteral("Custom%1").arg(index + 1);
-			m_scriptTextColour->setItemText(index, text.isEmpty() ? scriptFallback : text);
+			const int     scriptItemIndex = index + 1;
+			const QString scriptFallback  = QStringLiteral("Custom%1").arg(scriptItemIndex);
+			if (scriptItemIndex < m_scriptTextColour->count())
+			{
+				m_scriptTextColour->setItemText(scriptItemIndex, text.isEmpty() ? scriptFallback : text);
+				updateScriptNoteColourItems();
+			}
 		}
 	};
 	for (int i = 0; i < m_customColourNames.size(); ++i)
@@ -6093,6 +6098,7 @@ void WorldPreferencesDialog::buildUi()
 			name = QStringLiteral("Custom%1").arg(i + 1);
 		m_scriptTextColour->addItem(name);
 	}
+	updateScriptNoteColourItems();
 	m_scriptTextColour->setFixedWidth(120);
 	connect(m_scriptTextColour, qOverload<int>(&QComboBox::currentIndexChanged), this,
 	        [this](const int) { updateScriptNoteSwatches(); });
@@ -6264,7 +6270,7 @@ void WorldPreferencesDialog::buildUi()
 			        AppController *app              = AppController::instance();
 			        const QString  resolvedFileName = app ? app->makeAbsolutePath(fileName) : fileName;
 			        const QString  editorWindowName =
-                        m_editorWindowName ? m_editorWindowName->text().trimmed() : QString();
+			            m_editorWindowName ? m_editorWindowName->text().trimmed() : QString();
 			        const auto tryRaiseConfiguredEditorWindow = [&]
 			        {
 				        if (editorWindowName.isEmpty())
@@ -7176,8 +7182,8 @@ void WorldPreferencesDialog::buildUi()
 	// Printing
 	auto *printingLayout     = new QVBoxLayout(printingPage);
 	auto  buildPrintingGroup = [](const QString &title, QVector<QCheckBox *> &boldChecks,
-                                 QVector<QCheckBox *> &italicChecks, QVector<QCheckBox *> &underlineChecks,
-                                 QWidget *parent) -> QGroupBox *
+	                              QVector<QCheckBox *> &italicChecks, QVector<QCheckBox *> &underlineChecks,
+	                              QWidget *parent) -> QGroupBox *
 	{
 		static const QStringList colours = {QStringLiteral("Black"), QStringLiteral("Red"),
 		                                    QStringLiteral("Green"), QStringLiteral("Yellow"),
@@ -7415,7 +7421,7 @@ void WorldPreferencesDialog::buildUi()
 	        {
 		        const QString startDir = m_runtime ? m_runtime->fileBrowsingDirectory() : QString();
 		        const QString dirName  = QFileDialog::getExistingDirectory(
-                    this, QStringLiteral("Save chat files folder"), startDir);
+		            this, QStringLiteral("Save chat files folder"), startDir);
 		        if (!dirName.isEmpty())
 		        {
 			        if (m_runtime)
@@ -8910,8 +8916,8 @@ void WorldPreferencesDialog::buildUi()
 	const int      treeHeight = rowHeight * treeItems + (m_pageTree->frameWidth() * 2) + 12;
 	const QMargins margins    = layout->contentsMargins();
 	const int      minHeight  = treeHeight + buttons->sizeHint().height() + margins.top() + margins.bottom() +
-	                      (layout->spacing() * 2);
-	const int minHeightWithPadding = minHeight + ((minHeight * 2) / 10);
+	                            (layout->spacing() * 2);
+	const int      minHeightWithPadding = minHeight + ((minHeight * 2) / 10);
 	setMinimumHeight(qMax(minHeightWithPadding, minimumHeight()));
 	int baseWidth = qMax(minimumWidth(), sizeHint().width());
 	baseWidth += (baseWidth * 1) / 20;
@@ -9067,6 +9073,7 @@ void WorldPreferencesDialog::populateCustomColours()
 		setSwatchButtonColour(m_customTextSwatches.value(i), textColours[i]);
 		setSwatchButtonColour(m_customBackSwatches.value(i), backColours[i]);
 	}
+	updateScriptNoteColourItems();
 }
 
 void WorldPreferencesDialog::populateLogging() const
@@ -9595,29 +9602,18 @@ void WorldPreferencesDialog::populateScripting() const
 	}
 	if (m_scriptTextColour)
 	{
-		const QString raw   = attrs.value(QStringLiteral("note_text_colour"));
-		bool          ok    = false;
-		int           value = raw.toInt(&ok);
-		if (!ok)
+		QVector<QColor> customTextColours;
+		if (m_customTextSwatches.size() >= MAX_CUSTOM)
 		{
-			const QColor decoded = parseColourValue(raw);
-			if (decoded.isValid())
-			{
-				value = static_cast<int>(toColourRef(decoded));
-				ok    = true;
-			}
+			customTextColours.reserve(MAX_CUSTOM);
+			for (int i = 0; i < MAX_CUSTOM; ++i)
+				customTextColours.push_back(swatchButtonColour(m_customTextSwatches.value(i)));
 		}
-		int index = 0;
-		if (ok)
-		{
-			if (value == WorldRuntime::kSameColour || value < 0)
-				index = 0;
-			else
-				index = value + 1;
-		}
-		else
-			index = 5;
-		const int maxIndex = m_scriptTextColour->count() - 1;
+		const QString raw      = attrs.value(QStringLiteral("note_text_colour"));
+		int           index    = customTextColours.size() == MAX_CUSTOM
+		                             ? QMudNoteColour::publicIndexFromWorldAttribute(raw, customTextColours)
+		                             : QMudNoteColour::publicIndexFromWorldAttribute(raw);
+		const int     maxIndex = m_scriptTextColour->count() - 1;
 		if (maxIndex >= 0)
 		{
 			index = qBound(0, index, maxIndex);
@@ -9680,6 +9676,7 @@ void WorldPreferencesDialog::updateScriptNoteSwatches() const
 {
 	if (!m_scriptTextColour || !m_scriptTextSwatch || !m_scriptBackSwatch)
 		return;
+	updateScriptNoteColourItems();
 	const int  index = m_scriptTextColour->currentIndex() - 1;
 	const bool valid =
 	    index >= 0 && index < m_customTextSwatches.size() && index < m_customBackSwatches.size();
@@ -9693,6 +9690,35 @@ void WorldPreferencesDialog::updateScriptNoteSwatches() const
 	}
 	setSwatchButtonColour(m_scriptTextSwatch, swatchButtonColour(m_customTextSwatches.value(index)));
 	setSwatchButtonColour(m_scriptBackSwatch, swatchButtonColour(m_customBackSwatches.value(index)));
+}
+
+void WorldPreferencesDialog::updateScriptNoteColourItems() const
+{
+	if (!m_scriptTextColour)
+		return;
+
+	m_scriptTextColour->setItemData(0, QVariant(), Qt::ForegroundRole);
+	m_scriptTextColour->setItemData(0, QVariant(), Qt::BackgroundRole);
+	for (int i = 0; i < MAX_CUSTOM; ++i)
+	{
+		const int itemIndex = i + 1;
+		if (itemIndex >= m_scriptTextColour->count())
+			break;
+		if (i >= m_customTextSwatches.size() || i >= m_customBackSwatches.size())
+			continue;
+
+		QColor foreground = swatchButtonColour(m_customTextSwatches.value(i));
+		QColor background = swatchButtonColour(m_customBackSwatches.value(i));
+		if (!foreground.isValid() || !background.isValid())
+			continue;
+		if (foreground == background)
+		{
+			foreground = Qt::black;
+			background = Qt::white;
+		}
+		m_scriptTextColour->setItemData(itemIndex, foreground, Qt::ForegroundRole);
+		m_scriptTextColour->setItemData(itemIndex, background, Qt::BackgroundRole);
+	}
 }
 
 void WorldPreferencesDialog::calculateMemoryUsage(const bool allowProgress)

--- a/src/dialogs/WorldPreferencesDialog.h
+++ b/src/dialogs/WorldPreferencesDialog.h
@@ -282,6 +282,10 @@ class WorldPreferencesDialog : public QDialog
 		 */
 		void                          updateScriptNoteSwatches() const;
 		/**
+		 * @brief Updates scripting note colour combo item roles from custom colours.
+		 */
+		void                          updateScriptNoteColourItems() const;
+		/**
 		 * @brief Recalculates memory usage estimates for scripts/rules.
 		 * @param allowProgress Show progress UI for expensive runs when `true`.
 		 */

--- a/src/helpers/MainFrameActionUtils.cpp
+++ b/src/helpers/MainFrameActionUtils.cpp
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
  *
  * File: MainFrameActionUtils.cpp
- * Role: Pure helpers for action ids/tooltips used by main-frame world-slot toolbar wiring.
+ * Role: Pure helpers for main-frame action ids, tooltips, and platform menu policy.
  */
 
 #include "MainFrameActionUtils.h"
@@ -24,6 +24,22 @@ namespace QMudMainFrameActionUtils
 		if (slot == 10)
 			return QStringLiteral("Activates world #10 (Ctrl+0)");
 		return QStringLiteral("Activates world #%1").arg(slot);
+	}
+
+	QAction::MenuRole menuRoleForCommand(const QString &commandName)
+	{
+		if (commandName == QStringLiteral("ExitClient"))
+			return QAction::QuitRole;
+		if (commandName == QStringLiteral("QuitFromWorld"))
+			return QAction::NoRole;
+		return QAction::TextHeuristicRole;
+	}
+
+	QKeySequence shortcutForCommand(const QString &commandName, const QKeySequence &configuredShortcut)
+	{
+		if (commandName == QStringLiteral("ExitClient") && configuredShortcut.isEmpty())
+			return {QKeySequence::Quit};
+		return configuredShortcut;
 	}
 
 	bool shouldAttemptIncomingLineTaskbarFlash(const bool worldFlashEnabled, const bool appFocused)

--- a/src/helpers/MainFrameActionUtils.cpp
+++ b/src/helpers/MainFrameActionUtils.cpp
@@ -30,9 +30,14 @@ namespace QMudMainFrameActionUtils
 	{
 		if (commandName == QStringLiteral("ExitClient"))
 			return QAction::QuitRole;
+#ifdef Q_OS_MACOS
+		Q_UNUSED(commandName);
+		return QAction::NoRole;
+#else
 		if (commandName == QStringLiteral("QuitFromWorld"))
 			return QAction::NoRole;
 		return QAction::TextHeuristicRole;
+#endif
 	}
 
 	QKeySequence shortcutForCommand(const QString &commandName, const QKeySequence &configuredShortcut)

--- a/src/helpers/MainFrameActionUtils.cpp
+++ b/src/helpers/MainFrameActionUtils.cpp
@@ -20,9 +20,11 @@ namespace QMudMainFrameActionUtils
 	QString worldButtonTooltipForSlot(const int slot)
 	{
 		if (slot >= 1 && slot <= 9)
-			return QStringLiteral("Activates world #%1 (Ctrl+%1)").arg(slot);
+			return toolbarTooltipWithShortcut(QStringLiteral("Activates world #%1").arg(slot),
+			                                  QStringLiteral("Ctrl+%1").arg(slot));
 		if (slot == 10)
-			return QStringLiteral("Activates world #10 (Ctrl+0)");
+			return toolbarTooltipWithShortcut(QStringLiteral("Activates world #10"),
+			                                  QStringLiteral("Ctrl+0"));
 		return QStringLiteral("Activates world #%1").arg(slot);
 	}
 
@@ -45,6 +47,15 @@ namespace QMudMainFrameActionUtils
 		if (commandName == QStringLiteral("ExitClient") && configuredShortcut.isEmpty())
 			return {QKeySequence::Quit};
 		return configuredShortcut;
+	}
+
+	QString toolbarTooltipWithShortcut(const QString &label, const QString &portableShortcut)
+	{
+		const QKeySequence shortcut = QKeySequence::fromString(portableShortcut, QKeySequence::PortableText);
+		const QString      nativeShortcut = shortcut.toString(QKeySequence::NativeText);
+		if (nativeShortcut.isEmpty())
+			return label;
+		return QStringLiteral("%1 (%2)").arg(label, nativeShortcut);
 	}
 
 	bool shouldAttemptIncomingLineTaskbarFlash(const bool worldFlashEnabled, const bool appFocused)

--- a/src/helpers/MainFrameActionUtils.h
+++ b/src/helpers/MainFrameActionUtils.h
@@ -3,11 +3,14 @@
  * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
  *
  * File: MainFrameActionUtils.h
- * Role: Pure helpers for action ids/tooltips used by main-frame world-slot toolbar wiring.
+ * Role: Pure helpers for main-frame action ids, tooltips, and platform menu policy.
  */
 
 #ifndef QMUD_MAINFRAMEACTIONUTILS_H
 #define QMUD_MAINFRAMEACTIONUTILS_H
+
+#include <QAction>
+#include <QKeySequence>
 
 class QString;
 
@@ -18,28 +21,42 @@ namespace QMudMainFrameActionUtils
 	 * @param slot 1-based slot index.
 	 * @return Command name used by action dispatch.
 	 */
-	QString            worldCommandNameForSlot(int slot);
+	QString                         worldCommandNameForSlot(int slot);
 
 	/**
 	 * @brief Builds user-facing toolbar tooltip text for one world slot.
 	 * @param slot 1-based slot index.
 	 * @return Tooltip string including shortcut hint when available.
 	 */
-	QString            worldButtonTooltipForSlot(int slot);
+	QString                         worldButtonTooltipForSlot(int slot);
+	/**
+	 * @brief Resolves native menu role for a main-frame command action.
+	 * @param commandName Command identifier.
+	 * @return Qt menu role used for platform menu integration.
+	 */
+	[[nodiscard]] QAction::MenuRole menuRoleForCommand(const QString &commandName);
+	/**
+	 * @brief Resolves keyboard shortcut for a main-frame command action.
+	 * @param commandName Command identifier.
+	 * @param configuredShortcut Shortcut explicitly assigned by caller.
+	 * @return Shortcut that should be installed on the action.
+	 */
+	[[nodiscard]] QKeySequence shortcutForCommand(const QString      &commandName,
+	                                              const QKeySequence &configuredShortcut = QKeySequence());
 	/**
 	 * @brief Returns whether incoming server line should attempt taskbar flash.
 	 * @param worldFlashEnabled `true` when world flash option is enabled.
 	 * @param appFocused `true` when QMud currently has application focus.
 	 * @return `true` when runtime should attempt flash request.
 	 */
-	[[nodiscard]] bool shouldAttemptIncomingLineTaskbarFlash(bool worldFlashEnabled, bool appFocused);
+	[[nodiscard]] bool         shouldAttemptIncomingLineTaskbarFlash(bool worldFlashEnabled, bool appFocused);
 	/**
 	 * @brief Resolves app-focused state for taskbar flash gating from Qt/main-window focus signals.
 	 * @param qtAppFocused `true` when Qt reports ApplicationActive.
 	 * @param windowFocused `true` when main-window focus tracker reports focused.
 	 * @return `true` when flash logic should treat app as focused.
 	 */
-	[[nodiscard]] bool resolveIncomingLineFocusForFlash(bool qtAppFocused, bool windowFocused);
+	[[nodiscard]] bool         resolveIncomingLineFocusForFlash(bool qtAppFocused, bool windowFocused);
 	/**
 	 * @brief Resolves app-focused state for activity-sound gating from Qt/main-window focus signals.
 	 * @param qtAppFocused `true` when Qt reports ApplicationActive.

--- a/src/helpers/MainFrameActionUtils.h
+++ b/src/helpers/MainFrameActionUtils.h
@@ -44,40 +44,47 @@ namespace QMudMainFrameActionUtils
 	[[nodiscard]] QKeySequence shortcutForCommand(const QString      &commandName,
 	                                              const QKeySequence &configuredShortcut = QKeySequence());
 	/**
+	 * @brief Builds toolbar tooltip text with a platform-native shortcut suffix.
+	 * @param label User-facing tooltip label.
+	 * @param portableShortcut Shortcut in Qt portable text form.
+	 * @return Tooltip label with native shortcut hint appended when available.
+	 */
+	[[nodiscard]] QString toolbarTooltipWithShortcut(const QString &label, const QString &portableShortcut);
+	/**
 	 * @brief Returns whether incoming server line should attempt taskbar flash.
 	 * @param worldFlashEnabled `true` when world flash option is enabled.
 	 * @param appFocused `true` when QMud currently has application focus.
 	 * @return `true` when runtime should attempt flash request.
 	 */
-	[[nodiscard]] bool         shouldAttemptIncomingLineTaskbarFlash(bool worldFlashEnabled, bool appFocused);
+	[[nodiscard]] bool    shouldAttemptIncomingLineTaskbarFlash(bool worldFlashEnabled, bool appFocused);
 	/**
 	 * @brief Resolves app-focused state for taskbar flash gating from Qt/main-window focus signals.
 	 * @param qtAppFocused `true` when Qt reports ApplicationActive.
 	 * @param windowFocused `true` when main-window focus tracker reports focused.
 	 * @return `true` when flash logic should treat app as focused.
 	 */
-	[[nodiscard]] bool         resolveIncomingLineFocusForFlash(bool qtAppFocused, bool windowFocused);
+	[[nodiscard]] bool    resolveIncomingLineFocusForFlash(bool qtAppFocused, bool windowFocused);
 	/**
 	 * @brief Resolves app-focused state for activity-sound gating from Qt/main-window focus signals.
 	 * @param qtAppFocused `true` when Qt reports ApplicationActive.
 	 * @param windowFocused `true` when main-window focus tracker reports focused.
 	 * @return `true` when sound logic should treat app as focused.
 	 */
-	[[nodiscard]] bool resolveIncomingLineFocusForActivitySound(bool qtAppFocused, bool windowFocused);
+	[[nodiscard]] bool    resolveIncomingLineFocusForActivitySound(bool qtAppFocused, bool windowFocused);
 	/**
 	 * @brief Returns whether main window should issue a background flash request now.
 	 * @param appFocused `true` when QMud currently has application focus.
 	 * @param flashAlreadyRequested `true` when background session has already requested flash.
 	 * @return `true` when a new flash request should be issued.
 	 */
-	[[nodiscard]] bool shouldRequestBackgroundTaskbarFlash(bool appFocused, bool flashAlreadyRequested);
+	[[nodiscard]] bool    shouldRequestBackgroundTaskbarFlash(bool appFocused, bool flashAlreadyRequested);
 	/**
 	 * @brief Returns whether focus transition should reset background flash latch.
 	 * @param previousFocused Previous application focus state.
 	 * @param currentFocused Current application focus state.
 	 * @return `true` when focus state changed and latch should reset.
 	 */
-	[[nodiscard]] bool shouldResetBackgroundFlashLatch(bool previousFocused, bool currentFocused);
+	[[nodiscard]] bool    shouldResetBackgroundFlashLatch(bool previousFocused, bool currentFocused);
 } // namespace QMudMainFrameActionUtils
 
 #endif // QMUD_MAINFRAMEACTIONUTILS_H

--- a/src/helpers/NoteColourUtils.cpp
+++ b/src/helpers/NoteColourUtils.cpp
@@ -1,0 +1,135 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: NoteColourUtils.cpp
+ * Role: MUSHclient-compatible note colour option encoding helpers.
+ */
+
+#include "helpers/NoteColourUtils.h"
+
+#include "WorldOptions.h"
+
+#include <QColor>
+
+namespace
+{
+	constexpr long kSameColourPackedValue = 0x00FFFFFF;
+
+	struct ParsedNoteColour
+	{
+			long   packed{0};
+			QColor rgb;
+			bool   valid{false};
+	};
+
+	/**
+	 * @brief Packs RGB into MUSHclient COLORREF order.
+	 * @param colour Qt RGB color.
+	 * @return COLORREF-style packed value.
+	 */
+	[[nodiscard]] long colourRefFromQColor(const QColor &colour)
+	{
+		return (static_cast<long>(colour.blue()) << 16) | (static_cast<long>(colour.green()) << 8) |
+		       static_cast<long>(colour.red());
+	}
+
+	/**
+	 * @brief Converts COLORREF-style value to a Qt color.
+	 * @param value COLORREF-style packed value.
+	 * @return Qt RGB color.
+	 */
+	[[nodiscard]] QColor qColorFromColourRef(const long value)
+	{
+		return {static_cast<int>(value & 0xFF), static_cast<int>((value >> 8) & 0xFF),
+		        static_cast<int>((value >> 16) & 0xFF)};
+	}
+
+	/**
+	 * @brief Clamps public note color index to the supported MUSHclient range.
+	 * @param publicIndex Public note color index.
+	 * @return Clamped public note color index.
+	 */
+	[[nodiscard]] int clampPublicIndex(const int publicIndex)
+	{
+		return qBound(0, publicIndex, MAX_CUSTOM);
+	}
+
+	/**
+	 * @brief Parses a persisted note-color value as either MUSH COLORREF or Qt RGB text.
+	 * @param value Persisted world attribute value.
+	 * @return Parsed color information.
+	 */
+	[[nodiscard]] ParsedNoteColour parseNoteColourValue(const QString &value)
+	{
+		const QString trimmed = value.trimmed();
+		if (trimmed.isEmpty())
+			return {};
+
+		bool ok     = false;
+		long packed = trimmed.toLong(&ok, 0);
+		if (ok)
+			return {packed, qColorFromColourRef(packed), true};
+
+		const QColor colour(trimmed);
+		if (!colour.isValid())
+			return {};
+		return {colourRefFromQColor(colour), colour, true};
+	}
+
+	/**
+	 * @brief Matches a legacy literal RGB note color against the custom text color table.
+	 * @param colour Literal RGB note color.
+	 * @param customTextColours Custom text colors indexed as `Custom1-Custom16`.
+	 * @return Public index, or `-1` when no match exists.
+	 */
+	[[nodiscard]] int publicIndexFromLegacyRgb(const QColor &colour, const QVector<QColor> &customTextColours)
+	{
+		if (!colour.isValid())
+			return -1;
+		const qsizetype count = qMin(customTextColours.size(), qsizetype{MAX_CUSTOM});
+		for (qsizetype i = 0; i < count; ++i)
+		{
+			const QColor &customColour = customTextColours.at(i);
+			if (customColour.isValid() && customColour.rgb() == colour.rgb())
+				return static_cast<int>(i) + 1;
+		}
+		return -1;
+	}
+} // namespace
+
+namespace QMudNoteColour
+{
+	int publicIndexFromRuntimeIndex(const int runtimeIndex)
+	{
+		return runtimeIndex < 0 ? 0 : clampPublicIndex(runtimeIndex + 1);
+	}
+
+	int publicIndexFromWorldAttribute(const QString &value, const int fallbackPublicIndex)
+	{
+		return publicIndexFromWorldAttribute(value, {}, fallbackPublicIndex);
+	}
+
+	int publicIndexFromWorldAttribute(const QString &value, const QVector<QColor> &customTextColours,
+	                                  const int fallbackPublicIndex)
+	{
+		const ParsedNoteColour parsed = parseNoteColourValue(value);
+		if (!parsed.valid)
+			return clampPublicIndex(fallbackPublicIndex);
+
+		if (parsed.packed == kSameColourPackedValue || parsed.packed < 0)
+			return 0;
+		if (parsed.packed < MAX_CUSTOM)
+			return static_cast<int>(parsed.packed) + 1;
+		if (const int legacyIndex = publicIndexFromLegacyRgb(parsed.rgb, customTextColours); legacyIndex >= 0)
+			return legacyIndex;
+		return clampPublicIndex(fallbackPublicIndex);
+	}
+
+	QString worldAttributeFromPublicIndex(const int publicIndex)
+	{
+		const int  index  = clampPublicIndex(publicIndex);
+		const long packed = index == 0 ? kSameColourPackedValue : index - 1;
+		return qColorFromColourRef(packed).name(QColor::HexRgb);
+	}
+} // namespace QMudNoteColour

--- a/src/helpers/NoteColourUtils.h
+++ b/src/helpers/NoteColourUtils.h
@@ -1,0 +1,58 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: NoteColourUtils.h
+ * Role: Helpers for MUSHclient-compatible note colour option encoding.
+ */
+
+#ifndef QMUD_NOTE_COLOUR_UTILS_H
+#define QMUD_NOTE_COLOUR_UTILS_H
+
+#include <QColor>
+#include <QString>
+#include <QVector>
+
+namespace QMudNoteColour
+{
+	/**
+	 * @brief Default MUSHclient public note color index.
+	 */
+	constexpr int         kDefaultPublicIndex = 5;
+
+	/**
+	 * @brief Converts runtime note color index to public SetNoteColour/GetNoteColour index.
+	 * @param runtimeIndex Runtime index, where `-1` means same/default color.
+	 * @return Public index in range `0..16`.
+	 */
+	[[nodiscard]] int     publicIndexFromRuntimeIndex(int runtimeIndex);
+
+	/**
+	 * @brief Converts a persisted `note_text_color` value to public note color index.
+	 * @param value Persisted world attribute value.
+	 * @param fallbackPublicIndex Public index used when value is empty or invalid.
+	 * @return Public index in range `0..16`.
+	 */
+	[[nodiscard]] int     publicIndexFromWorldAttribute(const QString &value,
+	                                                    int            fallbackPublicIndex = kDefaultPublicIndex);
+
+	/**
+	 * @brief Converts a persisted `note_text_color` value using custom text colors for legacy RGB values.
+	 * @param value Persisted world attribute value.
+	 * @param customTextColours Custom text colors indexed as `Custom1-Custom16`.
+	 * @param fallbackPublicIndex Public index used when value is empty or invalid.
+	 * @return Public index in range `0..16`.
+	 */
+	[[nodiscard]] int     publicIndexFromWorldAttribute(const QString         &value,
+	                                                    const QVector<QColor> &customTextColours,
+	                                                    int fallbackPublicIndex = kDefaultPublicIndex);
+
+	/**
+	 * @brief Encodes public note color index as MUSHclient-compatible world attribute value.
+	 * @param publicIndex Public index in range `0..16`.
+	 * @return Persisted `note_text_colour` value.
+	 */
+	[[nodiscard]] QString worldAttributeFromPublicIndex(int publicIndex);
+} // namespace QMudNoteColour
+
+#endif // QMUD_NOTE_COLOUR_UTILS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -305,6 +305,15 @@ qmud_add_qtest(tst_ColorUtils
         LABELS
         unit)
 
+qmud_add_qtest(tst_NoteColourUtils
+        SOURCES
+        unit/tst_NoteColourUtils.cpp
+        "${CMAKE_SOURCE_DIR}/src/helpers/NoteColourUtils.cpp"
+        LIBRARIES
+        Qt6::Gui
+        LABELS
+        unit)
+
 qmud_add_qtest(tst_FontUtils
         GUI
         SOURCES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -630,6 +630,7 @@ qmud_add_qtest(tst_WorldCommandProcessor_TimerAccounting
 
 if (QMUD_ENABLE_GUI_TESTS)
     qmud_add_qtest(tst_MainFrame_Actions
+            GUI
             SOURCES
             gui/tst_MainFrame_Actions.cpp
             "${CMAKE_SOURCE_DIR}/src/helpers/MainFrameActionUtils.cpp"

--- a/tests/gui/tst_Dialog_GlobalPreferencesUpdates.cpp
+++ b/tests/gui/tst_Dialog_GlobalPreferencesUpdates.cpp
@@ -19,6 +19,7 @@
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QDir>
 #include <QFile>
+#include <QFont>
 #include <QLabel>
 #include <QPushButton>
 #include <QSpinBox>
@@ -80,6 +81,10 @@ namespace
 		state.globalOptions.insert(QStringLiteral("UpdateCheckIntervalHours"), 1);
 		state.globalOptions.insert(QStringLiteral("EnableReloadFeature"), 1);
 		state.globalOptions.insert(QStringLiteral("ReloadMccpDisableTimeoutMs"), 1000);
+		state.globalOptions.insert(QStringLiteral("PrinterFont"), QStringLiteral("Courier"));
+		state.globalOptions.insert(QStringLiteral("PrinterFontSize"), 10);
+		state.globalOptions.insert(QStringLiteral("PrinterFontWeight"), QFont::Normal);
+		state.globalOptions.insert(QStringLiteral("PrinterFontItalic"), 0);
 
 		QFile::remove(testIniFilePath());
 	}
@@ -482,6 +487,33 @@ class tst_Dialog_GlobalPreferencesUpdates : public QObject
 			QCOMPARE(stubState().globalOptions.value(QStringLiteral("ReloadMccpDisableTimeoutMs")).toInt(),
 			         850);
 			QCOMPARE(stubState().applyGlobalPreferencesCallCount, 1);
+		}
+
+		/**
+		 * @brief Verifies printer font family and style are displayed and persisted separately.
+		 */
+		void printerFontStyleLoadsAndPersists()
+		{
+			resetStubState();
+			stubState().globalOptions.insert(QStringLiteral("PrinterFont"), QStringLiteral("Menlo"));
+			stubState().globalOptions.insert(QStringLiteral("PrinterFontSize"), 11);
+			stubState().globalOptions.insert(QStringLiteral("PrinterFontWeight"), QFont::Bold);
+			stubState().globalOptions.insert(QStringLiteral("PrinterFontItalic"), 1);
+
+			GlobalPreferencesDialog dialog;
+			dialog.show();
+
+			QVERIFY(findLabelByText(dialog, QStringLiteral("Menlo")));
+			QVERIFY(findLabelByText(dialog, QStringLiteral("11 pt. Bold Italic")));
+
+			dialog.accept();
+
+			QCOMPARE(stubState().globalOptions.value(QStringLiteral("PrinterFont")).toString(),
+			         QStringLiteral("Menlo"));
+			QCOMPARE(stubState().globalOptions.value(QStringLiteral("PrinterFontSize")).toInt(), 11);
+			QCOMPARE(stubState().globalOptions.value(QStringLiteral("PrinterFontWeight")).toInt(),
+			         static_cast<int>(QFont::Bold));
+			QCOMPARE(stubState().globalOptions.value(QStringLiteral("PrinterFontItalic")).toInt(), 1);
 		}
 
 		/**

--- a/tests/gui/tst_Dialog_WorldPreferences.cpp
+++ b/tests/gui/tst_Dialog_WorldPreferences.cpp
@@ -232,6 +232,40 @@ class tst_Dialog_WorldPreferences : public QObject
 				         qPrintable(QStringLiteral("Unexpected fixed-width policy for %1").arg(spinName)));
 			}
 		}
+
+		void scriptingNoteColourApplyUpdatesRuntimeState()
+		{
+			const QString sourcePath =
+			    QDir(QStringLiteral(QMUD_TEST_SOURCE_DIR))
+			        .filePath(QStringLiteral("src/dialogs/WorldPreferencesDialog.cpp"));
+			QFile sourceFile(sourcePath);
+			QVERIFY2(sourceFile.open(QIODevice::ReadOnly | QIODevice::Text),
+			         qPrintable(QStringLiteral("Failed to open %1").arg(sourcePath)));
+			const QString sourceText = QString::fromUtf8(sourceFile.readAll());
+
+			QVERIFY2(sourceText.contains(QStringLiteral("QMudNoteColour::worldAttributeFromPublicIndex")),
+			         "Expected scripting Note colour persistence to use shared note-colour encoding.");
+			QVERIFY2(sourceText.contains(QStringLiteral("m_runtime->setNoteTextColour(notePublicIndex)")),
+			         "Expected scripting Note colour apply path to update runtime Note() colour state.");
+		}
+
+		void scriptingNoteColourComboItemsUseCustomColours()
+		{
+			const QString sourcePath =
+			    QDir(QStringLiteral(QMUD_TEST_SOURCE_DIR))
+			        .filePath(QStringLiteral("src/dialogs/WorldPreferencesDialog.cpp"));
+			QFile sourceFile(sourcePath);
+			QVERIFY2(sourceFile.open(QIODevice::ReadOnly | QIODevice::Text),
+			         qPrintable(QStringLiteral("Failed to open %1").arg(sourcePath)));
+			const QString sourceText = QString::fromUtf8(sourceFile.readAll());
+
+			QVERIFY2(sourceText.contains(QStringLiteral("updateScriptNoteColourItems")),
+			         "Expected scripting Note colour combo item role updater.");
+			QVERIFY2(sourceText.contains(QStringLiteral("Qt::ForegroundRole")),
+			         "Expected scripting Note colour combo entries to carry foreground colours.");
+			QVERIFY2(sourceText.contains(QStringLiteral("Qt::BackgroundRole")),
+			         "Expected scripting Note colour combo entries to carry background colours.");
+		}
 };
 // NOLINTEND(readability-convert-member-functions-to-static)
 

--- a/tests/gui/tst_MainFrame_Actions.cpp
+++ b/tests/gui/tst_MainFrame_Actions.cpp
@@ -55,6 +55,56 @@ class tst_MainFrame_Actions : public QObject
 			QCOMPARE(QMudMainFrameActionUtils::worldButtonTooltipForSlot(slot), expected);
 		}
 
+		void menuRoleForCommand_data()
+		{
+			QTest::addColumn<QString>("commandName");
+			QTest::addColumn<QAction::MenuRole>("expected");
+
+			QTest::newRow("application-quit") << QStringLiteral("ExitClient") << QAction::QuitRole;
+			QTest::newRow("world-quit") << QStringLiteral("QuitFromWorld") << QAction::NoRole;
+			QTest::newRow("ordinary-action") << QStringLiteral("Open") << QAction::TextHeuristicRole;
+		}
+
+		void menuRoleForCommand()
+		{
+			QFETCH(QString, commandName);
+			QFETCH(QAction::MenuRole, expected);
+			QCOMPARE(QMudMainFrameActionUtils::menuRoleForCommand(commandName), expected);
+		}
+
+		void shortcutForCommand_data()
+		{
+			QTest::addColumn<QString>("commandName");
+			QTest::addColumn<QString>("configuredShortcutText");
+			QTest::addColumn<bool>("expectedStandardQuit");
+			QTest::addColumn<QString>("expectedShortcutText");
+
+			QTest::newRow("application-quit-default")
+			    << QStringLiteral("ExitClient") << QString() << true << QString();
+			QTest::newRow("application-quit-explicit")
+			    << QStringLiteral("ExitClient") << QStringLiteral("Ctrl+Alt+Q") << false
+			    << QStringLiteral("Ctrl+Alt+Q");
+			QTest::newRow("world-quit") << QStringLiteral("QuitFromWorld") << QStringLiteral("Ctrl+Shift+Q")
+			                            << false << QStringLiteral("Ctrl+Shift+Q");
+		}
+
+		void shortcutForCommand()
+		{
+			QFETCH(QString, commandName);
+			QFETCH(QString, configuredShortcutText);
+			QFETCH(bool, expectedStandardQuit);
+			QFETCH(QString, expectedShortcutText);
+
+			const QKeySequence configuredShortcut =
+			    QKeySequence::fromString(configuredShortcutText, QKeySequence::PortableText);
+			const QKeySequence actual =
+			    QMudMainFrameActionUtils::shortcutForCommand(commandName, configuredShortcut);
+			if (expectedStandardQuit)
+				QCOMPARE(actual, QKeySequence(QKeySequence::Quit));
+			else
+				QCOMPARE(actual.toString(QKeySequence::PortableText), expectedShortcutText);
+		}
+
 		void shouldAttemptIncomingLineTaskbarFlash_data()
 		{
 			QTest::addColumn<bool>("worldFlashEnabled");
@@ -166,7 +216,7 @@ class tst_MainFrame_Actions : public QObject
 		// NOLINTEND(readability-convert-member-functions-to-static)
 };
 
-QTEST_APPLESS_MAIN(tst_MainFrame_Actions)
+QTEST_MAIN(tst_MainFrame_Actions)
 
 #if __has_include("tst_MainFrame_Actions.moc")
 #include "tst_MainFrame_Actions.moc"

--- a/tests/gui/tst_MainFrame_Actions.cpp
+++ b/tests/gui/tst_MainFrame_Actions.cpp
@@ -42,9 +42,18 @@ class tst_MainFrame_Actions : public QObject
 			QTest::addColumn<int>("slot");
 			QTest::addColumn<QString>("expected");
 
-			QTest::newRow("first-slot") << 1 << QStringLiteral("Activates world #1 (Ctrl+1)");
-			QTest::newRow("ninth-slot") << 9 << QStringLiteral("Activates world #9 (Ctrl+9)");
-			QTest::newRow("tenth-slot") << 10 << QStringLiteral("Activates world #10 (Ctrl+0)");
+			QTest::newRow("first-slot")
+			    << 1
+			    << QMudMainFrameActionUtils::toolbarTooltipWithShortcut(QStringLiteral("Activates world #1"),
+			                                                            QStringLiteral("Ctrl+1"));
+			QTest::newRow("ninth-slot")
+			    << 9
+			    << QMudMainFrameActionUtils::toolbarTooltipWithShortcut(QStringLiteral("Activates world #9"),
+			                                                            QStringLiteral("Ctrl+9"));
+			QTest::newRow("tenth-slot")
+			    << 10
+			    << QMudMainFrameActionUtils::toolbarTooltipWithShortcut(QStringLiteral("Activates world #10"),
+			                                                            QStringLiteral("Ctrl+0"));
 			QTest::newRow("overflow-slot") << 12 << QStringLiteral("Activates world #12");
 		}
 
@@ -109,6 +118,19 @@ class tst_MainFrame_Actions : public QObject
 				QCOMPARE(actual, QKeySequence(QKeySequence::Quit));
 			else
 				QCOMPARE(actual.toString(QKeySequence::PortableText), expectedShortcutText);
+		}
+
+		void toolbarTooltipWithShortcut()
+		{
+			const QString nativeShortcut =
+			    QKeySequence::fromString(QStringLiteral("Shift+Ctrl+8"), QKeySequence::PortableText)
+			        .toString(QKeySequence::NativeText);
+			QCOMPARE(QMudMainFrameActionUtils::toolbarTooltipWithShortcut(QStringLiteral("Triggers"),
+			                                                              QStringLiteral("Shift+Ctrl+8")),
+			         QStringLiteral("Triggers (%1)").arg(nativeShortcut));
+			QCOMPARE(
+			    QMudMainFrameActionUtils::toolbarTooltipWithShortcut(QStringLiteral("Triggers"), QString()),
+			    QStringLiteral("Triggers"));
 		}
 
 		void shouldAttemptIncomingLineTaskbarFlash_data()

--- a/tests/gui/tst_MainFrame_Actions.cpp
+++ b/tests/gui/tst_MainFrame_Actions.cpp
@@ -61,8 +61,14 @@ class tst_MainFrame_Actions : public QObject
 			QTest::addColumn<QAction::MenuRole>("expected");
 
 			QTest::newRow("application-quit") << QStringLiteral("ExitClient") << QAction::QuitRole;
+#ifdef Q_OS_MACOS
+			QTest::newRow("world-quit") << QStringLiteral("QuitFromWorld") << QAction::NoRole;
+			QTest::newRow("ordinary-action") << QStringLiteral("Open") << QAction::NoRole;
+			QTest::newRow("preferences-action") << QStringLiteral("Preferences") << QAction::NoRole;
+#else
 			QTest::newRow("world-quit") << QStringLiteral("QuitFromWorld") << QAction::NoRole;
 			QTest::newRow("ordinary-action") << QStringLiteral("Open") << QAction::TextHeuristicRole;
+#endif
 		}
 
 		void menuRoleForCommand()

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -509,6 +509,7 @@ namespace
 			void workerCallbackBatchCapturesOutputMiniWindowAndSaveStateMutations();
 			void workerColourOutputMatchesMushclientGroupingAndNewlineSemantics();
 			void colourTellIgnoresTrailingLuaGsubReturnAndKeepsFollowingNote();
+			void executeScriptNoteUsesRuntimeNoteColour();
 			void triggerAnchoredColourOutputKeepsNativePromptText();
 			void callbackSnapshotSuppliesGetInfoAndMiniWindowReads();
 			void deferredRuntimeMutationSkipsDestroyedRuntime();
@@ -1422,6 +1423,43 @@ end
 	QCOMPARE(logicalOutputLinesFromEntries(state.lineEntries),
 	         QStringList({QStringLiteral("You made 10,000 gold!")}));
 	teardownWorkerEngine(executor, engine);
+}
+
+void tst_LuaCallbackEngine::executeScriptNoteUsesRuntimeNoteColour()
+{
+	WorldRuntime runtime;
+	auto        &state  = runtimeStubState(&runtime);
+	auto         engine = QSharedPointer<LuaCallbackEngine>::create();
+	engine->setWorldRuntime(&runtime);
+	setEngineScript(*engine, QString());
+
+	auto snapshot                        = QSharedPointer<LuaCallbackMiniWindowSnapshot>::create();
+	snapshot->hasRuntimeCountersSnapshot = true;
+	snapshot->runtimeCounterValues.insert(QStringLiteral("notesInRgb"), true);
+	snapshot->runtimeCounterValues.insert(QStringLiteral("noteColourFore"),
+	                                      QVariant::fromValue<qlonglong>(0x00FFFF00));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("noteColourBack"),
+	                                      QVariant::fromValue<qlonglong>(0));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("noteTextColour"), -1);
+
+	LuaExecutorDirect       executor;
+	LuaBatchDispatchRequest request;
+	request.engines               = {engine};
+	request.kind                  = LuaBatchDispatchKind::ExecuteScript;
+	request.stringArg             = QStringLiteral("Note('test')");
+	request.stringArg2            = QStringLiteral("immediate note colour");
+	request.miniWindowSnapshotArg = snapshot;
+	LuaBatchDispatchResult result = executor.dispatchBatch(request);
+	QVERIFY(result.boolResultValid);
+	QVERIFY(result.boolResult);
+	executeDeferredMutations(result);
+
+	QCOMPARE(state.lineEntries.size(), 1);
+	const WorldRuntime::LineEntry &entry = state.lineEntries.constFirst();
+	QCOMPARE(entry.text, QStringLiteral("test"));
+	QVERIFY(!entry.spans.isEmpty());
+	QCOMPARE(entry.spans.constFirst().fore, QColor(0, 255, 255));
+	QCOMPARE(entry.spans.constFirst().back, QColor(Qt::black));
 }
 
 void tst_LuaCallbackEngine::triggerAnchoredColourOutputKeepsNativePromptText()

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -25,6 +25,7 @@
 #include <QtTest/QTest>
 
 #include <atomic>
+#include <clocale>
 #include <limits>
 #include <memory>
 
@@ -493,6 +494,7 @@ namespace
 
 		private slots:
 			// NOLINTBEGIN(readability-convert-member-functions-to-static)
+			void initTestCase();
 			void directCallbackShapesRoundTrip();
 			void wildcardAndStyleCallbackReceivesContextTables();
 			void mxpCallbacksMarshalArguments();
@@ -505,6 +507,7 @@ namespace
 			void deferredRuntimeMutationBatchesPreserveOrderAndOwnership();
 			void directExecutorDispatchesRealEngines();
 			void callPluginMarshallingUsesTargetEngineState();
+			void noArgsDispatchReportsCallbackFailure();
 			void workerDispatchesPluginLifecycleCallbacksOnRealEngines();
 			void workerCallbackBatchCapturesOutputMiniWindowAndSaveStateMutations();
 			void workerColourOutputMatchesMushclientGroupingAndNewlineSemantics();
@@ -626,6 +629,11 @@ namespace
 } // namespace
 
 // NOLINTBEGIN(readability-convert-member-functions-to-static)
+void tst_LuaCallbackEngine::initTestCase()
+{
+	std::setlocale(LC_NUMERIC, "C");
+}
+
 void tst_LuaCallbackEngine::directCallbackShapesRoundTrip()
 {
 	LuaCallbackEngine engine;
@@ -1252,6 +1260,50 @@ end
 	QCOMPARE(lua_gettop(caller.get()), 4);
 	QCOMPARE(QString::fromUtf8(lua_tostring(caller.get(), 3)), QStringLiteral("input:42.0"));
 	QVERIFY(lua_toboolean(caller.get(), 4) != 0);
+}
+
+void tst_LuaCallbackEngine::noArgsDispatchReportsCallbackFailure()
+{
+	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
+	LuaExecutorWorker executor;
+	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
+function successful_install()
+  return true
+end
+function failed_install()
+  return false
+end
+)lua"));
+
+	LuaBatchDispatchRequest request;
+	request.engines       = {engine};
+	request.kind          = LuaBatchDispatchKind::NoArgs;
+	request.functionName  = QStringLiteral("successful_install");
+	request.defaultResult = true;
+	LuaBatchDispatchResult result;
+	dispatchWorkerAndWait(executor, request, result);
+	QVERIFY(result.boolResultValid);
+	QVERIFY(result.boolResult);
+	QVERIFY(result.hasFunctionValid);
+	QVERIFY(result.hasFunction);
+
+	request.functionName = QStringLiteral("failed_install");
+	dispatchWorkerAndWait(executor, request, result);
+	QVERIFY(result.boolResultValid);
+	QVERIFY(!result.boolResult);
+	QVERIFY(result.hasFunctionValid);
+	QVERIFY(result.hasFunction);
+
+	request.functionName = QStringLiteral("missing_install");
+	dispatchWorkerAndWait(executor, request, result);
+	QVERIFY(result.boolResultValid);
+	QVERIFY(result.boolResult);
+	QVERIFY(result.hasFunctionValid);
+	QVERIFY(!result.hasFunction);
+
+	request.kind    = LuaBatchDispatchKind::TeardownEnginesMany;
+	request.engines = {engine};
+	dispatchWorkerAndWait(executor, request);
 }
 
 void tst_LuaCallbackEngine::workerDispatchesPluginLifecycleCallbacksOnRealEngines()

--- a/tests/unit/tst_MainFrameMdiUtils.cpp
+++ b/tests/unit/tst_MainFrameMdiUtils.cpp
@@ -103,6 +103,22 @@ class tst_MainFrameMdiUtils : public QObject
 			                                                            QStringLiteral("world-a"), true));
 		}
 
+		void windowMatchesRuntimeIdentityWithoutOwnerOnlyAcceptsUnownedWindows()
+		{
+			QMdiSubWindow unowned;
+			QVERIFY(QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&unowned, 0, QString(), false));
+
+			QMdiSubWindow relatedByToken;
+			relatedByToken.setProperty("worldRuntimeToken", QVariant::fromValue<qulonglong>(42));
+			QVERIFY(
+			    !QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&relatedByToken, 0, QString(), false));
+
+			QMdiSubWindow relatedByWorldId;
+			relatedByWorldId.setProperty("worldId", QStringLiteral("world-a"));
+			QVERIFY(
+			    !QMudMainFrameMdiUtils::windowMatchesRuntimeIdentity(&relatedByWorldId, 0, QString(), false));
+		}
+
 		void firstWindowMatchingRuntimeIdentityUsesCreationOrder()
 		{
 			QMdiSubWindow unrelated;

--- a/tests/unit/tst_NoteColourUtils.cpp
+++ b/tests/unit/tst_NoteColourUtils.cpp
@@ -1,0 +1,93 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_NoteColourUtils.cpp
+ * Role: Unit coverage for MUSHclient-compatible note colour option encoding.
+ */
+
+#include "WorldOptions.h"
+#include "helpers/NoteColourUtils.h"
+
+#include <QColor>
+#include <QVector>
+#include <QtTest/QTest>
+
+/**
+ * @brief QTest fixture for note colour option conversion helpers.
+ */
+class tst_NoteColourUtils : public QObject
+{
+		Q_OBJECT
+
+	private slots:
+		/**
+		 * @brief Verifies MUSHclient COLORREF-style persisted values map to public note indexes.
+		 */
+		static void worldAttributeValuesMapToPublicIndexes()
+		{
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("#040000")), 5);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("4")), 5);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("#ffffff")), 0);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("-1")), 0);
+		}
+
+		/**
+		 * @brief Verifies invalid values use the supplied public-index fallback.
+		 */
+		static void invalidWorldAttributeValuesUseFallback()
+		{
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QString(), 7), 7);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("not-a-colour"), 8), 8);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("#00ff00"), 9), 9);
+		}
+
+		/**
+		 * @brief Verifies legacy QMud RGB note colours map back to matching custom colour slots.
+		 */
+		static void legacyRgbWorldAttributeValuesMatchCustomTextColours()
+		{
+			QVector<QColor> customTextColours(MAX_CUSTOM, QColor(Qt::white));
+			customTextColours[3] = QColor(0, 255, 255);
+			customTextColours[8] = QColor(255, 0, 255);
+
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("#00ffff"),
+			                                                       customTextColours, 7),
+			         4);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("#ff00ff"),
+			                                                       customTextColours, 7),
+			         9);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("#040000"),
+			                                                       customTextColours, 7),
+			         5);
+			QCOMPARE(QMudNoteColour::publicIndexFromWorldAttribute(QStringLiteral("#ffffff"),
+			                                                       customTextColours, 7),
+			         0);
+		}
+
+		/**
+		 * @brief Verifies public note indexes persist in MUSHclient-compatible form.
+		 */
+		static void publicIndexesMapToWorldAttributeValues()
+		{
+			QCOMPARE(QMudNoteColour::worldAttributeFromPublicIndex(0), QStringLiteral("#ffffff"));
+			QCOMPARE(QMudNoteColour::worldAttributeFromPublicIndex(5), QStringLiteral("#040000"));
+			QCOMPARE(QMudNoteColour::worldAttributeFromPublicIndex(16), QStringLiteral("#0f0000"));
+		}
+
+		/**
+		 * @brief Verifies runtime note indexes map to public SetNoteColour/GetNoteColour indexes.
+		 */
+		static void runtimeIndexesMapToPublicIndexes()
+		{
+			QCOMPARE(QMudNoteColour::publicIndexFromRuntimeIndex(-1), 0);
+			QCOMPARE(QMudNoteColour::publicIndexFromRuntimeIndex(0), 1);
+			QCOMPARE(QMudNoteColour::publicIndexFromRuntimeIndex(4), 5);
+		}
+};
+
+QTEST_APPLESS_MAIN(tst_NoteColourUtils)
+
+#if __has_include("tst_NoteColourUtils.moc")
+#include "tst_NoteColourUtils.moc"
+#endif


### PR DESCRIPTION
## Summary

- Fix QAction metadata on Mac. Fixes #90 Fixes #98 
- Persist and display printing font size and style. Fixes #88 
- Fix Note() color setting via scripting world preferences. Fixes #95
- Additional parity for Notepads handling.
- Mark plugins as disabled when they fail to load.
- Stop hardcoding shortcut text in tooltips. Fixes #97 

## Scope

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- Increase parity with MUSHclient on Notepads handling, essentially for some VI workflows.
- Correct behavior where some plugins would rely on enabled/disable status to detect dependency availability and plugins failing to load properly due to eg a missing lib.
- Note() coloring is now on par with MUSHclient.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

