### PR TITLE
`fix`:  Fix Connect menu item, related Show Connect/Disconnect Message bugs

### DIFF
--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -5210,6 +5210,7 @@ bool AppController::openWorldDocument(const QString &path)
 		applyConfiguredWorldDefaults(runtime);
 		if (auto *view = window->view())
 			view->applyRuntimeSettings();
+		m_mainWindow->refreshActionState();
 		const auto worldName = runtime->worldAttributes().value(QStringLiteral("name")).trimmed();
 		if (!worldName.isEmpty())
 		{

--- a/src/WorldChildWindow.cpp
+++ b/src/WorldChildWindow.cpp
@@ -300,9 +300,7 @@ void WorldChildWindow::bindRuntime(WorldRuntime *worldRuntime, const RuntimeBind
 			                      flag.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
 			                      flag == QStringLiteral("1") ||
 			                      flag.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
-			    if (!show && !suppressConnectNote)
-				    return;
-			    if (!suppressConnectNote)
+			    if (show && !suppressConnectNote)
 			    {
 				    const QString when =
 				        QDateTime::currentDateTime().toString(QStringLiteral("dddd, MMMM dd, yyyy, h:mm AP"));
@@ -327,7 +325,11 @@ void WorldChildWindow::bindRuntime(WorldRuntime *worldRuntime, const RuntimeBind
 		        [this]
 		        {
 			        if (MainWindowHost *main = resolveMainWindowHost(window()))
+			        {
+				        main->setConnectedState(false);
+				        main->refreshTitleBar();
 				        main->updateActivityToolbarButtons();
+			        }
 		        });
 		connect(
 		    worldRuntime, &WorldRuntime::socketError, this,
@@ -517,11 +519,6 @@ void WorldChildWindow::bindRuntime(WorldRuntime *worldRuntime, const RuntimeBind
 				    const QString msg = QStringLiteral("The \"%1\" server has closed the connection")
 				                            .arg(disconnectedWorldName);
 				    main->showStatusMessage(msg, 5000);
-			    }
-			    if (MainWindowHost *main = resolveMainWindowHost(window()))
-			    {
-				    main->setConnectedState(false);
-				    main->refreshTitleBar();
 			    }
 			    if (m_commandProcessor)
 				    m_commandProcessor->handleWorldDisconnected();


### PR DESCRIPTION
## Summary

This fixes three related bugs relating to connecting to a world:

1. The Connect menu item is always disabled when a world first opens if Auto Connect is not enabled, even if the active world is not connected
2. The Connect menu item will not be re-enabled after disconnecting if "Show Connect/Disconnect messages" is disabled
3. The login sequence the user has configured will not be sent on reconnection if "Show Connect/Disconnect messages" is disabled

## Scope

- [* ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

None

## Validation

1. Connect is correctly enabled when opening a world that does not have Auto Reconnect selected
2. Disabling "Show Connect/Disconnect messages"  no longer stops the login sequence from being sent or the Connect menu item from being permanently disabled

## Checklist

- [ *] I verified behavior manually or with tests.
- [ *] I updated docs when relevant.
- [ *] I did not introduce unrelated changes.

