### PR TITLE
`fix`: Send to command queue not splitting action lines

### DIFF
--- a/src/WorldCommandProcessor.cpp
+++ b/src/WorldCommandProcessor.cpp
@@ -3806,9 +3806,12 @@ void WorldCommandProcessor::sendMsg(const QString &text, const bool echo, const 
 	if (m_noEcho)
 		bEcho = false;
 
+	// normalize endlines so dialog text splits into individual lines
+	strText.replace(kEndLine, QStringLiteral("\n"));
+
 	// strip trailing endline - that would trigger an extra blank line
-	if (strText.endsWith(kEndLine))
-		strText.chop(kEndLine.size());
+	if (strText.endsWith(QLatin1Char('\n')))
+		strText.chop(1);
 
 	// fix up German umlauts
 	if (m_translateGerman)
@@ -3816,7 +3819,7 @@ void WorldCommandProcessor::sendMsg(const QString &text, const bool echo, const 
 
 	// to make sure each individual line ends up on the output window marked as user
 	// input (and in the right color) break up the string into individual lines
-	QStringList strList = strText.split(kEndLine);
+	QStringList strList = strText.split(QLatin1Char('\n'));
 
 	// if list is empty, make sure we send at least one empty line
 	if (strList.isEmpty())
@@ -4175,7 +4178,9 @@ void WorldCommandProcessor::updateQueuedCommandsStatusLine()
 			break;
 		}
 
-		const QString direction = item.mid(1).trimmed();
+		// keep the status bar single line even if an entry has embedded newlines
+		QString direction = item.mid(1).trimmed();
+		direction.replace(QLatin1Char('\n'), QLatin1Char(' '));
 		if (direction.isEmpty())
 			continue;
 


### PR DESCRIPTION
## Summary

This fixes the Send to Command Queue setting for trigger/alias/etc actions. The lines in the action were not actually being split because kEndLine was "\r\n", however, Qt uses "\n" by default as the separator, so they were being sent all as a single command batch which completely bypassed the speedwalk delay.

A second, related glitch this fixes is the entire block of action commands being put into the status line with the newlines still in them [when Send to Command Queue is used], causing the status line to momentarily grow in height; this would appear to the user as the status line flashing well into the world output scrollback area. We now explicitly ensure that there are no newlines in the text sent to the statusline through this path, so that this cannot happen.

## Scope

- [* ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

None

## Validation

Send to Command Queue delays now work again, and the status bar no longer grows to the entire size of the QMud window for an instant when they trigger.

## Checklist

- [* ] I verified behavior manually or with tests.
- [ *] I updated docs when relevant.
- [ *] I did not introduce unrelated changes.

