### PR TITLE
`fix`: Fix QMud segfaulting during program exit

### DIFF
--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -4264,14 +4264,6 @@ WorldRuntime::~WorldRuntime()
 	}
 	m_view = nullptr;
 
-	for (auto &plugin : m_plugins)
-	{
-		if (plugin.lua && hasValidPluginId(plugin))
-			dispatchSingleEngineNoArgCallback(plugin.lua, QStringLiteral("OnPluginClose"), true);
-		savePluginStateForPlugin(plugin, false, nullptr);
-	}
-	m_pluginCallbackDispatchShuttingDown = true;
-
 	QVector<QSharedPointer<LuaCallbackEngine>> enginesToTeardown;
 	enginesToTeardown.reserve((m_luaCallbacks ? 1 : 0) + m_plugins.size());
 	for (auto &plugin : m_plugins)
@@ -4283,6 +4275,30 @@ WorldRuntime::~WorldRuntime()
 	if (m_luaCallbacks)
 		enginesToTeardown.push_back(makeNonOwningLuaEngineRef(m_luaCallbacks));
 	cancelSuspendedPluginCallbackDispatchesForEngines(enginesToTeardown);
+
+	const auto dispatchTeardownCallback = [this](const QSharedPointer<LuaCallbackEngine> &lua,
+	                                             const QString                            &fn)
+	{
+		LuaBatchDispatchRequest req;
+		req.kind          = LuaBatchDispatchKind::NoArgs;
+		req.lane          = LuaBatchDispatchLane::Callback;
+		req.engines       = {lua};
+		req.defaultResult = true;
+		req.functionName  = fn;
+		static_cast<void>(dispatchLuaBatch(req));
+	};
+
+	for (auto &plugin : m_plugins)
+	{
+		if (plugin.lua && hasValidPluginId(plugin))
+		{
+			dispatchTeardownCallback(plugin.lua, QStringLiteral("OnPluginClose"));
+			if (plugin.saveState)
+				dispatchTeardownCallback(plugin.lua, QStringLiteral("OnPluginSaveState"));
+		}
+		savePluginStateForPlugin(plugin, false, nullptr, true);
+	}
+	m_pluginCallbackDispatchShuttingDown = true;
 	for (auto &plugin : m_plugins)
 		plugin.lua.clear();
 	dispatchTeardownLuaEngines(enginesToTeardown, true);
@@ -21520,7 +21536,8 @@ int WorldRuntime::savePluginState(const QString &pluginId, bool scripted, QStrin
 	return savePluginStateForPlugin(m_plugins[index], scripted, error);
 }
 
-int WorldRuntime::savePluginStateForPlugin(Plugin &plugin, bool scripted, QString *error)
+int WorldRuntime::savePluginStateForPlugin(Plugin &plugin, bool scripted, QString *error,
+                                           bool skipLuaDispatch)
 {
 	if (!scripted && !plugin.saveState)
 		return eOK;
@@ -21543,7 +21560,7 @@ int WorldRuntime::savePluginStateForPlugin(Plugin &plugin, bool scripted, QStrin
 		return scripted ? ePluginCouldNotSaveState : eOK;
 
 	plugin.savingStateNow = true;
-	if (plugin.lua)
+	if (plugin.lua && !skipLuaDispatch)
 		dispatchSingleEngineNoArgCallback(plugin.lua, QStringLiteral("OnPluginSaveState"), true);
 	plugin.savingStateNow = false;
 

--- a/src/WorldRuntime.h
+++ b/src/WorldRuntime.h
@@ -5307,7 +5307,8 @@ class WorldRuntime : public QObject
 		 * @param error Optional output error message.
 		 * @return API status code.
 		 */
-		int  savePluginStateForPlugin(Plugin &plugin, bool scripted, QString *error);
+		int  savePluginStateForPlugin(Plugin &plugin, bool scripted, QString *error,
+		                              bool skipLuaDispatch = false);
 		/**
 		 * @brief Sorts plugins by sequence ordering.
 		 */


### PR DESCRIPTION
## Summary

OnPluginClose and OnPluginSaveState were dispatched through queuePluginCallbackDispatch, which captures a LuaCallbackMiniWindowSnapshot. During teardown, the snapshot holds a QVariant(QStringList) built from world state that is invalidated by the time the snapshot is destroyed, causing a segfault in the QVariant destructor. Fixed by dispatching both callbacks via dispatchLuaBatch instead, which bypasses snapshot capture.

The second way QMud could segfault during teardown is intermittent: if a plugin had a suspended modal coroutine, dispatching OnPluginClose would resume it via lua_resume before cleanup, causing heap corruption through stale pointers on the coroutine stack. Fixed by moving the suspended callback cancellation before the dispatch loop.

[Edit 2: Refactored so the lambda isn't defined inside of the loop, which made it difficult to read and was bad style on my part.]

## Scope

- [ *] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

None. Crash was on program teardown so most users probably wouldn't even notice, apart from maybe seeing coredumps; this is a correctness fix.

## Validation

Closing QMud while it has a world with active Lua plugins opened no longer causes it to dump core.

## Checklist

- [ *] I verified behavior manually or with tests.
- [ *] I updated docs when relevant.
- [ *] I did not introduce unrelated changes.

