### PR TITLE
`fix`: Default shortcut bindings overriding CTRL+Z/P/N emacs combos

### DIFF
--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -3228,8 +3228,15 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 	    hasOnlyAlt && (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter);
 	const bool ctrlG       = hasOnlyCtrl && keyEvent->key() == Qt::Key_G;
 	const int  tabShortcut = QMudMainFrameActionUtils::adjacentTabShortcutStep(keyEvent->key(), mods);
+	bool       ctrlZ       = false;
+	if (hasOnlyCtrl && keyEvent->key() == Qt::Key_Z)
+	{
+		if (const auto *world = activeWorldChildWindow())
+			if (const auto *view = world->view())
+				ctrlZ = view->ctrlZGoesToEndOfBuffer();
+	}
 
-	if (!altEnter && !ctrlG && tabShortcut == 0)
+	if (!altEnter && !ctrlG && tabShortcut == 0 && !ctrlZ)
 		return QMainWindow::eventFilter(watched, event);
 
 	if (event->type() == QEvent::ShortcutOverride)
@@ -3250,7 +3257,7 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 
 	if (QApplication::activeModalWidget())
 	{
-		if (tabShortcut != 0)
+		if (tabShortcut != 0 || ctrlZ)
 			return QMainWindow::eventFilter(watched, event);
 		keyEvent->accept();
 		return true;
@@ -3270,6 +3277,19 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 
 	if (tabShortcut != 0 && triggerAdjacentMdiTabFromShortcut(tabShortcut))
 	{
+		keyEvent->accept();
+		return true;
+	}
+	if (ctrlZ)
+	{
+        auto* world = activeWorldChildWindow();
+        auto* view = world ? world->view() : nullptr;
+
+        if (view)
+        {
+            this->onStatusFreezeDoubleClick();
+        }
+
 		keyEvent->accept();
 		return true;
 	}

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -13801,6 +13801,16 @@ bool InputTextEdit::event(QEvent *event)
 				event->accept();
 				return true;
 			}
+			// Claim these before window-level QActions (Undo/Print/New) steal them when compat bindings are on
+			const bool ctrlNoShift = plainCtrl && !(modifiers & Qt::ShiftModifier);
+			if (ctrlNoShift &&
+			    ((keyEvent->key() == Qt::Key_Z && m_view->m_ctrlZGoesToEndOfBuffer) ||
+			     (keyEvent->key() == Qt::Key_P && m_view->m_ctrlPGoesToPreviousCommand) ||
+			     (keyEvent->key() == Qt::Key_N && m_view->m_ctrlNGoesToNextCommand)))
+			{
+				event->accept();
+				return true;
+			}
 			if (m_view->hasWorldAcceleratorBinding(keyEvent))
 			{
 				event->accept();

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -313,6 +313,7 @@ class WorldView : public QWidget
 		 * @brief Scrolls output to end.
 		 */
 		void                          scrollOutputToEnd() const;
+		bool                          ctrlZGoesToEndOfBuffer() const { return m_ctrlZGoesToEndOfBuffer; }
 		/**
 		 * @brief Scrolls output one page up.
 		 */


### PR DESCRIPTION
## Summary

[Edit: Sorry for the noise again; I did not realize that deleting the feature branches on my fork after merging them there would also cause the PR to close on your upstream]

The ZMud and emacs style keyboard shortcuts (CTRL+P, CTRL+N, CTRL+Z) were not functioning even when their options were enabled, because those key combinations had other default bindings which took precedence, e.g. CTRL+P would still bring up the printer dialog. This patch makes all of those shortcuts work when they are enabled, and should work with both the upstream and my fork.

If there is a cleaner way to do this, please let me know or feel free to fix it.

## Scope

- [* ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

None

## Validation

CTRL + Z now closes the split window and brings the scrollback to the most recent output, zMUD style
CTRL + P now cycles to the previous command in the command history
CTRL + N now cycles to the next entered command in the command history

## Checklist

- [* ] I verified behavior manually or with tests.
- [ *] I updated docs when relevant.
- [ *] I did not introduce unrelated changes.

