### PR TITLE
Preload openssl libs on Windows. Fix command option shortcut parity drift. Fix potential segfaults around lua engine teardown. Fix incorrect show_connect_disconnect gating. Split send-to-world/queue action/execute lines properly. Refactor TelnetProcessor. Add direct trigger priority queue. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ These are intentional design choices in QMud:
 ## Contributors
 
 - Abigail Brady ([Cryosphere](https://cryosphere.org/))
+- RunnerScrab
 
 ## License
 

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -5210,6 +5210,7 @@ bool AppController::openWorldDocument(const QString &path)
 		applyConfiguredWorldDefaults(runtime);
 		if (auto *view = window->view())
 			view->applyRuntimeSettings();
+		m_mainWindow->refreshActionState();
 		const auto worldName = runtime->worldAttributes().value(QStringLiteral("name")).trimmed();
 		if (!worldName.isEmpty())
 		{
@@ -5276,6 +5277,7 @@ bool AppController::openWorldDocument(const QString &path)
 		window->showMaximized();
 	runtime->setPluginInstallDeferred(true);
 	applyConfiguredWorldDefaults(runtime);
+	m_mainWindow->refreshActionState();
 	if (m_suppressAutoConnect)
 		return true;
 	const QPointer<WorldRuntime> runtimeGuard(runtime);

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -648,6 +648,7 @@ namespace
 			QSet<QString>                                         missingMiniWindowHotspots;
 			int                                                   actionSourceOverride{0};
 			bool                                                  hasActionSourceOverride{false};
+			bool                                                  directTriggerScriptActionPriority{false};
 			QPointer<WorldRuntime>                                deferredRuntimeTarget;
 			QVector<std::function<void()>>                        deferredRuntimeMutations;
 			bool                                                  hasPendingDeferredRuntimeMutations{false};
@@ -660,6 +661,12 @@ namespace
 	{
 			bool done{false};
 			int  value{0};
+	};
+
+	struct CallbackActionSourceOverride
+	{
+			bool           active{false};
+			unsigned short source{WorldRuntime::eUnknownActionSource};
 	};
 
 	enum class DeferredRuntimeMutationFlushPolicy
@@ -703,6 +710,16 @@ namespace
 		context.hasPendingDeferredRuntimeMutations = false;
 		if (g_activeDeferredMutationContextCount > 0)
 			--g_activeDeferredMutationContextCount;
+	}
+
+	CallbackActionSourceOverride callbackActionSourceOverride(const LuaCallbackExecutionContext *context)
+	{
+		if (!context || !context->hasActionSourceOverride)
+			return {};
+		CallbackActionSourceOverride source;
+		source.active = true;
+		source.source = static_cast<unsigned short>(context->actionSourceOverride);
+		return source;
 	}
 
 	void pushActiveCallbackContext(const LuaCallbackEngine *engine, LuaCallbackExecutionContext &&context)
@@ -6712,8 +6729,10 @@ namespace
 	QVariantHash commandUiValuesFromSnapshot(const WorldRuntime::CommandUiSnapshot &snapshot)
 	{
 		QVariantHash values;
-		values.reserve(52);
+		values.reserve(53);
 		values.insert(QStringLiteral("queuedCommands"), snapshot.queuedCommands);
+		values.insert(QStringLiteral("triggerPriorityQueuedCommandCount"),
+		              snapshot.triggerPriorityQueuedCommandCount);
 		values.insert(QStringLiteral("commandInputText"), snapshot.commandInputText);
 		values.insert(QStringLiteral("commandHistory"), snapshot.commandHistory);
 		values.insert(QStringLiteral("inputSelectionStartColumn"), snapshot.inputSelectionStartColumn);
@@ -6775,7 +6794,9 @@ namespace
 	{
 		WorldRuntime::CommandUiSnapshot snapshot;
 		const QVariantHash             &values = dispatchSnapshot.commandUiValues;
-		snapshot.queuedCommands   = values.value(QStringLiteral("queuedCommands")).toStringList();
+		snapshot.queuedCommands = values.value(QStringLiteral("queuedCommands")).toStringList();
+		snapshot.triggerPriorityQueuedCommandCount =
+		    values.value(QStringLiteral("triggerPriorityQueuedCommandCount")).toInt();
 		snapshot.commandInputText = values.value(QStringLiteral("commandInputText")).toString();
 		snapshot.commandHistory   = values.value(QStringLiteral("commandHistory")).toStringList();
 		snapshot.inputSelectionStartColumn =
@@ -9644,7 +9665,9 @@ namespace
 		if (lines.isEmpty())
 			lines.append(QString());
 
-		bool changed = false;
+		const auto *context         = activeCallbackContextConst(engine);
+		const bool  triggerPriority = !queue && context && context->directTriggerScriptActionPriority;
+		bool        changed         = false;
 		for (const QString &line : lines)
 		{
 			if (!QMudCommandQueue::shouldQueueCommand(speedWalkDelay, queue,
@@ -9653,7 +9676,18 @@ namespace
 				immediateLines.append(line);
 				continue;
 			}
-			snapshot.queuedCommands.append(QMudCommandQueue::encodeQueueEntry(line, queue, echo, log));
+			const QString encoded = QMudCommandQueue::encodeQueueEntry(line, queue, echo, log);
+			if (triggerPriority)
+			{
+				const int queueSize = sizeToInt(snapshot.queuedCommands.size());
+				const int insertAt  = qBound(0, snapshot.triggerPriorityQueuedCommandCount, queueSize);
+				snapshot.queuedCommands.insert(insertAt, encoded);
+				snapshot.triggerPriorityQueuedCommandCount = insertAt + 1;
+			}
+			else
+			{
+				snapshot.queuedCommands.append(encoded);
+			}
 			changed = true;
 		}
 
@@ -13434,8 +13468,12 @@ static int luaDiscardQueue(lua_State *L)
 		enqueueRuntimeThreadDeferredMutationNoResult(
 		    engine, runtime, [](const WorldRuntime &targetRuntime)
 		    { static_cast<void>(targetRuntime.discardQueuedCommands()); });
-		updateCachedCommandUiSnapshot(engine, [](WorldRuntime::CommandUiSnapshot &cached)
-		                              { cached.queuedCommands.clear(); });
+		updateCachedCommandUiSnapshot(engine,
+		                              [](WorldRuntime::CommandUiSnapshot &cached)
+		                              {
+			                              cached.queuedCommands.clear();
+			                              cached.triggerPriorityQueuedCommandCount = 0;
+		                              });
 		WorldRuntime::RuntimeCountersSnapshot runtimeSnapshot;
 		static_cast<void>(resolveRuntimeCountersSnapshotForApi(engine, runtime, runtimeSnapshot));
 		updateCallbackRuntimeSnapshot(engine, [](WorldRuntime::RuntimeCountersSnapshot &cached)
@@ -16648,12 +16686,18 @@ static int luaExecute(lua_State *L)
 		return 1;
 	}
 	const QString input = QString::fromUtf8(luaL_checkstring(L, 1));
-	if (activeCallbackContextConst(engine))
+	if (const auto *context = activeCallbackContextConst(engine); context)
 	{
-		return enqueueRuntimeThreadAsyncStatusResult(
+		const bool triggerPriority = context->directTriggerScriptActionPriority;
+		const int  results         = enqueueRuntimeThreadAsyncStatusResult(
 		    L, engine, runtime, QStringLiteral("Execute"), eOK, eWorldClosed,
-		    [input](const WorldRuntime &targetRuntime) -> int { return targetRuntime.executeCommand(input); },
+		    [input, triggerPriority](const WorldRuntime &targetRuntime) -> int
+		    {
+			    return triggerPriority ? targetRuntime.executeCommandWithTriggerPriority(input)
+			                           : targetRuntime.executeCommand(input);
+		    },
 		    [](const int status) { return status == eOK; });
+		return results;
 	}
 	const int result = runOnRuntimeThreadDeferredMutation(
 	    engine, runtime, [input](const WorldRuntime &targetRuntime) -> int
@@ -30656,13 +30700,34 @@ static int pushDispatchSendCommandResult(lua_State *L, const LuaCallbackEngine *
 			return 1;
 		}
 
+		const auto                        *context              = activeCallbackContextConst(engine);
+		const CallbackActionSourceOverride actionSourceOverride = callbackActionSourceOverride(context);
+		const bool                         directTriggerPrioritySend =
+		    context && context->directTriggerScriptActionPriority && !queue && !immediate;
 		const QPointer<WorldRuntime> runtimeGuard(runtime);
 		const int                    results = enqueueRuntimeThreadAsyncOkStatusResult(
 		    L, engine, runtime, apiName, eWorldClosed,
-		    [runtimeGuard, text, echo, queue, log, history, immediate](WorldRuntime &) -> int
+		    [runtimeGuard, text, echo, queue, log, history, immediate, actionSourceOverride,
+		     directTriggerPrioritySend](WorldRuntime &) -> int
 		    {
 			    if (!runtimeGuard)
 				    return eWorldClosed;
+			    if (actionSourceOverride.active)
+			    {
+				    const unsigned short previousActionSource = runtimeGuard->currentActionSource();
+				    runtimeGuard->setCurrentActionSource(actionSourceOverride.source);
+				    [[maybe_unused]] const auto restoreActionSource = qScopeGuard(
+				        [runtimeGuard, previousActionSource]
+				        {
+					        if (runtimeGuard)
+						        runtimeGuard->setCurrentActionSource(previousActionSource);
+				        });
+				    return directTriggerPrioritySend
+				               ? runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history)
+				               : runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
+			    }
+			    if (directTriggerPrioritySend)
+				    return runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history);
 			    return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
 		    });
 		if (lua_tointeger(L, -results) == eOK)
@@ -46440,8 +46505,11 @@ bool LuaCallbackEngine::executeScript(const QString &code, const QString &descri
 	                                                  ? CallbackWildcardDomain::Trigger
 	                                                  : CallbackWildcardDomain::None;
 	LuaCallbackExecutionContext  context;
-	context.wildcardDomain                   = wildcardDomain;
-	context.triggerOutputReplacesMatchedLine = triggerOutputReplacesMatchedLine;
+	context.wildcardDomain                    = wildcardDomain;
+	context.actionSourceOverride              = hasTriggerContext ? WorldRuntime::eTriggerFired : -1;
+	context.hasActionSourceOverride           = hasTriggerContext;
+	context.directTriggerScriptActionPriority = hasTriggerContext;
+	context.triggerOutputReplacesMatchedLine  = triggerOutputReplacesMatchedLine;
 	pushActiveCallbackContext(this, std::move(context));
 	if (const auto *snapshot = currentDispatchMiniWindowSnapshot(); snapshot)
 		seedCallbackMiniWindowSnapshot(this, snapshot);

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -9836,7 +9836,7 @@ void LuaCallbackEngine::setScriptText(const QString &script)
 	if (!m_observedPluginCallbackPresence.isEmpty())
 		m_observedPluginCallbackPresence.clear();
 	if (m_callbackCatalogObserver)
-		m_callbackCatalogObserver(m_pluginId.trimmed().toLower(), {}, m_luaFunctionsSet);
+		m_callbackCatalogObserver(pluginIdMetadata().trimmed().toLower(), {}, m_luaFunctionsSet);
 }
 
 bool LuaCallbackEngine::loadScript()
@@ -9870,7 +9870,7 @@ void LuaCallbackEngine::resetState()
 	m_callingPluginIdStack.clear();
 	m_dispatchMiniWindowSnapshotStack.clear();
 	if (m_callbackCatalogObserver)
-		m_callbackCatalogObserver(m_pluginId.trimmed().toLower(), {}, m_luaFunctionsSet);
+		m_callbackCatalogObserver(pluginIdMetadata().trimmed().toLower(), {}, m_luaFunctionsSet);
 #endif
 }
 
@@ -9963,7 +9963,7 @@ void LuaCallbackEngine::refreshLuaCallbackCatalogNow()
 {
 	bindOrAssertExecutionThread("LuaCallbackEngine::refreshLuaCallbackCatalogNow");
 #ifdef QMUD_ENABLE_LUA_SCRIPTING
-	const QString normalizedPluginId = m_pluginId.trimmed().toLower();
+	const QString normalizedPluginId = pluginIdMetadata().trimmed().toLower();
 	if (m_observedPluginCallbacks.isEmpty())
 	{
 		if (m_observedPluginCallbackPresence.isEmpty())
@@ -10018,8 +10018,6 @@ lua_State *LuaCallbackEngine::luaState() const
 void LuaCallbackEngine::setPluginInfo(const QString &id, const QString &name, const QString &directory)
 {
 	bindOrAssertExecutionThread("LuaCallbackEngine::setPluginInfo");
-	m_pluginId                  = id;
-	m_pluginName                = name;
 	QString normalizedDirectory = directory;
 	if (!normalizedDirectory.isEmpty() && !normalizedDirectory.endsWith('/') &&
 	    !normalizedDirectory.endsWith('\\'))
@@ -10027,18 +10025,30 @@ void LuaCallbackEngine::setPluginInfo(const QString &id, const QString &name, co
 		normalizedDirectory += '/';
 	}
 	normalizedDirectory.replace(QLatin1Char('\\'), QLatin1Char('/'));
+	m_pluginId        = id;
+	m_pluginName      = name;
 	m_pluginDirectory = normalizedDirectory;
 }
 
 QString LuaCallbackEngine::pluginId() const
 {
 	bindOrAssertExecutionThread("LuaCallbackEngine::pluginId");
+	return pluginIdMetadata();
+}
+
+QString LuaCallbackEngine::pluginIdMetadata() const
+{
 	return m_pluginId;
 }
 
 QString LuaCallbackEngine::pluginName() const
 {
 	bindOrAssertExecutionThread("LuaCallbackEngine::pluginName");
+	return pluginNameMetadata();
+}
+
+QString LuaCallbackEngine::pluginNameMetadata() const
+{
 	return m_pluginName;
 }
 

--- a/src/LuaCallbackEngine.h
+++ b/src/LuaCallbackEngine.h
@@ -116,10 +116,20 @@ class LuaCallbackEngine
 		 */
 		[[nodiscard]] QString pluginId() const;
 		/**
+		 * @brief Returns plugin id metadata without binding Lua execution-thread affinity.
+		 * @return Plugin id metadata.
+		 */
+		[[nodiscard]] QString pluginIdMetadata() const;
+		/**
 		 * @brief Returns bound plugin display name.
 		 * @return Plugin display name.
 		 */
 		[[nodiscard]] QString pluginName() const;
+		/**
+		 * @brief Returns plugin display-name metadata without binding Lua execution-thread affinity.
+		 * @return Plugin display-name metadata.
+		 */
+		[[nodiscard]] QString pluginNameMetadata() const;
 		/**
 		 * @brief Returns bound plugin directory (legacy type-20 GetPluginInfo value).
 		 * @return Plugin directory with trailing separator when known.

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -34,6 +34,11 @@ namespace
 #else
 	constexpr DWORD kLoadLibrarySearchDefaultDirs = 0x00001000;
 #endif
+#ifdef LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
+	constexpr DWORD kLoadLibrarySearchDllLoadDir = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
+#else
+	constexpr DWORD kLoadLibrarySearchDllLoadDir = 0x00000100;
+#endif
 
 	template <typename Function> Function resolveKernel32Function(HMODULE kernel32, const char *name)
 	{
@@ -42,6 +47,17 @@ namespace
 		static_assert(sizeof(function) == sizeof(procedure));
 		std::memcpy(&function, &procedure, sizeof(function));
 		return function;
+	}
+
+	void preloadBundledOpenSslDll(const QString &dllPath, bool useModernSearchFlags)
+	{
+		const wchar_t *path = reinterpret_cast<const wchar_t *>(dllPath.utf16());
+		const HMODULE  module =
+		    useModernSearchFlags
+		        ? LoadLibraryExW(path, nullptr, kLoadLibrarySearchDllLoadDir | kLoadLibrarySearchDefaultDirs)
+		        : LoadLibraryW(path);
+		if (!module)
+			qWarning() << "Failed to preload bundled OpenSSL DLL" << dllPath << "error" << GetLastError();
 	}
 #endif
 
@@ -93,14 +109,23 @@ namespace
 		auto addDllDirectoryFn = resolveKernel32Function<AddDllDirectoryFn>(kernel32, "AddDllDirectory");
 		if (setDefaultDllDirectoriesFn && addDllDirectoryFn)
 		{
-			setDefaultDllDirectoriesFn(kLoadLibrarySearchDefaultDirs);
-			addDllDirectoryFn(libDirPath);
+			if (!setDefaultDllDirectoriesFn(kLoadLibrarySearchDefaultDirs))
+				qWarning() << "SetDefaultDllDirectories failed with error" << GetLastError();
+			if (!addDllDirectoryFn(libDirPath))
+				qWarning() << "AddDllDirectory failed for" << libDir << "with error" << GetLastError();
+			preloadBundledOpenSslDll(libDir + QStringLiteral("\\libcrypto-3-x64.dll"), true);
+			preloadBundledOpenSslDll(libDir + QStringLiteral("\\libssl-3-x64.dll"), true);
 			return;
 		}
 
 		auto setDllDirectoryWFn = resolveKernel32Function<SetDllDirectoryWFn>(kernel32, "SetDllDirectoryW");
 		if (setDllDirectoryWFn)
-			setDllDirectoryWFn(libDirPath);
+		{
+			if (!setDllDirectoryWFn(libDirPath))
+				qWarning() << "SetDllDirectory failed for" << libDir << "with error" << GetLastError();
+			preloadBundledOpenSslDll(libDir + QStringLiteral("\\libcrypto-3-x64.dll"), false);
+			preloadBundledOpenSslDll(libDir + QStringLiteral("\\libssl-3-x64.dll"), false);
+		}
 	}
 #endif
 } // namespace

--- a/src/TelnetProcessor.cpp
+++ b/src/TelnetProcessor.cpp
@@ -518,11 +518,13 @@ void TelnetProcessor::resetConnectionState()
 	m_subnegotiationData.clear();
 	m_outbound.clear();
 	m_ansiBuffer.clear();
+	m_pendingPacketTransformBytes.clear();
 	m_outputSize = 0;
 	m_mxpPhase   = MXP_NONE;
 	m_mxpString.clear();
 	m_mxpEvents.clear();
 	m_mxpModeChanges.clear();
+	m_telnetPluginEvents.clear();
 	m_mxpEventsOverflowed = false;
 	m_mxpEventSequence    = 0;
 	m_mxpEnabled          = false;
@@ -574,19 +576,233 @@ void TelnetProcessor::queueInitialNegotiation(const bool requestSga, const bool 
 
 QByteArray TelnetProcessor::processBytes(const QByteArray &data)
 {
-	if (data.isEmpty())
+	return processBytes(data, {});
+}
+
+QByteArray TelnetProcessor::processBytes(const QByteArray              &data,
+                                         const PacketTransformCallback &packetTransform)
+{
+	if (data.isEmpty() && m_pendingPacketTransformBytes.isEmpty())
 		return {};
 
 	m_outputSize = 0;
 
+	QByteArray input = m_pendingPacketTransformBytes + data;
+	m_pendingPacketTransformBytes.clear();
+
 	QByteArray output;
 	QByteArray tailPlain;
-	auto       takePostCompressionRemainder = [&]
+	auto       appendPlainBytes = [&](QByteArray plain)
+	{
+		if (plain.isEmpty())
+			return;
+		if (packetTransform)
+			packetTransform(plain);
+		if (!plain.isEmpty())
+			output.append(processPlainBytes(plain));
+	};
+	struct MccpActivationRange
+	{
+			qsizetype start{-1};
+			qsizetype end{-1};
+			qsizetype holdStart{-1};
+	};
+	auto findSubnegotiationEnd = [](const QByteArray &bytes, const qsizetype start) -> qsizetype
+	{
+		for (qsizetype i = start; i + 1 < bytes.size(); ++i)
+		{
+			if (static_cast<unsigned char>(bytes.at(i)) != IAC)
+				continue;
+			const auto next = static_cast<unsigned char>(bytes.at(i + 1));
+			if (next == IAC)
+			{
+				++i;
+				continue;
+			}
+			if (next == SE)
+				return i + 2;
+		}
+		return -1;
+	};
+	auto findMccpActivationRange = [&](const QByteArray &bytes) -> MccpActivationRange
+	{
+		if (bytes.isEmpty())
+			return {};
+
+		auto rangeForSubnegotiation = [&](const qsizetype startOffset, const qsizetype optionOffset,
+		                                  const bool holdIncomplete) -> MccpActivationRange
+		{
+			if (optionOffset >= bytes.size())
+				return holdIncomplete ? MccpActivationRange{-1, -1, startOffset} : MccpActivationRange{};
+			const auto option = static_cast<unsigned char>(bytes.at(optionOffset));
+			if (option == TELOPT_COMPRESS2)
+			{
+				const qsizetype end = findSubnegotiationEnd(bytes, optionOffset + 1);
+				if (end < 0)
+					return holdIncomplete ? MccpActivationRange{-1, -1, startOffset}
+					                      : MccpActivationRange{startOffset, bytes.size(), -1};
+				return {startOffset, end, -1};
+			}
+			if (option == TELOPT_COMPRESS)
+			{
+				if (optionOffset + 1 >= bytes.size())
+					return holdIncomplete ? MccpActivationRange{-1, -1, startOffset} : MccpActivationRange{};
+				if (static_cast<unsigned char>(bytes.at(optionOffset + 1)) == WILL)
+				{
+					const qsizetype terminatorOffset = optionOffset + 2;
+					if (terminatorOffset >= bytes.size())
+						return holdIncomplete ? MccpActivationRange{-1, -1, startOffset}
+						                      : MccpActivationRange{};
+					if (static_cast<unsigned char>(bytes.at(terminatorOffset)) != IAC)
+						return {};
+					const qsizetype end = findSubnegotiationEnd(bytes, terminatorOffset);
+					if (end < 0)
+						return holdIncomplete ? MccpActivationRange{-1, -1, startOffset}
+						                      : MccpActivationRange{startOffset, bytes.size(), -1};
+					return {startOffset, end, -1};
+				}
+			}
+			return {};
+		};
+
+		switch (m_phase)
+		{
+		case HAVE_IAC:
+			if (static_cast<unsigned char>(bytes.at(0)) == SB)
+				return rangeForSubnegotiation(0, 1, true);
+			break;
+		case HAVE_SB:
+			return rangeForSubnegotiation(0, 0, true);
+		case HAVE_SUBNEGOTIATION:
+			if (m_subnegotiationType == TELOPT_COMPRESS2)
+			{
+				const qsizetype end = findSubnegotiationEnd(bytes, 0);
+				if (end < 0)
+					return {-1, -1, 0};
+				return {0, end, -1};
+			}
+			return {};
+		case HAVE_SUBNEGOTIATION_IAC:
+			if (m_subnegotiationType == TELOPT_COMPRESS2)
+			{
+				if (static_cast<unsigned char>(bytes.at(0)) != IAC)
+					return {0, 1, -1};
+				const qsizetype end = findSubnegotiationEnd(bytes, 1);
+				if (end < 0)
+					return {-1, -1, 0};
+				return {0, end, -1};
+			}
+			return {};
+		case HAVE_COMPRESS:
+			if (static_cast<unsigned char>(bytes.at(0)) == WILL)
+			{
+				const qsizetype end = findSubnegotiationEnd(bytes, 1);
+				if (end < 0)
+					return {-1, -1, 0};
+				return {0, end, -1};
+			}
+			return {};
+		case HAVE_COMPRESS_WILL:
+			if (m_seenCompressWillIac && static_cast<unsigned char>(bytes.at(0)) == SE)
+				return {0, 1, -1};
+			{
+				const qsizetype end = findSubnegotiationEnd(bytes, 0);
+				if (end < 0)
+					return {-1, -1, 0};
+				return {0, end, -1};
+			}
+		default:
+			break;
+		}
+
+		for (qsizetype i = 0; i < bytes.size(); ++i)
+		{
+			if (static_cast<unsigned char>(bytes.at(i)) != IAC)
+				continue;
+
+			if (i + 1 >= bytes.size())
+				return {-1, -1, i};
+
+			const auto command = static_cast<unsigned char>(bytes.at(i + 1));
+			if (command == IAC)
+			{
+				++i;
+				continue;
+			}
+			if (command != SB)
+			{
+				if (command == WILL || command == WONT || command == DO || command == DONT)
+				{
+					if (i + 2 >= bytes.size())
+						return {-1, -1, i};
+					i += 2;
+				}
+				else
+				{
+					++i;
+				}
+				continue;
+			}
+
+			const MccpActivationRange range = rangeForSubnegotiation(i, i + 2, true);
+			if (range.start >= 0)
+				return range;
+			if (range.holdStart >= 0)
+				return range;
+
+			const qsizetype subnegotiationEnd = findSubnegotiationEnd(bytes, i + 3);
+			if (subnegotiationEnd < 0)
+				return {};
+			i = subnegotiationEnd - 1;
+		}
+		return {};
+	};
+	auto takePostCompressionRemainder = [&]
 	{
 		if (m_postCompressionRemainder.isEmpty())
 			return;
 		tailPlain.append(m_postCompressionRemainder);
 		m_postCompressionRemainder.clear();
+	};
+	auto processCompressedBytes = [&](const QByteArray &compressed)
+	{
+		if (compressed.isEmpty())
+			return;
+		m_totalCompressedBytes += compressed.size();
+		if (const QByteArray decompressed = inflateIfNeeded(compressed); !decompressed.isEmpty())
+		{
+			m_totalUncompressedBytes += decompressed.size();
+			appendPlainBytes(decompressed);
+		}
+		takePostCompressionRemainder();
+	};
+	std::function<void(const QByteArray &)> processUncompressedBytes;
+	processUncompressedBytes = [&](const QByteArray &bytes)
+	{
+		if (bytes.isEmpty())
+			return;
+		const MccpActivationRange activationRange = findMccpActivationRange(bytes);
+		if (activationRange.start < 0)
+		{
+			if (activationRange.holdStart >= 0)
+			{
+				appendPlainBytes(bytes.left(activationRange.holdStart));
+				m_pendingPacketTransformBytes = bytes.mid(activationRange.holdStart);
+				return;
+			}
+			appendPlainBytes(bytes);
+			return;
+		}
+
+		appendPlainBytes(bytes.left(activationRange.start));
+		output.append(
+		    processPlainBytes(bytes.mid(activationRange.start, activationRange.end - activationRange.start)));
+
+		const QByteArray compressedTail = bytes.mid(activationRange.end);
+		if (m_compress)
+			processCompressedBytes(compressedTail);
+		else
+			processUncompressedBytes(compressedTail);
 	};
 	auto drainPendingCompressed = [&]
 	{
@@ -594,14 +810,7 @@ QByteArray TelnetProcessor::processBytes(const QByteArray &data)
 		{
 			const QByteArray pendingChunk = m_pendingCompressed;
 			m_pendingCompressed.clear();
-			m_totalCompressedBytes += pendingChunk.size();
-			const QByteArray decompressed = inflateIfNeeded(pendingChunk);
-			if (!decompressed.isEmpty())
-			{
-				m_totalUncompressedBytes += decompressed.size();
-				output.append(processPlainBytes(decompressed));
-			}
-			takePostCompressionRemainder();
+			processCompressedBytes(pendingChunk);
 		}
 	};
 
@@ -611,18 +820,14 @@ QByteArray TelnetProcessor::processBytes(const QByteArray &data)
 		// compressed bytes from telnet parsing must be processed before fresh socket
 		// payload.
 		drainPendingCompressed();
-		m_totalCompressedBytes += data.size();
-		if (const QByteArray decompressed = inflateIfNeeded(data); !decompressed.isEmpty())
-		{
-			m_totalUncompressedBytes += decompressed.size();
-			output.append(processPlainBytes(decompressed));
-		}
-		takePostCompressionRemainder();
-		drainPendingCompressed();
+		if (m_compress)
+			processCompressedBytes(input);
+		else
+			processUncompressedBytes(input);
 	}
 	else
 	{
-		output = processPlainBytes(data);
+		processUncompressedBytes(input);
 	}
 
 	while (true)
@@ -637,7 +842,7 @@ QByteArray TelnetProcessor::processBytes(const QByteArray &data)
 		{
 			const QByteArray plainTail = tailPlain;
 			tailPlain.clear();
-			output.append(processPlainBytes(plainTail));
+			processUncompressedBytes(plainTail);
 			progressed = true;
 		}
 		if (!progressed)
@@ -652,6 +857,13 @@ QByteArray TelnetProcessor::takeOutboundData()
 	QByteArray out = m_outbound;
 	m_outbound.clear();
 	return out;
+}
+
+QList<TelnetProcessor::TelnetPluginEvent> TelnetProcessor::takeTelnetPluginEvents()
+{
+	QList<TelnetPluginEvent> events = m_telnetPluginEvents;
+	m_telnetPluginEvents.clear();
+	return events;
 }
 
 QList<TelnetProcessor::MxpEvent> TelnetProcessor::takeMxpEvents()
@@ -1387,6 +1599,7 @@ QByteArray TelnetProcessor::processPlainBytes(const QByteArray &data)
 				break;
 			case GA:
 			case EOR:
+				appendTelnetPluginEvent(TelnetPluginEvent::IacGa, c, {});
 				if (m_callbacks.onIacGa)
 					m_callbacks.onIacGa();
 				if (m_convertGAtoNewline)
@@ -1835,14 +2048,21 @@ QByteArray TelnetProcessor::processPlainBytes(const QByteArray &data)
 			else if (m_subnegotiationType == TELOPT_MUD_SPECIFIC)
 			{
 				// stuff for Aardwolf (telopt 102) - call specific plugin handler: OnPluginTelnetOption
+				appendTelnetPluginEvent(TelnetPluginEvent::Option, m_subnegotiationType,
+				                        m_subnegotiationData);
 				if (m_callbacks.onTelnetOption)
 					m_callbacks.onTelnetOption(m_subnegotiationData);
+				appendTelnetPluginEvent(TelnetPluginEvent::Subnegotiation, m_subnegotiationType,
+				                        m_subnegotiationData);
 				if (m_callbacks.onTelnetSubnegotiation)
 					m_callbacks.onTelnetSubnegotiation(m_subnegotiationType, m_subnegotiationData);
 			}
-			else if (m_callbacks.onTelnetSubnegotiation)
+			else
 			{
-				m_callbacks.onTelnetSubnegotiation(m_subnegotiationType, m_subnegotiationData);
+				appendTelnetPluginEvent(TelnetPluginEvent::Subnegotiation, m_subnegotiationType,
+				                        m_subnegotiationData);
+				if (m_callbacks.onTelnetSubnegotiation)
+					m_callbacks.onTelnetSubnegotiation(m_subnegotiationType, m_subnegotiationData);
 			}
 			m_phase = NONE;
 			break;
@@ -2117,6 +2337,18 @@ void TelnetProcessor::sendWindowSize()
 	}
 	response.append(reinterpret_cast<const char *>(p2), sizeof p2);
 	m_outbound.append(response);
+}
+
+void TelnetProcessor::appendTelnetPluginEvent(const TelnetPluginEvent::Type type, const int option,
+                                              const QByteArray &data)
+{
+	TelnetPluginEvent event;
+	event.type     = type;
+	event.offset   = m_outputSize;
+	event.sequence = m_mxpEventSequence++;
+	event.option   = option;
+	event.data     = data;
+	m_telnetPluginEvents.append(event);
 }
 
 // here when element collection complete

--- a/src/TelnetProcessor.h
+++ b/src/TelnetProcessor.h
@@ -14,6 +14,8 @@
 #define QMUD_TELNETPROCESSOR_H
 
 #include <QByteArray>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QList>
 #include <QMap>
 #include <QString>
 #include <array>
@@ -191,10 +193,42 @@ class TelnetProcessor
 		 */
 		QByteArray processBytes(const QByteArray &data);
 		/**
+		 * @brief Callback that can transform decompressed bytes before telnet/MXP parsing.
+		 */
+		using PacketTransformCallback = std::function<void(QByteArray &)>;
+		/**
+		 * @brief Processes incoming bytes and transforms each decompressed packet before parsing.
+		 * @param data Incoming raw bytes.
+		 * @param packetTransform Transform applied after MCCP decompression and before telnet parsing.
+		 * @return Processed/plain payload bytes for output.
+		 */
+		QByteArray processBytes(const QByteArray &data, const PacketTransformCallback &packetTransform);
+		/**
+		 * @brief Plugin-visible telnet event emitted at a position in processed output.
+		 */
+		struct TelnetPluginEvent
+		{
+				enum Type
+				{
+					IacGa,
+					Option,
+					Subnegotiation
+				} type{Subnegotiation};
+				int        offset{0};
+				int        sequence{0};
+				int        option{0};
+				QByteArray data;
+		};
+		/**
+		 * @brief Returns and clears plugin-visible telnet events since the previous call.
+		 * @return Ordered telnet plugin events.
+		 */
+		QList<TelnetPluginEvent> takeTelnetPluginEvents();
+		/**
 		 * @brief Returns and clears bytes queued for outbound socket write.
 		 * @return Queued outbound bytes.
 		 */
-		QByteArray takeOutboundData();
+		QByteArray               takeOutboundData();
 		/**
 		 * @brief Parsed MXP token emitted during stream processing.
 		 */
@@ -590,31 +624,39 @@ class TelnetProcessor
 		 * @brief Sends current NAWS window size.
 		 */
 		void                     sendWindowSize();
+		/**
+		 * @brief Records a plugin-visible telnet event at the current output position.
+		 * @param type Plugin event type.
+		 * @param option Telnet option number.
+		 * @param data Telnet event payload bytes.
+		 */
+		void       appendTelnetPluginEvent(TelnetPluginEvent::Type type, int option, const QByteArray &data);
 
-		Phase                    m_phase{NONE};
-		int                      m_code{0};
-		bool                     m_convertGAtoNewline{false};
-		bool                     m_noEchoOff{false};
-		bool                     m_noEcho{false};
-		bool                     m_utf8{false};
-		int                      m_useMxp{3}; // eNoMXP by default
-		bool                     m_naws{false};
-		bool                     m_nawsWanted{false};
-		int                      m_wrapColumns{0};
-		int                      m_wrapRows{0};
-		int                      m_ttypeSequence{0};
-		QString                  m_terminalIdentification{QStringLiteral("QMud")};
+		Phase      m_phase{NONE};
+		int        m_code{0};
+		bool       m_convertGAtoNewline{false};
+		bool       m_noEchoOff{false};
+		bool       m_noEcho{false};
+		bool       m_utf8{false};
+		int        m_useMxp{3}; // eNoMXP by default
+		bool       m_naws{false};
+		bool       m_nawsWanted{false};
+		int        m_wrapColumns{0};
+		int        m_wrapRows{0};
+		int        m_ttypeSequence{0};
+		QString    m_terminalIdentification{QStringLiteral("QMud")};
 
-		int                      m_subnegotiationType{0};
-		QByteArray               m_subnegotiationData;
-		QByteArray               m_outbound;
-		QByteArray               m_ansiBuffer;
-		QByteArray               m_pendingCompressed;
-		QByteArray               m_compressInput;
-		QByteArray               m_compressOutputChunk;
-		QByteArray               m_postCompressionRemainder;
-		int                      m_compressInputOffset{0};
-		int                      m_outputSize{0};
+		int        m_subnegotiationType{0};
+		QByteArray m_subnegotiationData;
+		QByteArray m_outbound;
+		QByteArray m_ansiBuffer;
+		QByteArray m_pendingPacketTransformBytes;
+		QByteArray m_pendingCompressed;
+		QByteArray m_compressInput;
+		QByteArray m_compressOutputChunk;
+		QByteArray m_postCompressionRemainder;
+		int        m_compressInputOffset{0};
+		int        m_outputSize{0};
 
 		enum MxpPhase
 		{
@@ -647,6 +689,7 @@ class TelnetProcessor
 		QMap<QByteArray, CustomElement> m_customElements;
 		QList<MxpEvent>                 m_mxpEvents;
 		QList<MxpModeChange>            m_mxpModeChanges;
+		QList<TelnetPluginEvent>        m_telnetPluginEvents;
 		bool                            m_mxpEventsOverflowed{false};
 		int                             m_mxpEventSequence{0};
 		Callbacks                       m_callbacks;

--- a/src/WorldChildWindow.cpp
+++ b/src/WorldChildWindow.cpp
@@ -296,13 +296,8 @@ void WorldChildWindow::bindRuntime(WorldRuntime *worldRuntime, const RuntimeBind
 			    const bool    suppressConnectNote = worldRuntime->reloadReattachConnectActionsSuppressed();
 			    const QString flag =
 			        worldRuntime->worldAttributes().value(QStringLiteral("show_connect_disconnect"));
-			    const bool show = flag.isEmpty() ||
-			                      flag.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
-			                      flag == QStringLiteral("1") ||
-			                      flag.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
-			    if (!show && !suppressConnectNote)
-				    return;
-			    if (!suppressConnectNote)
+			    if (const bool show = flag.isEmpty() || isEnabledFlagValue(flag);
+			        show && !suppressConnectNote)
 			    {
 				    const QString when =
 				        QDateTime::currentDateTime().toString(QStringLiteral("dddd, MMMM dd, yyyy, h:mm AP"));
@@ -323,12 +318,6 @@ void WorldChildWindow::bindRuntime(WorldRuntime *worldRuntime, const RuntimeBind
 			    if (m_view && shouldFocusInput)
 				    m_view->focusInput();
 		    });
-		connect(worldRuntime, &WorldRuntime::disconnected, this,
-		        [this]
-		        {
-			        if (MainWindowHost *main = resolveMainWindowHost(window()))
-				        main->updateActivityToolbarButtons();
-		        });
 		connect(
 		    worldRuntime, &WorldRuntime::socketError, this,
 		    [this, worldRuntime](const QString &message)
@@ -397,41 +386,43 @@ void WorldChildWindow::bindRuntime(WorldRuntime *worldRuntime, const RuntimeBind
 		    {
 			    if (!m_view || !worldRuntime)
 				    return;
+			    if (MainWindowHost *main = resolveMainWindowHost(window()))
+				    main->updateActivityToolbarButtons();
 			    const QString flag =
 			        worldRuntime->worldAttributes().value(QStringLiteral("show_connect_disconnect"));
-			    const bool show = flag.isEmpty() ||
-			                      flag.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
-			                      flag == QStringLiteral("1") ||
-			                      flag.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
-			    if (!show)
-				    return;
-			    const QString when =
-			        QDateTime::currentDateTime().toString(QStringLiteral("dddd, MMMM dd, yyyy, h:mm AP"));
-			    if (m_commandProcessor)
-				    m_commandProcessor->note(QStringLiteral("--- Disconnected on %1 ---").arg(when), true);
-			    else if (m_view)
-				    m_view->appendNoteText(QStringLiteral("--- Disconnected on %1 ---").arg(when), true);
-			    if (worldRuntime->connectTime().isValid())
+			    if (const bool show = flag.isEmpty() || isEnabledFlagValue(flag); show)
 			    {
-				    const qint64  seconds = worldRuntime->connectTime().secsTo(QDateTime::currentDateTime());
-				    const qint64  days    = seconds / 86400;
-				    const qint64  hours   = seconds % 86400 / 3600;
-				    const qint64  minutes = seconds % 3600 / 60;
-				    const qint64  secs    = seconds % 60;
-				    const QString duration =
-				        QStringLiteral("--- Connected for %1 day%2, %3 hour%4, %5 minute%6, %7 second%8. ---")
-				            .arg(days)
-				            .arg(days == 1 ? QString() : QStringLiteral("s"))
-				            .arg(hours)
-				            .arg(hours == 1 ? QString() : QStringLiteral("s"))
-				            .arg(minutes)
-				            .arg(minutes == 1 ? QString() : QStringLiteral("s"))
-				            .arg(secs)
-				            .arg(secs == 1 ? QString() : QStringLiteral("s"));
+				    const QString when =
+				        QDateTime::currentDateTime().toString(QStringLiteral("dddd, MMMM dd, yyyy, h:mm AP"));
 				    if (m_commandProcessor)
-					    m_commandProcessor->note(duration, true);
+					    m_commandProcessor->note(QStringLiteral("--- Disconnected on %1 ---").arg(when),
+					                             true);
 				    else if (m_view)
-					    m_view->appendNoteText(duration, true);
+					    m_view->appendNoteText(QStringLiteral("--- Disconnected on %1 ---").arg(when), true);
+				    if (worldRuntime->connectTime().isValid())
+				    {
+					    const qint64 seconds =
+					        worldRuntime->connectTime().secsTo(QDateTime::currentDateTime());
+					    const qint64  days    = seconds / 86400;
+					    const qint64  hours   = seconds % 86400 / 3600;
+					    const qint64  minutes = seconds % 3600 / 60;
+					    const qint64  secs    = seconds % 60;
+					    const QString duration =
+					        QStringLiteral(
+					            "--- Connected for %1 day%2, %3 hour%4, %5 minute%6, %7 second%8. ---")
+					            .arg(days)
+					            .arg(days == 1 ? QString() : QStringLiteral("s"))
+					            .arg(hours)
+					            .arg(hours == 1 ? QString() : QStringLiteral("s"))
+					            .arg(minutes)
+					            .arg(minutes == 1 ? QString() : QStringLiteral("s"))
+					            .arg(secs)
+					            .arg(secs == 1 ? QString() : QStringLiteral("s"));
+					    if (m_commandProcessor)
+						    m_commandProcessor->note(duration, true);
+					    else if (m_view)
+						    m_view->appendNoteText(duration, true);
+				    }
 			    }
 			    if (m_commandProcessor)
 			    {

--- a/src/WorldCommandProcessor.cpp
+++ b/src/WorldCommandProcessor.cpp
@@ -3649,10 +3649,10 @@ void WorldCommandProcessor::sendTo(const int sendTo, const QString &text, const 
 	switch (sendTo)
 	{
 	case eSendToWorld:
-		sendMsg(QMudCommandText::normalizeActionCommandTextForSend(text), echoSend, false, logIt);
+		sendMsg(QMudCommandText::normalizeActionCommandTextNewlines(text), echoSend, false, logIt);
 		break;
 	case eSendToCommandQueue:
-		sendMsg(QMudCommandText::normalizeActionCommandTextForSend(text), echoSend, true, logIt);
+		sendMsg(QMudCommandText::normalizeActionCommandTextNewlines(text), echoSend, true, logIt);
 		break;
 	case eSendToSpeedwalk:
 	{
@@ -3712,7 +3712,13 @@ void WorldCommandProcessor::sendTo(const int sendTo, const QString &text, const 
 		const bool saved = m_suppressInputLog;
 		if (omitFromLog)
 			m_suppressInputLog = true;
-		executeCommand(text);
+		const QString     normalized = QMudCommandText::normalizeActionCommandTextNewlines(text);
+		const QStringList commands   = normalized.split(kEndLine, Qt::SkipEmptyParts);
+		if (!commands.isEmpty())
+		{
+			for (const QString &command : commands)
+				executeCommand(command);
+		}
 		m_suppressInputLog = saved;
 	}
 	break;

--- a/src/WorldCommandProcessor.cpp
+++ b/src/WorldCommandProcessor.cpp
@@ -3609,10 +3609,10 @@ void WorldCommandProcessor::sendTo(const int sendTo, const QString &text, const 
 	switch (sendTo)
 	{
 	case eSendToWorld:
-		sendMsg(text, echoSend, false, logIt);
+		sendMsg(QMudCommandText::normalizeActionCommandTextForSend(text), echoSend, false, logIt);
 		break;
 	case eSendToCommandQueue:
-		sendMsg(text, echoSend, true, logIt);
+		sendMsg(QMudCommandText::normalizeActionCommandTextForSend(text), echoSend, true, logIt);
 		break;
 	case eSendToSpeedwalk:
 	{

--- a/src/WorldCommandProcessor.cpp
+++ b/src/WorldCommandProcessor.cpp
@@ -1168,9 +1168,15 @@ const QStringList &WorldCommandProcessor::queuedCommands() const
 	return m_queuedCommands;
 }
 
+int WorldCommandProcessor::triggerPriorityQueuedCommandCount() const
+{
+	return m_triggerPriorityQueuedCommands;
+}
+
 int WorldCommandProcessor::discardQueuedCommands()
 {
-	const int count = QMudCommandQueue::discardAll(m_queuedCommands);
+	const int count                 = QMudCommandQueue::discardAll(m_queuedCommands);
+	m_triggerPriorityQueuedCommands = 0;
 	if (m_runtime)
 		m_runtime->setQueuedCommandCount(0);
 	updateQueuedCommandsStatusLine();
@@ -1192,6 +1198,14 @@ int WorldCommandProcessor::executeCommand(const QString &text)
 	evaluateCommand(text);
 	--m_executionDepth;
 	return eOK;
+}
+
+int WorldCommandProcessor::executeCommandWithTriggerPriority(const QString &text)
+{
+	++m_triggerCommandPriorityDepth;
+	const auto restoreTriggerCommandPriority = qScopeGuard([this] { --m_triggerCommandPriorityDepth; });
+	Q_UNUSED(restoreTriggerCommandPriority);
+	return executeCommand(text);
 }
 
 void WorldCommandProcessor::sendToFromAccelerator(int sendTo, const QString &text, const QString &description,
@@ -1699,12 +1713,27 @@ void WorldCommandProcessor::sendRawText(const QString &text, const bool echo, co
 		m_view->addToHistoryForced(text);
 }
 
+void WorldCommandProcessor::sendRawTextWithTriggerPriority(const QString &text, const bool echo,
+                                                           const bool queue, const bool log,
+                                                           const bool history)
+{
+	++m_triggerCommandPriorityDepth;
+	const auto restoreTriggerCommandPriority = qScopeGuard([this] { --m_triggerCommandPriorityDepth; });
+	Q_UNUSED(restoreTriggerCommandPriority);
+	sendRawText(text, echo, queue, log, history);
+}
+
 void WorldCommandProcessor::sendImmediateText(const QString &text, const bool echo, const bool log,
                                               const bool history)
 {
 	doSendMsg(text, echo, log);
 	if (history && m_view)
 		m_view->addToHistoryForced(text);
+}
+
+void WorldCommandProcessor::sendDeferredInboundText(const QString &text, const bool echo, const bool log)
+{
+	doSendMsg(text, echo, log);
 }
 
 void WorldCommandProcessor::logInputCommand(const QString &text) const
@@ -3605,6 +3634,17 @@ void WorldCommandProcessor::sendTo(const int sendTo, const QString &text, const 
 	const bool logIt     = logInput && !omitFromLog;
 	const bool fromTimer = m_runtime && m_runtime->currentActionSource() == WorldRuntime::eTimerFired;
 	const bool echoSend  = omitFromOutput ? false : (fromTimer ? true : echoInput);
+	const bool triggerCommandPriority = m_runtime &&
+	                                    m_runtime->currentActionSource() == WorldRuntime::eTriggerFired &&
+	                                    (sendTo == eSendToWorld || sendTo == eSendToExecute);
+	if (triggerCommandPriority)
+		++m_triggerCommandPriorityDepth;
+	[[maybe_unused]] const auto restoreTriggerCommandPriority = qScopeGuard(
+	    [this, triggerCommandPriority]
+	    {
+		    if (triggerCommandPriority)
+			    --m_triggerCommandPriorityDepth;
+	    });
 
 	switch (sendTo)
 	{
@@ -3830,11 +3870,27 @@ void WorldCommandProcessor::sendMsg(const QString &text, const bool echo, const 
 
 		if (QMudCommandQueue::shouldQueueCommand(m_speedWalkDelay, queueIt, !m_queuedCommands.isEmpty()))
 		{
-			m_queuedCommands.append(QMudCommandQueue::encodeQueueEntry(strLine, queueIt, bEcho, logIt));
+			const QString encoded = QMudCommandQueue::encodeQueueEntry(strLine, queueIt, bEcho, logIt);
+			if (const bool triggerPriority = !queueIt && m_triggerCommandPriorityDepth > 0; triggerPriority)
+			{
+				const int insertAt =
+				    qBound(0, m_triggerPriorityQueuedCommands, safeQSizeToInt(m_queuedCommands.size()));
+				m_queuedCommands.insert(insertAt, encoded);
+				m_triggerPriorityQueuedCommands = insertAt + 1;
+			}
+			else
+			{
+				m_queuedCommands.append(encoded);
+			}
 
 		} // end of having a speedwalk delay
 		else
+		{
+			const bool triggerPriority = !queueIt && m_triggerCommandPriorityDepth > 0;
+			if (m_runtime && m_runtime->deferInboundImmediateCommand(strLine, bEcho, logIt, triggerPriority))
+				continue;
 			doSendMsg(strLine, bEcho, logIt); // just send it
+		}
 	} // end of breaking it into lines
 
 	if (!m_queuedCommands.isEmpty())
@@ -4114,8 +4170,11 @@ void WorldCommandProcessor::processQueuedCommands(bool flushAll)
 		}
 	}
 
-	bool              sentAny = false;
-	const QStringList batch   = QMudCommandQueue::takeDispatchBatch(m_queuedCommands, flushAll);
+	bool              sentAny         = false;
+	const int         queuedBefore    = safeQSizeToInt(m_queuedCommands.size());
+	const QStringList batch           = QMudCommandQueue::takeDispatchBatch(m_queuedCommands, flushAll);
+	const int         removedFromHead = queuedBefore - safeQSizeToInt(m_queuedCommands.size());
+	m_triggerPriorityQueuedCommands   = qMax(0, m_triggerPriorityQueuedCommands - removedFromHead);
 	for (const QString &queued : batch)
 	{
 		const QMudCommandQueue::QueueEntry decoded = QMudCommandQueue::decodeQueueEntry(queued);
@@ -4127,6 +4186,8 @@ void WorldCommandProcessor::processQueuedCommands(bool flushAll)
 		m_queueDispatchTimer.restart();
 	if (flushAll && m_queueDispatchTimer.isValid())
 		m_queueDispatchTimer.invalidate();
+	if (m_queuedCommands.isEmpty())
+		m_triggerPriorityQueuedCommands = 0;
 
 	if (m_runtime)
 		m_runtime->setQueuedCommandCount(safeQSizeToInt(m_queuedCommands.size()));

--- a/src/WorldCommandProcessor.h
+++ b/src/WorldCommandProcessor.h
@@ -56,6 +56,11 @@ class WorldCommandProcessor : public QObject
 		 */
 		const QStringList &queuedCommands() const;
 		/**
+		 * @brief Returns count of trigger-priority commands at the queue front.
+		 * @return Number of front-band trigger-priority queued commands.
+		 */
+		int                triggerPriorityQueuedCommandCount() const;
+		/**
 		 * @brief Clears queued commands and returns number discarded.
 		 * @return Discarded command count.
 		 */
@@ -72,6 +77,12 @@ class WorldCommandProcessor : public QObject
 		 * @return Execution status/result code.
 		 */
 		int                executeCommand(const QString &text);
+		/**
+		 * @brief Executes one direct trigger-script command with priority over queued movement.
+		 * @param text Command text.
+		 * @return Execution status/result code.
+		 */
+		int                executeCommandWithTriggerPriority(const QString &text);
 		/**
 		 * @brief Sends text using explicit send-target from accelerator context.
 		 * @param sendTo Send-target enum value.
@@ -158,6 +169,16 @@ class WorldCommandProcessor : public QObject
 		 */
 		void sendRawText(const QString &text, bool echo, bool queue, bool log, bool history);
 		/**
+		 * @brief Sends direct trigger-script raw command text with priority over queued movement.
+		 * @param text Command text.
+		 * @param echo Echo command when `true`.
+		 * @param queue Queue command when `true`.
+		 * @param log Log command when `true`.
+		 * @param history Add command to history when `true`.
+		 */
+		void sendRawTextWithTriggerPriority(const QString &text, bool echo, bool queue, bool log,
+		                                    bool history);
+		/**
 		 * @brief Sends text immediately bypassing queue delay.
 		 * @param text Command text.
 		 * @param echo Echo command when `true`.
@@ -165,6 +186,13 @@ class WorldCommandProcessor : public QObject
 		 * @param history Add command to history when `true`.
 		 */
 		void sendImmediateText(const QString &text, bool echo, bool log, bool history);
+		/**
+		 * @brief Sends one deferred inbound command line through the immediate send path.
+		 * @param text Command line text.
+		 * @param echo Echo command when `true`.
+		 * @param log Log command when `true`.
+		 */
+		void sendDeferredInboundText(const QString &text, bool echo, bool log);
 		/**
 		 * @brief Writes input line to log according to settings.
 		 * @param text Input text.
@@ -545,6 +573,8 @@ class WorldCommandProcessor : public QObject
 		WorldRuntime                                *m_runtime{nullptr};
 		WorldView                                   *m_view{nullptr};
 		QStringList                                  m_queuedCommands;
+		int                                          m_triggerPriorityQueuedCommands{0};
+		int                                          m_triggerCommandPriorityDepth{0};
 		bool                                         m_queueStatusOwnsMessage{false};
 		int                                          m_speedWalkDelay{0};
 		QString                                      m_speedWalkFiller;

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -568,8 +568,8 @@ namespace
 	{
 		if (!engine)
 			return QStringLiteral("<null>");
-		const QString id   = engine->pluginId().trimmed();
-		const QString name = engine->pluginName().trimmed();
+		const QString id   = engine->pluginIdMetadata().trimmed();
+		const QString name = engine->pluginNameMetadata().trimmed();
 		if (name.isEmpty())
 			return id;
 		return QStringLiteral("%1/%2").arg(id, name);
@@ -588,7 +588,7 @@ namespace
 	{
 		return std::ranges::any_of(
 		    engines, [](const QSharedPointer<LuaCallbackEngine> &engine)
-		    { return engine && qmudMmStartupDiagIsWatchedPluginId(engine->pluginId()); });
+		    { return engine && qmudMmStartupDiagIsWatchedPluginId(engine->pluginIdMetadata()); });
 	}
 
 	bool qmudMmStartupDiagRequestHasWatchedEngine(const LuaBatchDispatchRequest &request)
@@ -609,7 +609,7 @@ namespace
 			return true;
 		return std::ranges::any_of(
 		    recipients, [](const QSharedPointer<LuaCallbackEngine> &engine)
-		    { return engine && qmudMmStartupDiagIsWatchedPluginId(engine->pluginId()); });
+		    { return engine && qmudMmStartupDiagIsWatchedPluginId(engine->pluginIdMetadata()); });
 	}
 
 	QString qmudMmStartupDiagResultLabel(const LuaBatchDispatchResult &result)
@@ -13955,7 +13955,7 @@ void WorldRuntime::storeSuspendedPluginCallbackDispatch(PluginCallbackDispatchCo
 		if (const QSharedPointer<LuaCallbackEngine> &engine =
 		        command.request.engines.at(suspendedEngineIndex);
 		    engine)
-			suspended.pluginId = engine->pluginId();
+			suspended.pluginId = engine->pluginIdMetadata();
 	}
 	suspended.command                     = std::move(command);
 	suspended.partialResult               = std::move(result);

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -714,7 +714,7 @@ namespace
 		    QStringLiteral("OnPluginTelnetOption"),  QStringLiteral("OnPluginPacketReceived"),
 		    QStringLiteral("OnPluginMXPopenTag"),    QStringLiteral("OnPluginMXPcloseTag"),
 		    QStringLiteral("OnPluginMXPsetEntity"),  QStringLiteral("OnPluginMXPsetVariable"),
-		    QStringLiteral("OnPluginSaveState"),
+		    QStringLiteral("OnPluginClose"),         QStringLiteral("OnPluginSaveState"),
 		};
 		return kInputCriticalCallbacks.contains(request.functionName);
 	}
@@ -4288,22 +4288,6 @@ WorldRuntime::WorldRuntime(QObject *parent) : QObject(parent)
 
 WorldRuntime::~WorldRuntime()
 {
-	QMudNativePluginRegistry::discardRuntimeState(this);
-	if (m_viewDestroyedConnection)
-	{
-		QObject::disconnect(m_viewDestroyedConnection);
-		m_viewDestroyedConnection = QMetaObject::Connection{};
-	}
-	m_view = nullptr;
-
-	for (auto &plugin : m_plugins)
-	{
-		if (plugin.lua && hasValidPluginId(plugin))
-			dispatchSingleEngineNoArgCallback(plugin.lua, QStringLiteral("OnPluginClose"), true);
-		savePluginStateForPlugin(plugin, false, nullptr);
-	}
-	m_pluginCallbackDispatchShuttingDown = true;
-
 	QVector<QSharedPointer<LuaCallbackEngine>> enginesToTeardown;
 	enginesToTeardown.reserve((m_luaCallbacks ? 1 : 0) + m_plugins.size());
 	for (auto &plugin : m_plugins)
@@ -4314,7 +4298,24 @@ WorldRuntime::~WorldRuntime()
 	}
 	if (m_luaCallbacks)
 		enginesToTeardown.push_back(makeNonOwningLuaEngineRef(m_luaCallbacks));
+
 	cancelSuspendedPluginCallbackDispatchesForEngines(enginesToTeardown);
+
+	for (auto &plugin : m_plugins)
+	{
+		if (plugin.lua && hasValidPluginId(plugin))
+			dispatchSingleEngineNoArgCallback(plugin.lua, QStringLiteral("OnPluginClose"), true);
+		savePluginStateForPlugin(plugin, false, nullptr);
+	}
+	m_pluginCallbackDispatchShuttingDown = true;
+
+	if (m_viewDestroyedConnection)
+	{
+		QObject::disconnect(m_viewDestroyedConnection);
+		m_viewDestroyedConnection = QMetaObject::Connection{};
+	}
+	m_view = nullptr;
+
 	for (auto &plugin : m_plugins)
 		plugin.lua.clear();
 	dispatchTeardownLuaEngines(enginesToTeardown, true);
@@ -4323,6 +4324,7 @@ WorldRuntime::~WorldRuntime()
 		delete m_luaCallbacks;
 		m_luaCallbacks = nullptr;
 	}
+	QMudNativePluginRegistry::discardRuntimeState(this);
 
 	const QStringList dbNames = m_databases.keys();
 	for (const QString &name : dbNames)
@@ -19711,12 +19713,25 @@ int WorldRuntime::callPluginLua(const QString &pluginId, const QString &routine,
 		    QThread::currentThread() == thread()
 		        ? invokeNative()
 		        : qmudInvokeMethodOr(this, QMudNativePluginRegistry::NativeCallResult{}, invokeNative);
-		lua_pushnumber(callerState, result.errorCode);
 		if (result.errorCode != eOK)
+			return pushCodeAndMessage(result.errorCode, result.errorText);
+		const qsizetype returnValueCount      = result.returnValues.size();
+		constexpr int   kErrorCodeReturnCount = 1;
+		if (returnValueCount > std::numeric_limits<int>::max() - kErrorCodeReturnCount)
 		{
-			pushUtf8String(callerState, result.errorText);
-			return 2;
+			return pushCodeAndMessage(
+			    eErrorCallingPluginRoutine,
+			    QStringLiteral("Native plugin routine '%1' returned too many values").arg(routine));
 		}
+		const int pushedValueCount = static_cast<int>(returnValueCount) + kErrorCodeReturnCount;
+		if (lua_checkstack(callerState, pushedValueCount) == 0)
+		{
+			return pushCodeAndMessage(
+			    eErrorCallingPluginRoutine,
+			    QStringLiteral("Unable to reserve Lua stack space for native plugin routine '%1'")
+			        .arg(routine));
+		}
+		lua_pushnumber(callerState, result.errorCode);
 		for (const QVariant &value : result.returnValues)
 		{
 			switch (value.typeId())
@@ -19736,7 +19751,7 @@ int WorldRuntime::callPluginLua(const QString &pluginId, const QString &routine,
 				break;
 			}
 		}
-		return result.returnValues.size() + 1;
+		return pushedValueCount;
 	}
 
 	if (QThread::currentThread() != thread())

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -4070,20 +4070,14 @@ WorldRuntime::WorldRuntime(QObject *parent) : QObject(parent)
 	TelnetProcessor::Callbacks callbacks;
 	callbacks.onTelnetRequest = [this](int number, const QString &type)
 	{ return callPluginCallbacksStopOnTrue(QStringLiteral("OnPluginTelnetRequest"), number, type); };
-	callbacks.onTelnetSubnegotiation = [this](int number, const QByteArray &data)
+	callbacks.onTelnetSubnegotiation = [](int number, const QByteArray &data)
 	{
-		m_lastTelnetSubnegotiation = QString::fromLatin1(data);
-		callPluginCallbacksWithNumberAndBytes(QStringLiteral("OnPluginTelnetSubnegotiation"), number, data,
-		                                      true);
+		Q_UNUSED(number);
+		Q_UNUSED(data);
 	};
-	callbacks.onTelnetOption = [this](const QByteArray &data)
-	{ callPluginCallbacksWithBytes(QStringLiteral("OnPluginTelnetOption"), data, true); };
-	callbacks.onIacGa = [this]
-	{
-		m_lastLineWithIacGa = m_linesReceived;
-		callPluginCallbacksNoArgs(QStringLiteral("OnPluginIacGa"), true);
-	};
-	callbacks.onMxpStart = [this](bool pueblo, bool manual)
+	callbacks.onTelnetOption = [](const QByteArray &data) { Q_UNUSED(data); };
+	callbacks.onIacGa        = [] {};
+	callbacks.onMxpStart     = [this](bool pueblo, bool manual)
 	{
 		Q_UNUSED(manual);
 		mxpStartUp();
@@ -4438,6 +4432,49 @@ void WorldRuntime::receiveRawData(const QByteArray &data)
 	}
 }
 
+void WorldRuntime::beginInboundCommandDeferralScope() const
+{
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::beginInboundCommandDeferralScope");
+	++m_inboundCommandDeferralDepth;
+}
+
+void WorldRuntime::endInboundCommandDeferralScope() const
+{
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::endInboundCommandDeferralScope");
+	if (m_inboundCommandDeferralDepth <= 0)
+		return;
+	--m_inboundCommandDeferralDepth;
+	if (m_inboundCommandDeferralDepth == 0)
+		flushDeferredInboundCommands();
+}
+
+void WorldRuntime::flushDeferredInboundCommands() const
+{
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::flushDeferredInboundCommands");
+	if (m_flushingDeferredInboundCommands || m_deferredInboundCommands.isEmpty())
+		return;
+
+	const QVector<DeferredInboundCommand> commands = m_deferredInboundCommands;
+	m_deferredInboundCommands.clear();
+	m_deferredInboundTriggerPriorityCommands = 0;
+
+	m_flushingDeferredInboundCommands = true;
+	const auto restoreFlushing        = qScopeGuard([this] { m_flushingDeferredInboundCommands = false; });
+	Q_UNUSED(restoreFlushing);
+	for (const DeferredInboundCommand &command : commands)
+	{
+		if (!m_commandProcessor)
+			break;
+		const unsigned short previousActionSource               = m_currentActionSource;
+		const_cast<WorldRuntime *>(this)->m_currentActionSource = command.actionSource;
+		const auto restoreActionSource =
+		    qScopeGuard([this, previousActionSource]
+		                { const_cast<WorldRuntime *>(this)->m_currentActionSource = previousActionSource; });
+		Q_UNUSED(restoreActionSource);
+		m_commandProcessor->sendDeferredInboundText(command.text, command.echo, command.log);
+	}
+}
+
 void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simulatedInput)
 {
 	if (!simulatedInput)
@@ -4451,6 +4488,8 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 
 	const unsigned short previousActionSource = m_currentActionSource;
 	m_currentActionSource                     = eInputFromServer;
+	beginInboundCommandDeferralScope();
+	const auto    closeInboundCommandDeferral = qScopeGuard([this] { endInboundCommandDeferralScope(); });
 
 	const QString utf8Flag  = m_worldAttributes.value(QStringLiteral("utf_8"));
 	const bool    useUtf8   = isEnabledFlag(utf8Flag);
@@ -4482,7 +4521,8 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 	{
 		// Probe quarantine mode: keep telnet state/protocol negotiation current,
 		// but defer all output/plugin processing until keep/reconnect decision.
-		QByteArray                            processed                 = m_telnet.processBytes(data);
+		QByteArray processed = m_telnet.processBytes(data);
+		static_cast<void>(m_telnet.takeTelnetPluginEvents());
 		QList<TelnetProcessor::MxpEvent>      mxpEventsDuringProbe      = m_telnet.takeMxpEvents();
 		QList<TelnetProcessor::MxpModeChange> mxpModeChangesDuringProbe = m_telnet.takeMxpModeChanges();
 		QByteArray const                      outbound                  = m_telnet.takeOutboundData();
@@ -4587,24 +4627,73 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 		appendPacketDebug(QStringLiteral("Incoming"), data, m_inputPacketCount);
 	}
 
-	// Legacy behavior: packet callbacks run on telnet-processed bytes, not on the
-	// raw compressed stream.
-	QByteArray processed = simulatedInput ? data : m_telnet.processBytes(data);
-	callPluginCallbacksTransformBytes(QStringLiteral("OnPluginPacketReceived"), processed);
+	QByteArray                                processed;
+	QList<TelnetProcessor::TelnetPluginEvent> telnetPluginEvents;
+	auto rebaseTelnetEventOffsetsForRemoval = [&](const qsizetype startOffset, const qsizetype removedSize)
+	{
+		if (removedSize <= 0)
+			return;
+		const int start = safeQSizeToInt(startOffset);
+		const int count = safeQSizeToInt(removedSize);
+		for (TelnetProcessor::TelnetPluginEvent &event : telnetPluginEvents)
+		{
+			if (event.offset <= start)
+				continue;
+			const int removedBeforeEvent = qMin(count, event.offset - start);
+			event.offset -= removedBeforeEvent;
+		}
+	};
+	auto rebaseTelnetEventOffsetsForFilter = [&](const QByteArray &bytes, const auto shouldRemove)
+	{
+		if (telnetPluginEvents.isEmpty())
+			return;
+		QVector<int> removedBefore;
+		removedBefore.reserve(safeQSizeToInt(bytes.size()) + 1);
+		int removed = 0;
+		removedBefore.push_back(0);
+		for (const char ch : bytes)
+		{
+			if (shouldRemove(ch))
+				++removed;
+			removedBefore.push_back(removed);
+		}
+		const int originalSize = safeQSizeToInt(bytes.size());
+		for (TelnetProcessor::TelnetPluginEvent &event : telnetPluginEvents)
+		{
+			const int originalOffset = qBound(0, event.offset, originalSize);
+			event.offset             = originalOffset - removedBefore.at(originalOffset);
+		}
+	};
+	if (simulatedInput)
+	{
+		processed = data;
+		callPluginCallbacksTransformBytes(QStringLiteral("OnPluginPacketReceived"), processed);
+	}
+	else
+	{
+		// Packet callbacks transform each decompressed incoming payload before telnet/MXP
+		// parsing; parser event offsets are then based on the same bytes that render.
+		processed = m_telnet.processBytes(
+		    data, [this](QByteArray &packetPayload)
+		    { callPluginCallbacksTransformBytes(QStringLiteral("OnPluginPacketReceived"), packetPayload); });
+		telnetPluginEvents = m_telnet.takeTelnetPluginEvents();
+	}
 	if (processed.contains('\0'))
 	{
-		QByteArray sanitized;
+		const QByteArray beforeFilter = processed;
+		QByteArray       sanitized;
 		sanitized.reserve(processed.size());
 		for (const char ch : processed)
 		{
 			if (ch != '\0')
 				sanitized.append(ch);
 		}
+		rebaseTelnetEventOffsetsForFilter(beforeFilter, [](const char ch) { return ch == '\0'; });
 		processed.swap(sanitized);
 	}
 
 	// Port of the ReceiveMsg/DisplayMsg line handling:
-	// - pass data through telnet/MCCP phase processing
+	// - pass callback-transformed data through telnet/MCCP phase processing
 	// - accumulate raw bytes
 	// - split on LF
 	// - trim CR
@@ -4615,14 +4704,21 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 		if (const qsizetype marker = processed.indexOf(kPuebloStart); marker >= 0)
 		{
 			m_telnet.activatePuebloMode();
+			rebaseTelnetEventOffsetsForRemoval(marker, kPuebloStart.size());
 			processed.remove(marker, kPuebloStart.size());
 			if (marker < processed.size())
 			{
 				if (marker + 1 < processed.size() && processed.at(marker) == '\r' &&
 				    processed.at(marker + 1) == '\n')
+				{
+					rebaseTelnetEventOffsetsForRemoval(marker, 2);
 					processed.remove(marker, 2);
+				}
 				else if (processed.at(marker) == '\n')
+				{
+					rebaseTelnetEventOffsetsForRemoval(marker, 1);
 					processed.remove(marker, 1);
+				}
 			}
 		}
 	}
@@ -4634,13 +4730,16 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 	}
 	if (bellCount > 0)
 	{
-		QByteArray filtered;
+		const QByteArray beforeFilter = processed;
+		QByteArray       filtered;
 		filtered.reserve(processed.size());
 		for (char const ch : processed)
 		{
 			if (static_cast<unsigned char>(ch) != 0x07)
 				filtered.append(ch);
 		}
+		rebaseTelnetEventOffsetsForFilter(beforeFilter, [](const char ch)
+		                                  { return static_cast<unsigned char>(ch) == 0x07; });
 		processed = filtered;
 
 		if (const bool enableBeeps = isEnabledFlag(m_worldAttributes.value(QStringLiteral("enable_beeps")));
@@ -4679,8 +4778,37 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 			return;
 		}
 	}
+
+	std::ranges::sort(
+	    telnetPluginEvents,
+	    [](const TelnetProcessor::TelnetPluginEvent &a, const TelnetProcessor::TelnetPluginEvent &b)
+	    {
+		    if (a.offset != b.offset)
+			    return a.offset < b.offset;
+		    return a.sequence < b.sequence;
+	    });
+	auto dispatchTelnetPluginEvent = [this](const TelnetProcessor::TelnetPluginEvent &event)
+	{
+		switch (event.type)
+		{
+		case TelnetProcessor::TelnetPluginEvent::IacGa:
+			m_lastLineWithIacGa = m_linesReceived;
+			callPluginCallbacksNoArgs(QStringLiteral("OnPluginIacGa"), true);
+			break;
+		case TelnetProcessor::TelnetPluginEvent::Option:
+			callPluginCallbacksWithBytes(QStringLiteral("OnPluginTelnetOption"), event.data, true);
+			break;
+		case TelnetProcessor::TelnetPluginEvent::Subnegotiation:
+			m_lastTelnetSubnegotiation = QString::fromLatin1(event.data);
+			callPluginCallbacksWithNumberAndBytes(QStringLiteral("OnPluginTelnetSubnegotiation"),
+			                                      event.option, event.data, true);
+			break;
+		}
+	};
 	if (processed.isEmpty())
 	{
+		for (const TelnetProcessor::TelnetPluginEvent &event : std::as_const(telnetPluginEvents))
+			dispatchTelnetPluginEvent(event);
 		if (simulatedInput && m_reloadReattachUseDeferredMxpReplay)
 		{
 			m_reloadReattachUseDeferredMxpReplay = false;
@@ -5069,33 +5197,65 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 		ansiState.startTag   = current.startTag;
 		ansiState.monospace  = current.monospace;
 
-		constexpr QMudOscActionIds     oscActionIds{ActionNone, ActionSend, ActionPrompt, ActionHyperlink};
-		const QVector<QMudStyledChunk> chunks = qmudParseAnsiSgrChunks(
-		    processed, m_ansiStreamState, defaultFore, defaultBack, normalAnsiColorFromIndex,
-		    boldAnsiColorFromIndex, colorFromIndex, decodeIncomingDisplayBytes, ansiState, oscActionIds);
-		for (const QMudStyledChunk &chunk : chunks)
-			appendDecodedSegment(chunk.text, chunk.state);
+		auto commitAnsiRenderState = [&]
+		{
+			current.bold       = ansiState.bold;
+			current.underline  = ansiState.underline;
+			current.italic     = ansiState.italic;
+			current.blink      = ansiState.blink;
+			current.strike     = ansiState.strike;
+			current.inverse    = ansiState.inverse;
+			current.fore       = ansiState.fore;
+			current.back       = ansiState.back;
+			current.actionType = ansiState.actionType;
+			current.action     = ansiState.action;
+			current.hint       = ansiState.hint;
+			current.variable   = ansiState.variable;
+			current.startTag   = ansiState.startTag;
+			current.monospace  = ansiState.monospace;
 
-		current.bold       = ansiState.bold;
-		current.underline  = ansiState.underline;
-		current.italic     = ansiState.italic;
-		current.blink      = ansiState.blink;
-		current.strike     = ansiState.strike;
-		current.inverse    = ansiState.inverse;
-		current.fore       = ansiState.fore;
-		current.back       = ansiState.back;
-		current.actionType = ansiState.actionType;
-		current.action     = ansiState.action;
-		current.hint       = ansiState.hint;
-		current.variable   = ansiState.variable;
-		current.startTag   = ansiState.startTag;
-		current.monospace  = ansiState.monospace;
+			m_ansiRenderState                = current;
+			m_partialLineText                = lineText;
+			m_partialLineSpans               = lineSpans;
+			m_pendingCarriageReturnOverwrite = carriageReturnPending;
+			emit incomingStyledLinePartialReceived(lineText, lineSpans);
+		};
 
-		m_ansiRenderState                = current;
-		m_partialLineText                = lineText;
-		m_partialLineSpans               = lineSpans;
-		m_pendingCarriageReturnOverwrite = carriageReturnPending;
-		emit incomingStyledLinePartialReceived(lineText, lineSpans);
+		constexpr QMudOscActionIds oscActionIds{ActionNone, ActionSend, ActionPrompt, ActionHyperlink};
+		bool                       ansiRenderStateDirty = false;
+		auto                       appendAnsiBytes      = [&](const QByteArray &bytes)
+		{
+			if (bytes.isEmpty())
+				return;
+			const QVector<QMudStyledChunk> chunks = qmudParseAnsiSgrChunks(
+			    bytes, m_ansiStreamState, defaultFore, defaultBack, normalAnsiColorFromIndex,
+			    boldAnsiColorFromIndex, colorFromIndex, decodeIncomingDisplayBytes, ansiState, oscActionIds);
+			for (const QMudStyledChunk &chunk : chunks)
+				appendDecodedSegment(chunk.text, chunk.state);
+			ansiRenderStateDirty = true;
+		};
+
+		const int processedSize    = safeQSizeToInt(processed.size());
+		int       telnetEventIndex = 0;
+		int       lastTelnetOffset = 0;
+		for (; telnetEventIndex < telnetPluginEvents.size(); ++telnetEventIndex)
+		{
+			const TelnetProcessor::TelnetPluginEvent &event       = telnetPluginEvents.at(telnetEventIndex);
+			const int                                 eventOffset = qBound(0, event.offset, processedSize);
+			if (eventOffset > lastTelnetOffset)
+				appendAnsiBytes(processed.mid(lastTelnetOffset, eventOffset - lastTelnetOffset));
+			lastTelnetOffset = eventOffset;
+			if (ansiRenderStateDirty)
+			{
+				commitAnsiRenderState();
+				ansiRenderStateDirty = false;
+			}
+			dispatchTelnetPluginEvent(event);
+		}
+		if (lastTelnetOffset < processedSize)
+			appendAnsiBytes(processed.mid(lastTelnetOffset));
+
+		commitAnsiRenderState();
 		if (m_mxpTagStack.isEmpty() && !hasActiveMxpRenderContext)
 			m_mxpTextBuffer.clear();
 		m_currentActionSource = previousActionSource;
@@ -5124,17 +5284,18 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 				                  return a.offset < b.offset;
 			                  return a.sequence < b.sequence;
 		                  });
+		QList<TelnetProcessor::TelnetPluginEvent> sortedTelnetPluginEvents = telnetPluginEvents;
 
-		MxpStyleState          current               = m_mxpRenderStyle;
-		QVector<MxpStyleFrame> stack                 = m_mxpRenderStack;
-		QVector<QByteArray>    blockStack            = m_mxpRenderBlockStack;
-		bool                   linkOpen              = m_mxpRenderLinkOpen;
-		int                    preDepth              = m_mxpRenderPreDepth;
-		QString                lineText              = m_partialLineText;
-		QVector<StyleSpan>     lineSpans             = m_partialLineSpans;
-		bool                   carriageReturnPending = m_pendingCarriageReturnOverwrite;
-		bool                   mxpTrackingReset{false};
-		auto                   restoreCurrentFromAnsiState = [&]
+		MxpStyleState                             current               = m_mxpRenderStyle;
+		QVector<MxpStyleFrame>                    stack                 = m_mxpRenderStack;
+		QVector<QByteArray>                       blockStack            = m_mxpRenderBlockStack;
+		bool                                      linkOpen              = m_mxpRenderLinkOpen;
+		int                                       preDepth              = m_mxpRenderPreDepth;
+		QString                                   lineText              = m_partialLineText;
+		QVector<StyleSpan>                        lineSpans             = m_partialLineSpans;
+		bool                                      carriageReturnPending = m_pendingCarriageReturnOverwrite;
+		bool                                      mxpTrackingReset{false};
+		auto                                      restoreCurrentFromAnsiState = [&]
 		{
 			current.bold       = m_ansiRenderState.bold;
 			current.underline  = m_ansiRenderState.underline;
@@ -5256,9 +5417,10 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 			return (lhs == "send" && rhs == "a") || (lhs == "a" && rhs == "send");
 		};
 
-		int  last = 0;
+		const int processedSize = safeQSizeToInt(processed.size());
+		int       last          = 0;
 
-		auto applyStartTag =
+		auto      applyStartTag =
 		    [&](const QByteArray &activeTag, const QMap<QByteArray, QByteArray> &activeAttributes)
 		{
 			const QByteArray unnamedForeLocal = activeAttributes.value("1");
@@ -5717,35 +5879,104 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 			current.monospace  = ansiState.monospace;
 		};
 
+		auto commitMxpRenderState = [&]
+		{
+			m_mxpRenderStyle             = current;
+			m_mxpRenderStack             = stack;
+			m_mxpRenderBlockStack        = blockStack;
+			m_mxpRenderLinkOpen          = linkOpen;
+			m_mxpRenderPreDepth          = preDepth;
+			m_ansiRenderState.bold       = current.bold;
+			m_ansiRenderState.underline  = current.underline;
+			m_ansiRenderState.italic     = current.italic;
+			m_ansiRenderState.blink      = current.blink;
+			m_ansiRenderState.strike     = current.strike;
+			m_ansiRenderState.monospace  = current.monospace;
+			m_ansiRenderState.inverse    = current.inverse;
+			m_ansiRenderState.fore       = current.fore;
+			m_ansiRenderState.back       = current.back;
+			m_ansiRenderState.actionType = current.actionType;
+			m_ansiRenderState.action     = current.action;
+			m_ansiRenderState.hint       = current.hint;
+			m_ansiRenderState.variable   = current.variable;
+			m_ansiRenderState.startTag   = current.startTag;
+
+			m_partialLineText                = lineText;
+			m_partialLineSpans               = lineSpans;
+			m_pendingCarriageReturnOverwrite = carriageReturnPending;
+			emit incomingStyledLinePartialReceived(lineText, lineSpans);
+		};
+
 		auto isAtomicTag = [](const QByteArray &tag)
 		{
 			AtomicTagInfo info;
 			return lookupAtomicTagInfo(tag, info);
 		};
 
-		int modeChangeIndex = 0;
+		int  modeChangeIndex        = 0;
+		int  telnetPluginEventIndex = 0;
+		auto boundaryComesBefore    = [](const int boundaryOffset, const int boundarySequence,
+		                                 const int eventOffset, const int eventSequence)
+		{
+			return (boundaryOffset < eventOffset) ||
+			       (boundaryOffset == eventOffset && boundarySequence < eventSequence);
+		};
+		auto drainTelnetAndModeBoundariesBefore = [&](const int eventOffset, const int eventSequence)
+		{
+			while (true)
+			{
+				const bool haveModeChange =
+				    modeChangeIndex < sortedModeChanges.size() &&
+				    boundaryComesBefore(sortedModeChanges.at(modeChangeIndex).offset,
+				                        sortedModeChanges.at(modeChangeIndex).sequence, eventOffset,
+				                        eventSequence);
+				const bool haveTelnetEvent =
+				    telnetPluginEventIndex < sortedTelnetPluginEvents.size() &&
+				    boundaryComesBefore(sortedTelnetPluginEvents.at(telnetPluginEventIndex).offset,
+				                        sortedTelnetPluginEvents.at(telnetPluginEventIndex).sequence,
+				                        eventOffset, eventSequence);
+				if (!haveModeChange && !haveTelnetEvent)
+					break;
+
+				const bool takeModeChange =
+				    haveModeChange &&
+				    (!haveTelnetEvent ||
+				     boundaryComesBefore(sortedModeChanges.at(modeChangeIndex).offset,
+				                         sortedModeChanges.at(modeChangeIndex).sequence,
+				                         sortedTelnetPluginEvents.at(telnetPluginEventIndex).offset,
+				                         sortedTelnetPluginEvents.at(telnetPluginEventIndex).sequence));
+				if (takeModeChange)
+				{
+					const TelnetProcessor::MxpModeChange &modeChange =
+					    sortedModeChanges.at(modeChangeIndex++);
+					if (modeChange.offset > last)
+					{
+						appendStyled(processed.mid(last, modeChange.offset - last));
+						last = modeChange.offset;
+					}
+					applyMxpModeBarrier(modeChange);
+					continue;
+				}
+
+				const TelnetProcessor::TelnetPluginEvent &telnetEvent =
+				    sortedTelnetPluginEvents.at(telnetPluginEventIndex++);
+				const int telnetOffset = qBound(0, telnetEvent.offset, processedSize);
+				if (telnetOffset > last)
+				{
+					appendStyled(processed.mid(last, telnetOffset - last));
+					last = telnetOffset;
+				}
+				commitMxpRenderState();
+				dispatchTelnetPluginEvent(telnetEvent);
+			}
+		};
 
 		for (const TelnetProcessor::MxpEvent &ev : sorted)
 		{
 			if (mxpTrackingReset)
 				break;
 
-			while (modeChangeIndex < sortedModeChanges.size())
-			{
-				const TelnetProcessor::MxpModeChange &modeChange = sortedModeChanges.at(modeChangeIndex);
-				const bool                            boundaryComesBeforeEvent =
-				    (modeChange.offset < ev.offset) ||
-				    (modeChange.offset == ev.offset && modeChange.sequence < ev.sequence);
-				if (!boundaryComesBeforeEvent)
-					break;
-				if (modeChange.offset > last)
-				{
-					appendStyled(processed.mid(last, modeChange.offset - last));
-					last = modeChange.offset;
-				}
-				applyMxpModeBarrier(modeChange);
-				++modeChangeIndex;
-			}
+			drainTelnetAndModeBoundariesBefore(ev.offset, ev.sequence);
 
 			if (ev.offset > last)
 			{
@@ -6544,18 +6775,9 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 			}
 		}
 
-		while (modeChangeIndex < sortedModeChanges.size())
-		{
-			const TelnetProcessor::MxpModeChange &modeChange = sortedModeChanges.at(modeChangeIndex++);
-			if (modeChange.offset > last)
-			{
-				appendStyled(processed.mid(last, modeChange.offset - last));
-				last = modeChange.offset;
-			}
-			applyMxpModeBarrier(modeChange);
-		}
+		drainTelnetAndModeBoundariesBefore(std::numeric_limits<int>::max(), std::numeric_limits<int>::max());
 
-		if (last < processed.size())
+		if (last < processedSize)
 			appendStyled(processed.mid(last));
 
 		const bool hasActiveMxpRenderContextAfterProcessing =
@@ -6563,30 +6785,7 @@ void WorldRuntime::processRawDataPayload(const QByteArray &data, const bool simu
 		if (m_mxpTagStack.isEmpty() && !hasActiveMxpRenderContextAfterProcessing)
 			m_mxpTextBuffer.clear();
 
-		m_mxpRenderStyle             = current;
-		m_mxpRenderStack             = stack;
-		m_mxpRenderBlockStack        = blockStack;
-		m_mxpRenderLinkOpen          = linkOpen;
-		m_mxpRenderPreDepth          = preDepth;
-		m_ansiRenderState.bold       = current.bold;
-		m_ansiRenderState.underline  = current.underline;
-		m_ansiRenderState.italic     = current.italic;
-		m_ansiRenderState.blink      = current.blink;
-		m_ansiRenderState.strike     = current.strike;
-		m_ansiRenderState.monospace  = current.monospace;
-		m_ansiRenderState.inverse    = current.inverse;
-		m_ansiRenderState.fore       = current.fore;
-		m_ansiRenderState.back       = current.back;
-		m_ansiRenderState.actionType = current.actionType;
-		m_ansiRenderState.action     = current.action;
-		m_ansiRenderState.hint       = current.hint;
-		m_ansiRenderState.variable   = current.variable;
-		m_ansiRenderState.startTag   = current.startTag;
-
-		m_partialLineText                = lineText;
-		m_partialLineSpans               = lineSpans;
-		m_pendingCarriageReturnOverwrite = carriageReturnPending;
-		emit incomingStyledLinePartialReceived(lineText, lineSpans);
+		commitMxpRenderState();
 		m_currentActionSource = previousActionSource;
 	}
 }
@@ -9003,8 +9202,10 @@ void WorldRuntime::populateLuaCallbackDispatchVolatileSnapshot(
 	snapshot.commandUiOutputClientWidth  = commandUi.outputClientWidth;
 	snapshot.commandUiViewHeight         = commandUi.viewHeight;
 	snapshot.commandUiViewWidth          = commandUi.viewWidth;
-	snapshot.commandUiValues.reserve(52);
+	snapshot.commandUiValues.reserve(53);
 	snapshot.commandUiValues.insert(QStringLiteral("queuedCommands"), commandUi.queuedCommands);
+	snapshot.commandUiValues.insert(QStringLiteral("triggerPriorityQueuedCommandCount"),
+	                                commandUi.triggerPriorityQueuedCommandCount);
 	snapshot.commandUiValues.insert(QStringLiteral("commandInputText"), commandUi.commandInputText);
 	snapshot.commandUiValues.insert(QStringLiteral("inputSelectionStartColumn"),
 	                                commandUi.inputSelectionStartColumn);
@@ -9563,8 +9764,10 @@ QSharedPointer<const LuaCallbackMiniWindowSnapshot> WorldRuntime::captureLuaCall
 	snapshot->commandUiOutputClientWidth  = commandUi.outputClientWidth;
 	snapshot->commandUiViewHeight         = commandUi.viewHeight;
 	snapshot->commandUiViewWidth          = commandUi.viewWidth;
-	snapshot->commandUiValues.reserve(52);
+	snapshot->commandUiValues.reserve(53);
 	snapshot->commandUiValues.insert(QStringLiteral("queuedCommands"), commandUi.queuedCommands);
+	snapshot->commandUiValues.insert(QStringLiteral("triggerPriorityQueuedCommandCount"),
+	                                 commandUi.triggerPriorityQueuedCommandCount);
 	snapshot->commandUiValues.insert(QStringLiteral("commandInputText"), commandUi.commandInputText);
 	snapshot->commandUiValues.insert(QStringLiteral("inputSelectionStartColumn"),
 	                                 commandUi.inputSelectionStartColumn);
@@ -12871,6 +13074,18 @@ int WorldRuntime::executeCommand(const QString &text) const
 	return m_commandProcessor->executeCommand(text);
 }
 
+int WorldRuntime::executeCommandWithTriggerPriority(const QString &text) const
+{
+	if (QThread::currentThread() != thread())
+		return qmudInvokeMethodOr(const_cast<WorldRuntime *>(this), eWorldClosed,
+		                          [this, text] { return executeCommandWithTriggerPriority(text); });
+
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::executeCommandWithTriggerPriority");
+	if (!m_commandProcessor)
+		return eWorldClosed;
+	return m_commandProcessor->executeCommandWithTriggerPriority(text);
+}
+
 QString WorldRuntime::getEntityValue(const QString &name) const
 {
 	QByteArray value;
@@ -16167,6 +16382,51 @@ int WorldRuntime::sendCommand(const QString &text, bool echo, bool queue, bool l
 	return eOK;
 }
 
+int WorldRuntime::sendCommandWithTriggerPriority(const QString &text, const bool echo, const bool queue,
+                                                 const bool log, const bool history) const
+{
+	if (QThread::currentThread() != thread())
+		return qmudInvokeMethodOr(
+		    const_cast<WorldRuntime *>(this), eWorldClosed, [this, text, echo, queue, log, history]
+		    { return sendCommandWithTriggerPriority(text, echo, queue, log, history); });
+
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::sendCommandWithTriggerPriority");
+	if (m_connectPhase != eConnectConnectedToMud)
+		return eWorldClosed;
+	if (!m_commandProcessor)
+		return eWorldClosed;
+	if (m_commandProcessor->pluginProcessingSent())
+		return eItemInUse;
+
+	m_commandProcessor->sendRawTextWithTriggerPriority(text, echo, queue, log, history);
+	return eOK;
+}
+
+bool WorldRuntime::deferInboundImmediateCommand(const QString &text, const bool echo, const bool log,
+                                                const bool triggerPriority) const
+{
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::deferInboundImmediateCommand");
+	if (m_inboundCommandDeferralDepth <= 0 || m_flushingDeferredInboundCommands)
+		return false;
+
+	DeferredInboundCommand command;
+	command.text         = text;
+	command.echo         = echo;
+	command.log          = log;
+	command.actionSource = m_currentActionSource;
+	if (triggerPriority)
+	{
+		const int insertAt = qBound(0, m_deferredInboundTriggerPriorityCommands,
+		                            safeQSizeToInt(m_deferredInboundCommands.size()));
+		m_deferredInboundCommands.insert(insertAt, command);
+		m_deferredInboundTriggerPriorityCommands = insertAt + 1;
+		return true;
+	}
+
+	m_deferredInboundCommands.push_back(command);
+	return true;
+}
+
 void WorldRuntime::logInputCommand(const QString &text) const
 {
 	if (QThread::currentThread() != thread())
@@ -16271,7 +16531,10 @@ WorldRuntime::CommandUiSnapshot WorldRuntime::commandUiSnapshot(const bool inclu
 	qmudAssertObjectThreadAffinity(this, "WorldRuntime::commandUiSnapshot");
 	CommandUiSnapshot snapshot;
 	if (m_commandProcessor)
-		snapshot.queuedCommands = m_commandProcessor->queuedCommands();
+	{
+		snapshot.queuedCommands                    = m_commandProcessor->queuedCommands();
+		snapshot.triggerPriorityQueuedCommandCount = m_commandProcessor->triggerPriorityQueuedCommandCount();
+	}
 	snapshot.textRectangleLeft              = m_textRectangle.left;
 	snapshot.textRectangleTop               = m_textRectangle.top;
 	snapshot.textRectangleRight             = m_textRectangle.right;

--- a/src/WorldRuntime.h
+++ b/src/WorldRuntime.h
@@ -2748,6 +2748,12 @@ class WorldRuntime : public QObject
 		 */
 		[[nodiscard]] int            executeCommand(const QString &text) const;
 		/**
+		 * @brief Executes one direct trigger-script command with priority over queued movement.
+		 * @param text Command text.
+		 * @return API status code.
+		 */
+		[[nodiscard]] int            executeCommandWithTriggerPriority(const QString &text) const;
+		/**
 		 * @brief Gets MXP entity value.
 		 * @param name Entity name.
 		 * @return Entity value.
@@ -4020,8 +4026,29 @@ class WorldRuntime : public QObject
 		 * @param immediate Send as immediate when `true`.
 		 * @return API status code.
 		 */
-		[[nodiscard]] int  sendCommand(const QString &text, bool echo, bool queue, bool log, bool history,
-		                               bool immediate) const;
+		[[nodiscard]] int sendCommand(const QString &text, bool echo, bool queue, bool log, bool history,
+		                              bool immediate) const;
+		/**
+		 * @brief Sends direct trigger-script command text with priority over queued movement.
+		 * @param text Command text.
+		 * @param echo Echo command when `true`.
+		 * @param queue Queue command when `true`.
+		 * @param log Log command when `true`.
+		 * @param history Add command to history when `true`.
+		 * @return API status code.
+		 */
+		[[nodiscard]] int sendCommandWithTriggerPriority(const QString &text, bool echo, bool queue, bool log,
+		                                                 bool history) const;
+		/**
+		 * @brief Defers an immediate command send until current inbound world data finishes processing.
+		 * @param text Command line text.
+		 * @param echo Echo command when `true`.
+		 * @param log Log command when `true`.
+		 * @param triggerPriority Place command in the inbound trigger-priority band when `true`.
+		 * @return `true` when the command was deferred.
+		 */
+		[[nodiscard]] bool deferInboundImmediateCommand(const QString &text, bool echo, bool log,
+		                                                bool triggerPriority) const;
 		/**
 		 * @brief Command-processor bridge, accelerators, and plugin callbacks.
 		 */
@@ -4068,6 +4095,7 @@ class WorldRuntime : public QObject
 				QStringList queuedCommands;
 				QString     commandInputText;
 				QStringList commandHistory;
+				int         triggerPriorityQueuedCommandCount{0};
 				int         inputSelectionStartColumn{0};
 				int         inputSelectionEndColumn{0};
 				int         outputSelectionEndColumn{0};
@@ -5136,6 +5164,18 @@ class WorldRuntime : public QObject
 		 */
 		void processRawDataPayload(const QByteArray &data, bool simulatedInput);
 		/**
+		 * @brief Starts an inbound command deferral scope.
+		 */
+		void beginInboundCommandDeferralScope() const;
+		/**
+		 * @brief Ends an inbound command deferral scope and flushes staged commands at the outer boundary.
+		 */
+		void endInboundCommandDeferralScope() const;
+		/**
+		 * @brief Flushes staged commands created while inbound world data was being processed.
+		 */
+		void flushDeferredInboundCommands() const;
+		/**
 		 * @brief Queues plugin for deferred installation.
 		 * @param plugin Plugin instance.
 		 */
@@ -5642,72 +5682,83 @@ class WorldRuntime : public QObject
 		QList<TelnetProcessor::MxpEvent>                m_reloadReattachMxpProbeEvents;
 		QList<TelnetProcessor::MxpModeChange>           m_reloadReattachMxpProbeModeChanges;
 		quint64                                         m_reloadMccpProbeGeneration{0};
-		QDateTime                                       m_statusTime;
-		QDateTime                                       m_lastFlushTime;
-		QDateTime                                       m_clientStartTime;
-		QDateTime                                       m_worldStartTime;
-		int                                             m_mxpErrors{0};
-		bool                                            m_mxpActive{false};
-		bool                                            m_outputFrozen{false};
-		TextRectangleSettings                           m_textRectangle;
-		QMap<int, UdpListener>                          m_udpListeners;
-		QVector<SoundBuffer>                            m_soundBuffers;
-		int                                             m_outputFontHeight{0};
-		int                                             m_outputFontWidth{0};
-		int                                             m_inputFontHeight{0};
-		int                                             m_inputFontWidth{0};
-		int                                             m_queuedCommandCount{0};
-		bool                                            m_removeMapReverses{true};
-		qint64                                          m_bytesIn{0};
-		qint64                                          m_bytesOut{0};
-		int                                             m_inputPacketCount{0};
-		int                                             m_outputPacketCount{0};
-		bool                                            m_isMapping{false};
-		bool                                            m_variablesChanged{false};
-		bool                                            m_lineOmittedFromOutput{false};
-		bool                                            m_traceEnabled{false};
-		bool                                            m_worldFileModified{false};
-		qint64                                          m_newlinesReceived{0};
-		bool                                            m_scriptFileChanged{false};
-		bool                                            m_loadingDocument{false};
-		bool                                            m_inPlaySoundPluginCallback{false};
-		bool                                            m_inCancelSoundPluginCallback{false};
-		bool                                            m_inScreendrawCallback{false};
-		bool                                            m_inDrawOutputWindowCallback{false};
-		int                                             m_suppressWorldOutputResizedCallbacks{0};
-		bool                                            m_pluginInstallDeferred{false};
-		bool                                            m_pluginInstallInProgress{false};
-		bool                                            m_pluginInstallRetryQueued{false};
-		QVector<std::function<void()>>                  m_pluginInstallCommittedWaiters;
-		bool                                            m_deferredConnectAfterPluginInstallPending{false};
-		bool                                            m_deferredWorldConnectHandlersPending{false};
-		QString                                         m_deferredConnectHost;
-		quint16                                         m_deferredConnectPort{0};
-		int                                             m_outputWindowRedrawCount{0};
-		QFileSystemWatcher                             *m_scriptWatcher{nullptr};
-		QVector<MxpTagFrame>                            m_mxpTagStack;
-		QVector<MxpOpenTag>                             m_mxpOpenTags;
-		QByteArray                                      m_mxpTextBuffer;
-		QString                                         m_windowTitleOverride;
-		QString                                         m_mainTitleOverride;
-		class LuaCallbackEngine                        *m_luaCallbacks{nullptr};
-		std::unique_ptr<ILuaExecutor>                   m_luaExecutor;
-		QString                                         m_luaScriptText;
-		WorldCommandProcessor                          *m_commandProcessor{nullptr};
-		int                                             m_lastGoTo{1};
-		QList<QString>                                  m_mappingList;
-		qint64                                          m_triggerTimeNs{0};
-		qint64                                          m_aliasTimeNs{0};
-		QElapsedTimer                                   m_lineTimer;
-		qint64                                          m_nextLineNumber{1};
-		bool                                            m_luaContextLineActive{false};
-		bool                                            m_luaContextLineBuffered{false};
-		bool                                            m_luaContextLineCommitted{false};
-		int                                             m_luaContextLineBufferIndex{0};
-		LineEntry                                       m_luaContextLineEntry;
-		QHash<qint64, int>                              m_luaCallbackAfterAnchorInsertionOffsets;
-		mutable quint64                                 m_luaCallbackLineBufferSnapshotGeneration{0};
-		mutable quint64                                 m_luaCallbackLineBufferSnapshotCacheGeneration{0};
+		struct DeferredInboundCommand
+		{
+				QString        text;
+				bool           echo{false};
+				bool           log{false};
+				unsigned short actionSource{eUnknownActionSource};
+		};
+		mutable QVector<DeferredInboundCommand> m_deferredInboundCommands;
+		mutable int                             m_deferredInboundTriggerPriorityCommands{0};
+		mutable int                             m_inboundCommandDeferralDepth{0};
+		mutable bool                            m_flushingDeferredInboundCommands{false};
+		QDateTime                               m_statusTime;
+		QDateTime                               m_lastFlushTime;
+		QDateTime                               m_clientStartTime;
+		QDateTime                               m_worldStartTime;
+		int                                     m_mxpErrors{0};
+		bool                                    m_mxpActive{false};
+		bool                                    m_outputFrozen{false};
+		TextRectangleSettings                   m_textRectangle;
+		QMap<int, UdpListener>                  m_udpListeners;
+		QVector<SoundBuffer>                    m_soundBuffers;
+		int                                     m_outputFontHeight{0};
+		int                                     m_outputFontWidth{0};
+		int                                     m_inputFontHeight{0};
+		int                                     m_inputFontWidth{0};
+		int                                     m_queuedCommandCount{0};
+		bool                                    m_removeMapReverses{true};
+		qint64                                  m_bytesIn{0};
+		qint64                                  m_bytesOut{0};
+		int                                     m_inputPacketCount{0};
+		int                                     m_outputPacketCount{0};
+		bool                                    m_isMapping{false};
+		bool                                    m_variablesChanged{false};
+		bool                                    m_lineOmittedFromOutput{false};
+		bool                                    m_traceEnabled{false};
+		bool                                    m_worldFileModified{false};
+		qint64                                  m_newlinesReceived{0};
+		bool                                    m_scriptFileChanged{false};
+		bool                                    m_loadingDocument{false};
+		bool                                    m_inPlaySoundPluginCallback{false};
+		bool                                    m_inCancelSoundPluginCallback{false};
+		bool                                    m_inScreendrawCallback{false};
+		bool                                    m_inDrawOutputWindowCallback{false};
+		int                                     m_suppressWorldOutputResizedCallbacks{0};
+		bool                                    m_pluginInstallDeferred{false};
+		bool                                    m_pluginInstallInProgress{false};
+		bool                                    m_pluginInstallRetryQueued{false};
+		QVector<std::function<void()>>          m_pluginInstallCommittedWaiters;
+		bool                                    m_deferredConnectAfterPluginInstallPending{false};
+		bool                                    m_deferredWorldConnectHandlersPending{false};
+		QString                                 m_deferredConnectHost;
+		quint16                                 m_deferredConnectPort{0};
+		int                                     m_outputWindowRedrawCount{0};
+		QFileSystemWatcher                     *m_scriptWatcher{nullptr};
+		QVector<MxpTagFrame>                    m_mxpTagStack;
+		QVector<MxpOpenTag>                     m_mxpOpenTags;
+		QByteArray                              m_mxpTextBuffer;
+		QString                                 m_windowTitleOverride;
+		QString                                 m_mainTitleOverride;
+		class LuaCallbackEngine                *m_luaCallbacks{nullptr};
+		std::unique_ptr<ILuaExecutor>           m_luaExecutor;
+		QString                                 m_luaScriptText;
+		WorldCommandProcessor                  *m_commandProcessor{nullptr};
+		int                                     m_lastGoTo{1};
+		QList<QString>                          m_mappingList;
+		qint64                                  m_triggerTimeNs{0};
+		qint64                                  m_aliasTimeNs{0};
+		QElapsedTimer                           m_lineTimer;
+		qint64                                  m_nextLineNumber{1};
+		bool                                    m_luaContextLineActive{false};
+		bool                                    m_luaContextLineBuffered{false};
+		bool                                    m_luaContextLineCommitted{false};
+		int                                     m_luaContextLineBufferIndex{0};
+		LineEntry                               m_luaContextLineEntry;
+		QHash<qint64, int>                      m_luaCallbackAfterAnchorInsertionOffsets;
+		mutable quint64                         m_luaCallbackLineBufferSnapshotGeneration{0};
+		mutable quint64                         m_luaCallbackLineBufferSnapshotCacheGeneration{0};
 		mutable QSharedPointer<const LuaCallbackLineBufferSnapshot> m_luaCallbackLineBufferSnapshotCache;
 		mutable quint64 m_luaCallbackRecentLineBufferSnapshotCacheGeneration{0};
 		mutable QSharedPointer<const LuaCallbackLineBufferSnapshot>

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1265,6 +1265,10 @@ class WrapTextBrowser : public QAbstractScrollArea
 		{
 			if (m_view && m_view->handleWorldHotkey(event))
 				return;
+			if (m_view && m_view->handleCommandOptionShortcut(event))
+				return;
+			if (m_view && m_view->handleCommandHistoryShortcut(event))
+				return;
 			if (m_isLive)
 			{
 				event->accept();
@@ -11945,7 +11949,8 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 	if (isOutputWidget && event->type() == QEvent::ShortcutOverride)
 	{
 		if (const auto *keyEvent = dynamic_cast<QKeyEvent *>(event);
-		    keyEvent && hasWorldAcceleratorBinding(keyEvent))
+		    keyEvent && (hasWorldAcceleratorBinding(keyEvent) || hasCommandOptionShortcut(keyEvent) ||
+		                 hasCommandHistoryShortcut(keyEvent)))
 		{
 			event->accept();
 			return true;
@@ -11959,6 +11964,21 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 			if (keyEvent->matches(QKeySequence::Copy) && hasOutputSelection())
 			{
 				copySelection();
+				event->accept();
+				return true;
+			}
+			if (handleWorldHotkey(keyEvent))
+			{
+				event->accept();
+				return true;
+			}
+			if (handleCommandOptionShortcut(keyEvent))
+			{
+				event->accept();
+				return true;
+			}
+			if (handleCommandHistoryShortcut(keyEvent))
+			{
 				event->accept();
 				return true;
 			}
@@ -12021,12 +12041,6 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 				                    keyEvent->count());
 				m_input->setFocus(Qt::OtherFocusReason);
 				QCoreApplication::sendEvent(m_input, &forwarded);
-				return true;
-			}
-
-			if (handleWorldHotkey(keyEvent))
-			{
-				event->accept();
 				return true;
 			}
 		}
@@ -12888,6 +12902,84 @@ bool WorldView::hasWorldAcceleratorBinding(const QKeyEvent *event) const
 	return findAcceleratorCommandForEvent(m_runtime, event, keypad) >= 0;
 }
 
+bool WorldView::hasCommandOptionShortcut(const QKeyEvent *event) const
+{
+	if (!event)
+		return false;
+
+	const Qt::KeyboardModifiers modifiers = event->modifiers();
+	const bool hasOnlyCtrl = modifiers.testFlag(Qt::ControlModifier) &&
+	                         !modifiers.testFlag(Qt::AltModifier) && !modifiers.testFlag(Qt::ShiftModifier) &&
+	                         !modifiers.testFlag(Qt::MetaModifier);
+	if (!hasOnlyCtrl)
+		return false;
+
+	switch (event->key())
+	{
+	case Qt::Key_N:
+		return m_ctrlNGoesToNextCommand;
+	case Qt::Key_P:
+		return m_ctrlPGoesToPreviousCommand;
+	case Qt::Key_Z:
+		return m_ctrlZGoesToEndOfBuffer;
+	default:
+		return false;
+	}
+}
+
+bool WorldView::handleCommandOptionShortcut(QKeyEvent *event)
+{
+	if (!hasCommandOptionShortcut(event))
+		return false;
+
+	switch (event->key())
+	{
+	case Qt::Key_N:
+		recallNextCommand();
+		break;
+	case Qt::Key_P:
+		recallPreviousCommand();
+		break;
+	case Qt::Key_Z:
+		if (m_scrollbackSplitActive)
+			collapseScrollbackSplitToLiveOutput();
+		else
+			scrollOutputToEnd();
+		clearNativeOutputSelection(true);
+		break;
+	default:
+		return false;
+	}
+
+	event->accept();
+	return true;
+}
+
+bool WorldView::hasCommandHistoryShortcut(const QKeyEvent *event) const
+{
+	if (!event)
+		return false;
+	if (!m_altArrowRecallsPartial && !m_arrowRecallsPartial)
+		return false;
+
+	const Qt::KeyboardModifiers modifiers = event->modifiers();
+	const bool hasOnlyAlt = modifiers.testFlag(Qt::AltModifier) && !modifiers.testFlag(Qt::ControlModifier) &&
+	                        !modifiers.testFlag(Qt::ShiftModifier) && !modifiers.testFlag(Qt::MetaModifier);
+	return hasOnlyAlt && (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down);
+}
+
+bool WorldView::handleCommandHistoryShortcut(QKeyEvent *event)
+{
+	if (!hasCommandHistoryShortcut(event))
+		return false;
+
+	const int direction = event->key() == Qt::Key_Up ? -1 : 1;
+	recallPartialHistory(direction);
+
+	event->accept();
+	return true;
+}
+
 bool WorldView::handleWorldHotkey(QKeyEvent *event)
 {
 	if (!m_runtime || !event)
@@ -13608,6 +13700,22 @@ void InputTextEdit::keyPressEvent(QKeyEvent *event)
 #endif
 		return;
 	}
+	if (m_view && m_view->handleCommandOptionShortcut(event))
+	{
+#ifdef Q_OS_WIN
+		if (windowsAltNumpadDigitKey)
+			m_suppressNextAltNumpadCommit = true;
+#endif
+		return;
+	}
+	if (m_view && m_view->handleCommandHistoryShortcut(event))
+	{
+#ifdef Q_OS_WIN
+		if (windowsAltNumpadDigitKey)
+			m_suppressNextAltNumpadCommit = true;
+#endif
+		return;
+	}
 
 	if (m_view && plainTab)
 	{
@@ -13671,11 +13779,14 @@ void InputTextEdit::keyPressEvent(QKeyEvent *event)
 		m_view->pasteCommand(pasteText);
 		return;
 	}
-	if (m_view && event->key() == Qt::Key_Backspace && (event->modifiers() & Qt::ControlModifier))
+	const Qt::KeyboardModifiers keyModifiers = event->modifiers();
+	const bool                  ctrlBackspace =
+	    event->key() == Qt::Key_Backspace && keyModifiers.testFlag(Qt::ControlModifier) &&
+	    !keyModifiers.testFlag(Qt::AltModifier) && !keyModifiers.testFlag(Qt::ShiftModifier) &&
+	    !keyModifiers.testFlag(Qt::MetaModifier);
+	if (m_view && ctrlBackspace)
 	{
-		clear();
-		m_view->m_inputChanged = false;
-		m_view->resetHistoryRecall();
+		m_view->recallLastWord();
 		return;
 	}
 
@@ -13696,26 +13807,6 @@ void InputTextEdit::keyPressEvent(QKeyEvent *event)
 		}
 	}
 
-	if (m_view && (event->modifiers() & Qt::ControlModifier) &&
-	    !(event->modifiers() & (Qt::AltModifier | Qt::ShiftModifier | Qt::MetaModifier)))
-	{
-		if (event->key() == Qt::Key_N && m_view->m_ctrlNGoesToNextCommand)
-		{
-			m_view->recallNextCommand();
-			return;
-		}
-		if (event->key() == Qt::Key_P && m_view->m_ctrlPGoesToPreviousCommand)
-		{
-			m_view->recallPreviousCommand();
-			return;
-		}
-		if (event->key() == Qt::Key_Z && m_view->m_ctrlZGoesToEndOfBuffer)
-		{
-			m_view->scrollOutputToEnd();
-			return;
-		}
-	}
-
 	if (m_view && (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down))
 	{
 		const int direction = (event->key() == Qt::Key_Up) ? -1 : 1;
@@ -13729,14 +13820,6 @@ void InputTextEdit::keyPressEvent(QKeyEvent *event)
 					m_view->recallPartialHistory(direction);
 				else
 					m_view->recallHistory(direction);
-				handled = true;
-			}
-		}
-		else if (event->modifiers() == Qt::AltModifier)
-		{
-			if (m_view->m_altArrowRecallsPartial || m_view->m_arrowRecallsPartial)
-			{
-				m_view->recallPartialHistory(direction);
 				handled = true;
 			}
 		}
@@ -13786,11 +13869,14 @@ bool InputTextEdit::event(QEvent *event)
 		if (const auto *keyEvent = dynamic_cast<QKeyEvent *>(event))
 		{
 			const Qt::KeyboardModifiers modifiers = keyEvent->modifiers();
-			const bool                  plainCtrl = (modifiers & Qt::ControlModifier) != 0 &&
-			                                        (modifiers & (Qt::AltModifier | Qt::MetaModifier)) == 0;
-			const bool                  isCtrlBackspace = plainCtrl && keyEvent->key() == Qt::Key_Backspace;
-			const bool                  isCopyShortcut =
-			    keyEvent->matches(QKeySequence::Copy) || (plainCtrl && keyEvent->key() == Qt::Key_C);
+			const bool                  hasOnlyCtrl =
+			    (modifiers & Qt::ControlModifier) != 0 &&
+			    (modifiers & (Qt::AltModifier | Qt::ShiftModifier | Qt::MetaModifier)) == 0;
+			const bool isCtrlBackspace = hasOnlyCtrl && keyEvent->key() == Qt::Key_Backspace;
+			const bool isCopyShortcut =
+			    keyEvent->matches(QKeySequence::Copy) || (hasOnlyCtrl && keyEvent->key() == Qt::Key_C);
+			const bool isPasteShortcut = keyEvent->matches(QKeySequence::Paste);
+			const bool isPlainTab      = modifiers == Qt::NoModifier && keyEvent->key() == Qt::Key_Tab;
 			if (isCtrlBackspace)
 			{
 				event->accept();
@@ -13801,7 +13887,8 @@ bool InputTextEdit::event(QEvent *event)
 				event->accept();
 				return true;
 			}
-			if (m_view->hasWorldAcceleratorBinding(keyEvent))
+			if (isPasteShortcut || isPlainTab || m_view->hasWorldAcceleratorBinding(keyEvent) ||
+			    m_view->hasCommandOptionShortcut(keyEvent) || m_view->hasCommandHistoryShortcut(keyEvent))
 			{
 				event->accept();
 				return true;

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -405,6 +405,30 @@ class WorldView : public QWidget
 		 */
 		[[nodiscard]] bool   hasWorldAcceleratorBinding(const QKeyEvent *event) const;
 		/**
+		 * @brief Returns whether a key event is claimed by command option settings.
+		 * @param event Key event to inspect.
+		 * @return `true` when a command option shortcut should preempt Qt shortcuts.
+		 */
+		[[nodiscard]] bool   hasCommandOptionShortcut(const QKeyEvent *event) const;
+		/**
+		 * @brief Handles command option shortcuts.
+		 * @param event Key event to process.
+		 * @return `true` when the shortcut is consumed.
+		 */
+		bool                 handleCommandOptionShortcut(QKeyEvent *event);
+		/**
+		 * @brief Returns whether a key event is a command-history shortcut.
+		 * @param event Key event to inspect.
+		 * @return `true` when command-history routing should preempt Qt shortcuts.
+		 */
+		[[nodiscard]] bool   hasCommandHistoryShortcut(const QKeyEvent *event) const;
+		/**
+		 * @brief Handles command-history shortcuts.
+		 * @param event Key event to process.
+		 * @return `true` when the shortcut is consumed.
+		 */
+		bool                 handleCommandHistoryShortcut(QKeyEvent *event);
+		/**
 		 * @brief Returns true when miniwindow mouse capture is active.
 		 * @return `true` when miniwindow mouse capture is active.
 		 */

--- a/src/helpers/WorldCommandProcessorUtils.cpp
+++ b/src/helpers/WorldCommandProcessorUtils.cpp
@@ -175,7 +175,7 @@ namespace QMudCommandQueue
 
 namespace QMudCommandText
 {
-	QString normalizeActionCommandTextForSend(const QString &source)
+	QString normalizeActionCommandTextNewlines(const QString &source)
 	{
 		QString normalized;
 		normalized.reserve(source.size());

--- a/src/helpers/WorldCommandProcessorUtils.cpp
+++ b/src/helpers/WorldCommandProcessorUtils.cpp
@@ -175,6 +175,30 @@ namespace QMudCommandQueue
 
 namespace QMudCommandText
 {
+	QString normalizeActionCommandTextForSend(const QString &source)
+	{
+		QString normalized;
+		normalized.reserve(source.size());
+		for (qsizetype i = 0; i < source.size(); ++i)
+		{
+			const QChar ch = source.at(i);
+			if (ch == QLatin1Char('\r'))
+			{
+				if (i + 1 < source.size() && source.at(i + 1) == QLatin1Char('\n'))
+					++i;
+				normalized += QStringLiteral("\r\n");
+				continue;
+			}
+			if (ch == QLatin1Char('\n'))
+			{
+				normalized += QStringLiteral("\r\n");
+				continue;
+			}
+			normalized += ch;
+		}
+		return normalized;
+	}
+
 	QString fixupEscapeSequences(const QString &source)
 	{
 		QString out;

--- a/src/helpers/WorldCommandProcessorUtils.h
+++ b/src/helpers/WorldCommandProcessorUtils.h
@@ -91,6 +91,13 @@ namespace QMudCommandText
 	QString fixupEscapeSequences(const QString &source);
 
 	/**
+	 * @brief Converts action command body line endings to the send pipeline terminator.
+	 * @param source Action command text from send-to-world/queue bodies.
+	 * @return Command text with CRLF, LF, and CR represented as CRLF.
+	 */
+	QString normalizeActionCommandTextForSend(const QString &source);
+
+	/**
 	 * @brief Applies wildcard replacement/post-processing for send-target transforms.
 	 * @param wildcard Wildcard value to process.
 	 * @param makeLowerCase Force lowercase conversion when `true`.

--- a/src/helpers/WorldCommandProcessorUtils.h
+++ b/src/helpers/WorldCommandProcessorUtils.h
@@ -91,11 +91,11 @@ namespace QMudCommandText
 	QString fixupEscapeSequences(const QString &source);
 
 	/**
-	 * @brief Converts action command body line endings to the send pipeline terminator.
-	 * @param source Action command text from send-to-world/queue bodies.
+	 * @brief Converts action command body line endings to the command pipeline terminator.
+	 * @param source Action command text from multiline command bodies.
 	 * @return Command text with CRLF, LF, and CR represented as CRLF.
 	 */
-	QString normalizeActionCommandTextForSend(const QString &source);
+	QString normalizeActionCommandTextNewlines(const QString &source);
 
 	/**
 	 * @brief Applies wildcard replacement/post-processing for send-target transforms.

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -2159,14 +2159,16 @@ class tst_WorldView_Basic : public QObject
 			resetTestState();
 		}
 
-		void ctrlBackspaceClearsInput()
+		void ctrlBackspaceDeletesPreviousWordWhenOptionEnabled()
 		{
 			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("ctrl_backspace_deletes_last_word"), QStringLiteral("1"));
 
 			WorldView view;
 			view.resize(900, 640);
 			view.show();
 			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
 			QCoreApplication::processEvents();
 
 			QPlainTextEdit *input = view.inputEditor();
@@ -2185,7 +2187,39 @@ class tst_WorldView_Basic : public QObject
 			QTest::keyClick(input, Qt::Key_Backspace, Qt::ControlModifier);
 			QCoreApplication::processEvents();
 
-			QCOMPARE(view.inputText(), QString());
+			QCOMPARE(view.inputText(), QStringLiteral("alpha beta"));
+			QCOMPARE(shortcutTriggerCount, 0);
+			resetTestState();
+		}
+
+		void ctrlBackspaceRecallsLastHistoryWordWhenDeleteOptionDisabled()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("cast fireball"));
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+
+			int       shortcutTriggerCount = 0;
+			QShortcut conflictingShortcut(QKeySequence(QStringLiteral("Ctrl+Backspace")), input);
+			conflictingShortcut.setContext(Qt::WidgetWithChildrenShortcut);
+			connect(&conflictingShortcut, &QShortcut::activated, this,
+			        [&shortcutTriggerCount] { ++shortcutTriggerCount; });
+
+			input->setFocus(Qt::OtherFocusReason);
+			QTRY_VERIFY(input->hasFocus());
+			QTest::keyClick(input, Qt::Key_Backspace, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+
+			QCOMPARE(view.inputText(), QStringLiteral("fireball"));
 			QCOMPARE(shortcutTriggerCount, 0);
 			resetTestState();
 		}
@@ -2224,6 +2258,262 @@ class tst_WorldView_Basic : public QObject
 			QCOMPARE(g_acceleratorExecutionCount, 1);
 			QCOMPARE(g_lastExecutedAcceleratorCommand, commandId);
 			QCOMPARE(shortcutTriggerCount, 0);
+
+			resetTestState();
+		}
+
+		void commandOptionShortcutsOverrideConflictingShortcutsWithInputFocus()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("ctrl_p_goes_to_previous_command"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("ctrl_n_goes_to_next_command"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("ctrl_z_goes_to_end_of_buffer"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("north"));
+			view.addToHistoryForced(QStringLiteral("south"));
+			for (int i = 0; i < 320; ++i)
+				view.appendOutputText(QStringLiteral("command-option-input-scroll-%1").arg(i), true);
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			input->setFocus(Qt::OtherFocusReason);
+			QTRY_VERIFY(input->hasFocus());
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QScrollBar *bar = browser->verticalScrollBar();
+			QVERIFY(bar);
+			QTRY_VERIFY(bar->maximum() > bar->minimum());
+
+			int       shortcutTriggerCount = 0;
+			QShortcut ctrlPShortcut(QKeySequence(QStringLiteral("Ctrl+P")), &view);
+			QShortcut ctrlNShortcut(QKeySequence(QStringLiteral("Ctrl+N")), &view);
+			QShortcut ctrlZShortcut(QKeySequence(QStringLiteral("Ctrl+Z")), &view);
+			for (QShortcut *shortcut : {&ctrlPShortcut, &ctrlNShortcut, &ctrlZShortcut})
+			{
+				shortcut->setContext(Qt::ApplicationShortcut);
+				connect(shortcut, &QShortcut::activated, this,
+				        [&shortcutTriggerCount] { ++shortcutTriggerCount; });
+			}
+
+			QTest::keyClick(input, Qt::Key_P, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("south"));
+
+			QTest::keyClick(input, Qt::Key_P, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("north"));
+
+			QTest::keyClick(input, Qt::Key_N, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("south"));
+
+			QCOMPARE(view.setOutputScroll(0, true), 0);
+			QTRY_COMPARE(view.outputScrollPosition(), bar->minimum());
+			QTest::keyClick(input, Qt::Key_Z, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QTRY_COMPARE(view.outputScrollPosition(), bar->maximum());
+			QVERIFY(!view.isScrollbackSplitActive());
+			QCOMPARE(shortcutTriggerCount, 0);
+
+			resetTestState();
+		}
+
+		void commandOptionShortcutsOverrideConflictingShortcutsWithOutputFocus()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("ctrl_p_goes_to_previous_command"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("ctrl_n_goes_to_next_command"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("ctrl_z_goes_to_end_of_buffer"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("north"));
+			view.addToHistoryForced(QStringLiteral("south"));
+			for (int i = 0; i < 320; ++i)
+				view.appendOutputText(QStringLiteral("command-option-output-scroll-%1").arg(i), true);
+			QCoreApplication::processEvents();
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QWidget *viewport = browser->viewport();
+			QVERIFY(viewport);
+			QScrollBar *bar = browser->verticalScrollBar();
+			QVERIFY(bar);
+			QTRY_VERIFY(bar->maximum() > bar->minimum());
+
+			int       shortcutTriggerCount = 0;
+			QShortcut ctrlPShortcut(QKeySequence(QStringLiteral("Ctrl+P")), &view);
+			QShortcut ctrlNShortcut(QKeySequence(QStringLiteral("Ctrl+N")), &view);
+			QShortcut ctrlZShortcut(QKeySequence(QStringLiteral("Ctrl+Z")), &view);
+			for (QShortcut *shortcut : {&ctrlPShortcut, &ctrlNShortcut, &ctrlZShortcut})
+			{
+				shortcut->setContext(Qt::ApplicationShortcut);
+				connect(shortcut, &QShortcut::activated, this,
+				        [&shortcutTriggerCount] { ++shortcutTriggerCount; });
+			}
+
+			QTest::keyClick(viewport, Qt::Key_P, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("south"));
+
+			QTest::keyClick(viewport, Qt::Key_P, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("north"));
+
+			QTest::keyClick(viewport, Qt::Key_N, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("south"));
+
+			QCOMPARE(view.setOutputScroll(0, true), 0);
+			QTRY_COMPARE(view.outputScrollPosition(), bar->minimum());
+			QTest::keyClick(viewport, Qt::Key_Z, Qt::ControlModifier);
+			QCoreApplication::processEvents();
+			QTRY_COMPARE(view.outputScrollPosition(), bar->maximum());
+			QVERIFY(!view.isScrollbackSplitActive());
+			QCOMPARE(shortcutTriggerCount, 0);
+
+			resetTestState();
+		}
+
+		void commandOptionShortcutDetectionRequiresEnabledOption()
+		{
+			resetTestState();
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			QCoreApplication::processEvents();
+
+			QKeyEvent ctrlPDisabled(QEvent::ShortcutOverride, Qt::Key_P, Qt::ControlModifier);
+			QVERIFY(!view.hasCommandOptionShortcut(&ctrlPDisabled));
+
+			g_worldAttrs.insert(QStringLiteral("ctrl_p_goes_to_previous_command"), QStringLiteral("1"));
+			view.applyRuntimeSettings();
+			QKeyEvent ctrlPEnabled(QEvent::ShortcutOverride, Qt::Key_P, Qt::ControlModifier);
+			QVERIFY(view.hasCommandOptionShortcut(&ctrlPEnabled));
+
+			QKeyEvent ctrlShiftP(QEvent::ShortcutOverride, Qt::Key_P,
+			                     Qt::ControlModifier | Qt::ShiftModifier);
+			QVERIFY(!view.hasCommandOptionShortcut(&ctrlShiftP));
+
+			resetTestState();
+		}
+
+		void commandHistoryShortcutsOverrideConflictingShortcutsWithInputFocus()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("arrow_recalls_partial"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("hitman"));
+			view.addToHistoryForced(QStringLiteral("hit 321"));
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			input->setFocus(Qt::OtherFocusReason);
+			QTRY_VERIFY(input->hasFocus());
+			view.setInputText(QStringLiteral("hit"), true);
+
+			int       shortcutTriggerCount = 0;
+			QShortcut altUpShortcut(QKeySequence(QStringLiteral("Alt+Up")), &view);
+			QShortcut altDownShortcut(QKeySequence(QStringLiteral("Alt+Down")), &view);
+			for (QShortcut *shortcut : {&altUpShortcut, &altDownShortcut})
+			{
+				shortcut->setContext(Qt::ApplicationShortcut);
+				connect(shortcut, &QShortcut::activated, this,
+				        [&shortcutTriggerCount] { ++shortcutTriggerCount; });
+			}
+
+			QTest::keyClick(input, Qt::Key_Up, Qt::AltModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("hit 321"));
+			QCOMPARE(shortcutTriggerCount, 0);
+
+			resetTestState();
+		}
+
+		void commandHistoryShortcutsOverrideConflictingShortcutsWithOutputFocus()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("arrow_recalls_partial"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("hitman"));
+			view.addToHistoryForced(QStringLiteral("hit 321"));
+			view.appendOutputText(QStringLiteral("history-output-focus"), true);
+			QCoreApplication::processEvents();
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QWidget *viewport = browser->viewport();
+			QVERIFY(viewport);
+			view.setInputText(QStringLiteral("hit"), true);
+
+			int       shortcutTriggerCount = 0;
+			QShortcut altUpShortcut(QKeySequence(QStringLiteral("Alt+Up")), &view);
+			QShortcut altDownShortcut(QKeySequence(QStringLiteral("Alt+Down")), &view);
+			for (QShortcut *shortcut : {&altUpShortcut, &altDownShortcut})
+			{
+				shortcut->setContext(Qt::ApplicationShortcut);
+				connect(shortcut, &QShortcut::activated, this,
+				        [&shortcutTriggerCount] { ++shortcutTriggerCount; });
+			}
+
+			QTest::keyClick(viewport, Qt::Key_Up, Qt::AltModifier);
+			QCoreApplication::processEvents();
+			QCOMPARE(view.inputText(), QStringLiteral("hit 321"));
+			QCOMPARE(shortcutTriggerCount, 0);
+
+			resetTestState();
+		}
+
+		void commandHistoryShortcutDetectionRequiresEnabledOptionAndExactAltArrow()
+		{
+			resetTestState();
+
+			WorldView view;
+			QKeyEvent altUp(QEvent::ShortcutOverride, Qt::Key_Up, Qt::AltModifier);
+			QVERIFY(!view.hasCommandHistoryShortcut(&altUp));
+
+			g_worldAttrs.insert(QStringLiteral("alt_arrow_recalls_partial"), QStringLiteral("1"));
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+
+			QVERIFY(view.hasCommandHistoryShortcut(&altUp));
+
+			QKeyEvent altDown(QEvent::ShortcutOverride, Qt::Key_Down, Qt::AltModifier);
+			QVERIFY(view.hasCommandHistoryShortcut(&altDown));
+
+			QKeyEvent plainUp(QEvent::ShortcutOverride, Qt::Key_Up, Qt::NoModifier);
+			QVERIFY(!view.hasCommandHistoryShortcut(&plainUp));
+
+			QKeyEvent ctrlAltUp(QEvent::ShortcutOverride, Qt::Key_Up, Qt::ControlModifier | Qt::AltModifier);
+			QVERIFY(!view.hasCommandHistoryShortcut(&ctrlAltUp));
 
 			resetTestState();
 		}

--- a/tests/integration/tst_TelnetProcessor_Compression.cpp
+++ b/tests/integration/tst_TelnetProcessor_Compression.cpp
@@ -20,6 +20,7 @@ namespace
 	constexpr unsigned char SB               = 0xFA;
 	constexpr unsigned char SE               = 0xF0;
 	constexpr unsigned char TELOPT_COMPRESS2 = 86;
+	constexpr unsigned char GMCP             = 201;
 
 	QByteArray              bytes(std::initializer_list<unsigned char> raw)
 	{
@@ -95,6 +96,132 @@ class tst_TelnetProcessor_Compression : public QObject
 			QCOMPARE(processor.mccpType(), 0);
 			QVERIFY(processor.totalCompressedBytes() > 0);
 			QVERIFY(processor.totalUncompressedBytes() >= 5);
+		}
+
+		void packetTransformRunsAfterMccpInflateBeforeTelnetParsing()
+		{
+			TelnetProcessor  processor;
+
+			QByteArray       plain      = bytes({IAC, SB, GMCP, 'r', 'o', 'o', 'm', IAC, SE});
+			const QByteArray compressed = makeQtZlibPayload(plain);
+			QVERIFY(!compressed.isEmpty());
+
+			const QByteArray  gmcpMarker = bytes({IAC, SB, GMCP});
+			QList<QByteArray> seenPackets;
+			const QByteArray  prefix     = QByteArrayLiteral("pre");
+			const QByteArray  activation = bytes({IAC, SB, TELOPT_COMPRESS2, IAC, SE});
+			QByteArray        packet     = prefix + activation + compressed;
+			const QByteArray  output     = processor.processBytes(
+			    packet,
+			    [&](QByteArray &payload)
+			    {
+				    seenPackets.append(payload);
+				    if (payload == prefix)
+				    {
+					    payload = QByteArrayLiteral("prefix\n");
+					    return;
+				    }
+				    const qsizetype gmcpAt = payload.indexOf(gmcpMarker);
+				    if (gmcpAt >= 0)
+					    payload.insert(gmcpAt, QByteArrayLiteral("qxv-insert-5d2\r\n"));
+			    });
+
+			QCOMPARE(seenPackets.size(), 2);
+			QCOMPARE(seenPackets.at(0), prefix);
+			QCOMPARE(seenPackets.at(1), plain);
+			QVERIFY(!seenPackets.contains(activation));
+			QVERIFY(!seenPackets.contains(compressed));
+			QCOMPARE(output, QByteArrayLiteral("prefix\nqxv-insert-5d2\r\n"));
+
+			const QList<TelnetProcessor::TelnetPluginEvent> events = processor.takeTelnetPluginEvents();
+			QCOMPARE(events.size(), 1);
+			QCOMPARE(events.constFirst().type, TelnetProcessor::TelnetPluginEvent::Subnegotiation);
+			QCOMPARE(events.constFirst().offset, QByteArrayLiteral("prefix\nqxv-insert-5d2\r\n").size());
+		}
+
+		void packetTransformDoesNotMisclassifyEscapedIacInsideSubnegotiationAsMccp()
+		{
+			TelnetProcessor processor;
+
+			QByteArray      payload = QByteArrayLiteral("before");
+			payload += bytes({IAC, SB, GMCP, 'a', IAC, IAC, SB, TELOPT_COMPRESS2, 'b', IAC, SE});
+			payload += QByteArrayLiteral("after");
+
+			QList<QByteArray> seenPackets;
+			const QByteArray  output = processor.processBytes(payload, [&](const QByteArray &packetPayload)
+			                                                  { seenPackets.append(packetPayload); });
+
+			QCOMPARE(seenPackets.size(), 1);
+			QCOMPARE(seenPackets.constFirst(), payload);
+			QCOMPARE(output, QByteArrayLiteral("beforeafter"));
+			QVERIFY(!processor.isCompressing());
+
+			const QList<TelnetProcessor::TelnetPluginEvent> events = processor.takeTelnetPluginEvents();
+			QCOMPARE(events.size(), 1);
+			QCOMPARE(events.constFirst().type, TelnetProcessor::TelnetPluginEvent::Subnegotiation);
+			QCOMPARE(events.constFirst().option, static_cast<int>(GMCP));
+			QCOMPARE(events.constFirst().data, bytes({'a', IAC, SB, TELOPT_COMPRESS2, 'b'}));
+		}
+
+		void packetTransformDoesNotSeeSplitMccpActivation()
+		{
+			TelnetProcessor  processor;
+
+			const QByteArray plain      = QByteArrayLiteral("after-mccp\n");
+			const QByteArray compressed = makeQtZlibPayload(plain);
+			QVERIFY(!compressed.isEmpty());
+
+			const QByteArray  activation = bytes({IAC, SB, TELOPT_COMPRESS2, IAC, SE});
+			QList<QByteArray> seenPackets;
+			const QByteArray  firstOutput =
+			    processor.processBytes(QByteArrayLiteral("before\n") + activation.left(2),
+			                           [&](const QByteArray &payload) { seenPackets.append(payload); });
+			QCOMPARE(firstOutput, QByteArrayLiteral("before\n"));
+
+			const QByteArray secondOutput =
+			    processor.processBytes(activation.mid(2) + compressed,
+			                           [&](const QByteArray &payload) { seenPackets.append(payload); });
+			QCOMPARE(secondOutput, plain);
+
+			QCOMPARE(seenPackets.size(), 2);
+			QCOMPARE(seenPackets.at(0), QByteArrayLiteral("before\n"));
+			QCOMPARE(seenPackets.at(1), plain);
+			QVERIFY(!seenPackets.contains(activation));
+			QVERIFY(!seenPackets.contains(compressed));
+		}
+
+		void packetTransformDoesNotSeeMccpRestartAfterStreamEnd()
+		{
+			TelnetProcessor  processor;
+
+			const QByteArray firstPlain   = QByteArrayLiteral("old-stream\n");
+			const QByteArray secondPlain  = QByteArrayLiteral("new-stream\n");
+			const QByteArray firstStream  = makeQtZlibPayload(firstPlain);
+			const QByteArray secondStream = makeQtZlibPayload(secondPlain);
+			QVERIFY(!firstStream.isEmpty());
+			QVERIFY(!secondStream.isEmpty());
+
+			const QByteArray  activation     = bytes({IAC, SB, TELOPT_COMPRESS2, IAC, SE});
+			const QByteArray  plainRemainder = QByteArrayLiteral("after-copyover\n");
+			QList<QByteArray> seenPackets;
+			QByteArray        packet = activation + firstStream + plainRemainder + activation + secondStream;
+			const QByteArray  output =
+			    processor.processBytes(packet,
+			                           [&](QByteArray &payload)
+			                           {
+				                           seenPackets.append(payload);
+				                           if (payload == plainRemainder)
+					                           payload = QByteArrayLiteral("between-streams\n");
+			                           });
+
+			QCOMPARE(seenPackets.size(), 3);
+			QCOMPARE(seenPackets.at(0), firstPlain);
+			QCOMPARE(seenPackets.at(1), plainRemainder);
+			QCOMPARE(seenPackets.at(2), secondPlain);
+			QVERIFY(!seenPackets.contains(activation));
+			QVERIFY(!seenPackets.contains(firstStream));
+			QVERIFY(!seenPackets.contains(secondStream));
+			QCOMPARE(output, QByteArrayLiteral("old-stream\nbetween-streams\nnew-stream\n"));
 		}
 
 		void malformedCompressedDataEmitsFatalError()
@@ -192,7 +319,6 @@ class tst_TelnetProcessor_Compression : public QObject
 };
 
 QTEST_APPLESS_MAIN(tst_TelnetProcessor_Compression)
-
 
 #if __has_include("tst_TelnetProcessor_Compression.moc")
 #include "tst_TelnetProcessor_Compression.moc"

--- a/tests/integration/tst_TelnetProcessor_Subnegotiation.cpp
+++ b/tests/integration/tst_TelnetProcessor_Subnegotiation.cpp
@@ -20,7 +20,7 @@ namespace
 	constexpr unsigned char TELOPT_TERMINAL_TYPE = 24;
 	constexpr unsigned char TTYPE_SEND           = 1;
 
-	QByteArray bytes(std::initializer_list<unsigned char> raw)
+	QByteArray              bytes(std::initializer_list<unsigned char> raw)
 	{
 		QByteArray out;
 		for (const unsigned char c : raw)
@@ -36,11 +36,11 @@ class tst_TelnetProcessor_Subnegotiation : public QObject
 {
 		Q_OBJECT
 
-	// NOLINTBEGIN(readability-convert-member-functions-to-static)
+		// NOLINTBEGIN(readability-convert-member-functions-to-static)
 	private slots:
 		void genericSubnegotiationCallback()
 		{
-			TelnetProcessor  processor;
+			TelnetProcessor   processor;
 			TelnetCallbackSpy spy;
 			processor.setCallbacks(spy.callbacks());
 
@@ -50,9 +50,28 @@ class tst_TelnetProcessor_Subnegotiation : public QObject
 			QCOMPARE(spy.subnegotiations.at(0).data, QByteArrayLiteral("ab"));
 		}
 
+		void subnegotiationPluginEventRecordsProcessedStreamOffset()
+		{
+			TelnetProcessor processor;
+
+			QByteArray      input = QByteArrayLiteral("room text\r\n");
+			input += bytes({IAC, SB, 201, 'r', 'o', 'o', 'm', IAC, SE});
+			input += QByteArrayLiteral("prompt");
+
+			const QByteArray output = processor.processBytes(input);
+			QCOMPARE(output, QByteArrayLiteral("room text\r\nprompt"));
+
+			const QList<TelnetProcessor::TelnetPluginEvent> events = processor.takeTelnetPluginEvents();
+			QCOMPARE(events.size(), 1);
+			QCOMPARE(events.at(0).type, TelnetProcessor::TelnetPluginEvent::Subnegotiation);
+			QCOMPARE(events.at(0).option, 201);
+			QCOMPARE(events.at(0).data, QByteArrayLiteral("room"));
+			QCOMPARE(events.at(0).offset, QByteArrayLiteral("room text\r\n").size());
+		}
+
 		void mudSpecificCallsOptionAndSubnegotiation()
 		{
-			TelnetProcessor  processor;
+			TelnetProcessor   processor;
 			TelnetCallbackSpy spy;
 			processor.setCallbacks(spy.callbacks());
 
@@ -64,9 +83,26 @@ class tst_TelnetProcessor_Subnegotiation : public QObject
 			QCOMPARE(spy.telnetOptions.at(0), QByteArray("x\xFFy", 3));
 		}
 
-		void subnegotiationCanSpanPackets()
+		void mudSpecificPluginEventsKeepOptionBeforeSubnegotiation()
 		{
 			TelnetProcessor  processor;
+
+			const QByteArray output =
+			    processor.processBytes(bytes({'a', IAC, SB, TELOPT_MUD_SPECIFIC, 'x', IAC, SE, 'b'}));
+			QCOMPARE(output, QByteArrayLiteral("ab"));
+
+			const QList<TelnetProcessor::TelnetPluginEvent> events = processor.takeTelnetPluginEvents();
+			QCOMPARE(events.size(), 2);
+			QCOMPARE(events.at(0).type, TelnetProcessor::TelnetPluginEvent::Option);
+			QCOMPARE(events.at(1).type, TelnetProcessor::TelnetPluginEvent::Subnegotiation);
+			QCOMPARE(events.at(0).offset, 1);
+			QCOMPARE(events.at(1).offset, 1);
+			QVERIFY(events.at(0).sequence < events.at(1).sequence);
+		}
+
+		void subnegotiationCanSpanPackets()
+		{
+			TelnetProcessor   processor;
 			TelnetCallbackSpy spy;
 			processor.setCallbacks(spy.callbacks());
 
@@ -79,22 +115,44 @@ class tst_TelnetProcessor_Subnegotiation : public QObject
 			QCOMPARE(spy.subnegotiations.at(0).data, QByteArrayLiteral("ab"));
 		}
 
+		void splitSubnegotiationEscapedIacDoesNotStartMccp()
+		{
+			TelnetProcessor processor;
+
+			processor.processBytes(bytes({IAC, SB, 200, 'a'}));
+
+			QList<QByteArray> seenPackets;
+			const QByteArray  secondPacket = bytes({IAC, IAC, SB, 86, 'b', IAC, SE});
+			const QByteArray  output = processor.processBytes(secondPacket, [&](const QByteArray &payload)
+			                                                  { seenPackets.append(payload); });
+
+			QCOMPARE(output, QByteArray());
+			QCOMPARE(seenPackets.size(), 1);
+			QCOMPARE(seenPackets.constFirst(), secondPacket);
+			QVERIFY(!processor.isCompressing());
+
+			const QList<TelnetProcessor::TelnetPluginEvent> events = processor.takeTelnetPluginEvents();
+			QCOMPARE(events.size(), 1);
+			QCOMPARE(events.constFirst().type, TelnetProcessor::TelnetPluginEvent::Subnegotiation);
+			QCOMPARE(events.constFirst().option, 200);
+			QCOMPARE(events.constFirst().data, bytes({'a', IAC, SB, 86, 'b'}));
+		}
+
 		void terminalTypeSubnegotiationDoesNotCallGenericCallback()
 		{
-			TelnetProcessor  processor;
+			TelnetProcessor   processor;
 			TelnetCallbackSpy spy;
 			processor.setCallbacks(spy.callbacks());
 
 			processor.processBytes(bytes({IAC, SB, TELOPT_TERMINAL_TYPE, TTYPE_SEND, IAC, SE}));
 			QCOMPARE(spy.subnegotiations.size(), 0);
+			QVERIFY(processor.takeTelnetPluginEvents().isEmpty());
 			QVERIFY(!processor.takeOutboundData().isEmpty());
 		}
-	// NOLINTEND(readability-convert-member-functions-to-static)
+		// NOLINTEND(readability-convert-member-functions-to-static)
 };
 
 QTEST_APPLESS_MAIN(tst_TelnetProcessor_Subnegotiation)
-
-
 
 #if __has_include("tst_TelnetProcessor_Subnegotiation.moc")
 #include "tst_TelnetProcessor_Subnegotiation.moc"

--- a/tests/integration/tst_WorldCommandProcessor_Queueing.cpp
+++ b/tests/integration/tst_WorldCommandProcessor_Queueing.cpp
@@ -131,7 +131,7 @@ class tst_WorldCommandProcessor_Queueing : public QObject
 			QVERIFY(queue.isEmpty());
 		}
 
-		void actionCommandTextNormalizesLineEndingsForSend_data()
+		void actionCommandTextNormalizesNewlines_data()
 		{
 			QTest::addColumn<QString>("input");
 			QTest::addColumn<QString>("expected");
@@ -146,12 +146,12 @@ class tst_WorldCommandProcessor_Queueing : public QObject
 			QTest::newRow("empty") << QString() << QString();
 		}
 
-		void actionCommandTextNormalizesLineEndingsForSend()
+		void actionCommandTextNormalizesNewlines()
 		{
 			QFETCH(QString, input);
 			QFETCH(QString, expected);
 
-			QCOMPARE(QMudCommandText::normalizeActionCommandTextForSend(input), expected);
+			QCOMPARE(QMudCommandText::normalizeActionCommandTextNewlines(input), expected);
 		}
 		// NOLINTEND(readability-convert-member-functions-to-static)
 };

--- a/tests/integration/tst_WorldCommandProcessor_Queueing.cpp
+++ b/tests/integration/tst_WorldCommandProcessor_Queueing.cpp
@@ -130,6 +130,29 @@ class tst_WorldCommandProcessor_Queueing : public QObject
 			QCOMPARE(QMudCommandQueue::discardAll(queue), 2);
 			QVERIFY(queue.isEmpty());
 		}
+
+		void actionCommandTextNormalizesLineEndingsForSend_data()
+		{
+			QTest::addColumn<QString>("input");
+			QTest::addColumn<QString>("expected");
+
+			QTest::newRow("lf") << QStringLiteral("north\nsouth") << QStringLiteral("north\r\nsouth");
+			QTest::newRow("crlf") << QStringLiteral("north\r\nsouth") << QStringLiteral("north\r\nsouth");
+			QTest::newRow("cr") << QStringLiteral("north\rsouth") << QStringLiteral("north\r\nsouth");
+			QTest::newRow("mixed") << QStringLiteral("north\nsouth\reast\r\nwest")
+			                       << QStringLiteral("north\r\nsouth\r\neast\r\nwest");
+			QTest::newRow("trailing-lf") << QStringLiteral("north\n") << QStringLiteral("north\r\n");
+			QTest::newRow("trailing-crlf") << QStringLiteral("north\r\n") << QStringLiteral("north\r\n");
+			QTest::newRow("empty") << QString() << QString();
+		}
+
+		void actionCommandTextNormalizesLineEndingsForSend()
+		{
+			QFETCH(QString, input);
+			QFETCH(QString, expected);
+
+			QCOMPARE(QMudCommandText::normalizeActionCommandTextForSend(input), expected);
+		}
 		// NOLINTEND(readability-convert-member-functions-to-static)
 };
 

--- a/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
+++ b/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
@@ -253,11 +253,12 @@ class tst_WorldCommandProcessor_Trigger : public QObject
 			QCOMPARE(queuedPayloads(processor), (QStringList{QStringLiteral("qcmd-tail-9f31")}));
 			QCOMPARE(queuedTypes(processor), (QList<bool>{true}));
 
-			runtime.setCurrentActionSource(WorldRuntime::eTriggerFired);
-			processor.sendRawText(QStringLiteral("qcmd-priority-a17"), false, false, true, false);
-			processor.sendRawText(QStringLiteral("qcmd-priority-b42"), false, false, true, false);
-			processor.sendRawText(QStringLiteral("qcmd-priority-c83"), false, false, true, false);
-			runtime.setCurrentActionSource(WorldRuntime::eUnknownActionSource);
+			processor.sendRawTextWithTriggerPriority(QStringLiteral("qcmd-priority-a17"), false, false, true,
+			                                         false);
+			processor.sendRawTextWithTriggerPriority(QStringLiteral("qcmd-priority-b42"), false, false, true,
+			                                         false);
+			processor.sendRawTextWithTriggerPriority(QStringLiteral("qcmd-priority-c83"), false, false, true,
+			                                         false);
 
 			QCOMPARE(queuedPayloads(processor),
 			         (QStringList{QStringLiteral("qcmd-priority-a17"), QStringLiteral("qcmd-priority-b42"),
@@ -271,9 +272,8 @@ class tst_WorldCommandProcessor_Trigger : public QObject
 			                      QStringLiteral("qcmd-normal-d64")}));
 			QCOMPARE(queuedTypes(processor), (QList<bool>{false, false, false, true, false}));
 
-			runtime.setCurrentActionSource(WorldRuntime::eTriggerFired);
-			processor.sendRawText(QStringLiteral("qcmd-priority-e05"), false, false, true, false);
-			runtime.setCurrentActionSource(WorldRuntime::eUnknownActionSource);
+			processor.sendRawTextWithTriggerPriority(QStringLiteral("qcmd-priority-e05"), false, false, true,
+			                                         false);
 
 			QCOMPARE(queuedPayloads(processor),
 			         (QStringList{QStringLiteral("qcmd-priority-a17"), QStringLiteral("qcmd-priority-b42"),

--- a/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
+++ b/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
@@ -11,6 +11,13 @@
 #include "WorldCommandProcessorUtils.h"
 #include "WorldOptions.h"
 
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QHostAddress>
+#include <QScopedPointer>
+#include <QTcpServer>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QTcpSocket>
+#include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 
 namespace
@@ -47,6 +54,32 @@ namespace
 		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
 		trigger.children.insert(QStringLiteral("send"), QStringLiteral("return true"));
 		return trigger;
+	}
+
+	/**
+	 * @brief Decodes queued command payloads for assertions.
+	 * @param processor Processor whose queue should be inspected.
+	 * @return Queue payloads in dispatch order.
+	 */
+	QStringList queuedPayloads(const WorldCommandProcessor &processor)
+	{
+		QStringList payloads;
+		for (const QString &entry : processor.queuedCommands())
+			payloads.push_back(QMudCommandQueue::decodeQueueEntry(entry).payload);
+		return payloads;
+	}
+
+	/**
+	 * @brief Decodes queued command delayed-queue flags for assertions.
+	 * @param processor Processor whose queue should be inspected.
+	 * @return Queue delayed flags in dispatch order.
+	 */
+	QList<bool> queuedTypes(const WorldCommandProcessor &processor)
+	{
+		QList<bool> queuedTypes;
+		for (const QString &entry : processor.queuedCommands())
+			queuedTypes.push_back(QMudCommandQueue::decodeQueueEntry(entry).queuedType);
+		return queuedTypes;
 	}
 } // namespace
 
@@ -191,6 +224,62 @@ class tst_WorldCommandProcessor_Trigger : public QObject
 			QCOMPARE(capturedRuns.at(2).textColour, 0x0000ff);
 			QCOMPARE(capturedRuns.at(2).backColour, 0x000000);
 			QCOMPARE(capturedRuns.at(2).style, 0);
+		}
+
+		static void triggerSendsInsertAtPriorityQueueBoundary()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("1000"));
+
+			WorldCommandProcessor processor;
+			processor.setRuntime(&runtime);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			processor.sendRawText(QStringLiteral("qcmd-tail-9f31"), false, true, true, false);
+			QCOMPARE(queuedPayloads(processor), (QStringList{QStringLiteral("qcmd-tail-9f31")}));
+			QCOMPARE(queuedTypes(processor), (QList<bool>{true}));
+
+			runtime.setCurrentActionSource(WorldRuntime::eTriggerFired);
+			processor.sendRawText(QStringLiteral("qcmd-priority-a17"), false, false, true, false);
+			processor.sendRawText(QStringLiteral("qcmd-priority-b42"), false, false, true, false);
+			processor.sendRawText(QStringLiteral("qcmd-priority-c83"), false, false, true, false);
+			runtime.setCurrentActionSource(WorldRuntime::eUnknownActionSource);
+
+			QCOMPARE(queuedPayloads(processor),
+			         (QStringList{QStringLiteral("qcmd-priority-a17"), QStringLiteral("qcmd-priority-b42"),
+			                      QStringLiteral("qcmd-priority-c83"), QStringLiteral("qcmd-tail-9f31")}));
+			QCOMPARE(queuedTypes(processor), (QList<bool>{false, false, false, true}));
+
+			processor.sendRawText(QStringLiteral("qcmd-normal-d64"), false, false, true, false);
+			QCOMPARE(queuedPayloads(processor),
+			         (QStringList{QStringLiteral("qcmd-priority-a17"), QStringLiteral("qcmd-priority-b42"),
+			                      QStringLiteral("qcmd-priority-c83"), QStringLiteral("qcmd-tail-9f31"),
+			                      QStringLiteral("qcmd-normal-d64")}));
+			QCOMPARE(queuedTypes(processor), (QList<bool>{false, false, false, true, false}));
+
+			runtime.setCurrentActionSource(WorldRuntime::eTriggerFired);
+			processor.sendRawText(QStringLiteral("qcmd-priority-e05"), false, false, true, false);
+			runtime.setCurrentActionSource(WorldRuntime::eUnknownActionSource);
+
+			QCOMPARE(queuedPayloads(processor),
+			         (QStringList{QStringLiteral("qcmd-priority-a17"), QStringLiteral("qcmd-priority-b42"),
+			                      QStringLiteral("qcmd-priority-c83"), QStringLiteral("qcmd-priority-e05"),
+			                      QStringLiteral("qcmd-tail-9f31"), QStringLiteral("qcmd-normal-d64")}));
+			QCOMPARE(queuedTypes(processor), (QList<bool>{false, false, false, false, true, false}));
 		}
 };
 

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -8,6 +8,7 @@
 
 #include "NativePluginRegistry.h"
 #include "WorldChildWindow.h"
+#include "WorldCommandProcessor.h"
 #include "WorldCommandProcessorUtils.h"
 #include "WorldDocument.h"
 #include "WorldOptions.h"
@@ -319,6 +320,63 @@ end
 	}
 
 	/**
+	 * @brief Creates an execute trigger with a multiline action body.
+	 * @param match Trigger match text.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeMultilineExecuteTrigger(const QString &match)
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), match);
+		trigger.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToExecute));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		trigger.children.insert(QStringLiteral("send"),
+		                        QStringLiteral("qcmd-trigger-multi-a23\nqcmd-trigger-multi-b58\n"));
+		return trigger;
+	}
+
+	/**
+	 * @brief Creates an execute alias with a multiline action body.
+	 * @param match Alias match text.
+	 * @return Alias fixture.
+	 */
+	WorldRuntime::Alias makeMultilineExecuteAlias(const QString &match)
+	{
+		WorldRuntime::Alias alias;
+		alias.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		alias.attributes.insert(QStringLiteral("match"), match);
+		alias.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToExecute));
+		alias.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		alias.children.insert(QStringLiteral("send"),
+		                      QStringLiteral("qcmd-alias-multi-a23\nqcmd-alias-multi-b58\n"));
+		return alias;
+	}
+
+	/**
+	 * @brief Creates an execute timer with a multiline action body.
+	 * @return Timer fixture.
+	 */
+	WorldRuntime::Timer makeMultilineExecuteTimer()
+	{
+		WorldRuntime::Timer timer;
+		timer.attributes.insert(QStringLiteral("name"), QStringLiteral("qxv-timer-multiline-41"));
+		timer.attributes.insert(QStringLiteral("enabled"), QStringLiteral("1"));
+		timer.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToExecute));
+		timer.attributes.insert(QStringLiteral("at_time"), QStringLiteral("0"));
+		timer.attributes.insert(QStringLiteral("hour"), QStringLiteral("0"));
+		timer.attributes.insert(QStringLiteral("minute"), QStringLiteral("0"));
+		timer.attributes.insert(QStringLiteral("second"), QStringLiteral("3600"));
+		timer.attributes.insert(QStringLiteral("offset_hour"), QStringLiteral("0"));
+		timer.attributes.insert(QStringLiteral("offset_minute"), QStringLiteral("0"));
+		timer.attributes.insert(QStringLiteral("offset_second"), QStringLiteral("0"));
+		timer.children.insert(QStringLiteral("send"),
+		                      QStringLiteral("\nqcmd-timer-multi-a23\n\nqcmd-timer-multi-b58\n"));
+		timer.nextFireTime = QDateTime::currentDateTime().addSecs(3600);
+		return timer;
+	}
+
+	/**
 	 * @brief Decodes queued command payloads for assertions.
 	 * @param runtime Runtime whose queue should be inspected.
 	 * @return Queue payloads in dispatch order.
@@ -530,6 +588,137 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QTRY_COMPARE_WITH_TIMEOUT(
 			    queuedPayloads(runtime),
 			    (QStringList{QStringLiteral("qcmd-execute-a14"), QStringLiteral("qcmd-tail-z77")}), 5000);
+		}
+
+		static void executeTriggerMultilineActionRunsEachCommandWithoutTrailingBlank()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.triggersMutable().push_back(
+			    makeMultilineExecuteTrigger(QStringLiteral("qxv-execute-multiline-18")));
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			const QByteArray triggerLine = QByteArrayLiteral("qxv-execute-multiline-18\r\n");
+			QCOMPARE(acceptedSocket->write(triggerLine), static_cast<qint64>(triggerLine.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-trigger-multi-a23"),
+			                 QStringLiteral("qcmd-trigger-multi-b58"), QStringLiteral("qcmd-tail-z77")}),
+			    5000);
+		}
+
+		static void executeAliasMultilineActionRunsEachCommandWithoutTrailingBlank()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_aliases"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.aliasesMutable().push_back(
+			    makeMultilineExecuteAlias(QStringLiteral("qxv-alias-multiline-29")));
+			runtime.markAliasesChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			QCOMPARE(runtime.executeCommand(QStringLiteral("qxv-alias-multiline-29")), eOK);
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-tail-z77"), QStringLiteral("qcmd-alias-multi-a23"),
+			                 QStringLiteral("qcmd-alias-multi-b58")}),
+			    5000);
+		}
+
+		static void executeTimerMultilineActionRunsEachCommandWithoutBlankLines()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_timers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.timersMutable().push_back(makeMultilineExecuteTimer());
+			runtime.markTimersChanged();
+
+			WorldCommandProcessor processor;
+			processor.setRuntime(&runtime);
+			runtime.setCommandProcessor(&processor);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			runtime.timersMutable().first().nextFireTime = QDateTime::currentDateTime().addMSecs(-1);
+
+			QByteArray received;
+			auto       receivedTimerCommands = [&acceptedSocket, &received]
+			{
+				if (acceptedSocket->bytesAvailable() == 0)
+					acceptedSocket->waitForReadyRead(10);
+				received += acceptedSocket->readAll();
+				return received == QByteArrayLiteral("qcmd-timer-multi-a23\r\nqcmd-timer-multi-b58\r\n");
+			};
+			QTRY_VERIFY_WITH_TIMEOUT(receivedTimerCommands(), 5000);
 		}
 
 		static void directLuaTriggerSendCommandsEnterPriorityQueueBand()

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "NativePluginRegistry.h"
+#include "WorldChildWindow.h"
 #include "WorldDocument.h"
 #include "WorldRuntime.h"
 #include "WorldView.h"
@@ -31,6 +32,7 @@ namespace
 {
 	const QString kDeferredConnectPluginId = QStringLiteral("abcdeffedcbaabcdeffedcba");
 	const QString kTeardownStatePluginId   = QStringLiteral("fedcbaabcdeffedcbaabcdef");
+	const QString kHiddenMessagePluginId   = QStringLiteral("112233445566778899aabbcc");
 
 	/**
 	 * @brief Writes text to a test fixture file.
@@ -63,17 +65,61 @@ namespace
 	}
 
 	/**
+	 * @brief Writes a plugin fixture with connect/disconnect lifecycle markers.
+	 * @param pluginsDir Plugin fixture directory.
+	 * @return `true` when the plugin fixture was written.
+	 */
+	bool writeHiddenMessageLifecyclePlugin(const QString &pluginsDir)
+	{
+		const QString pluginPath = QDir(pluginsDir).filePath(QStringLiteral("hidden_messages.xml"));
+		return writeTextFile(pluginPath, QStringLiteral(R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<muclient>
+  <plugin
+    name="HiddenMessagesLifecycle"
+    author="QMud Test"
+    id="112233445566778899aabbcc"
+    language="lua"
+    enabled="y"
+    save_state="n"
+    sequence="100">
+    <script><![CDATA[
+function OnPluginConnect()
+  SetVariable("connect_marker", "connected")
+end
+
+function OnPluginDisconnect()
+  SetVariable("disconnect_marker", "disconnected")
+end
+]]></script>
+  </plugin>
+</muclient>
+)xml"));
+	}
+
+	/**
 	 * @brief Reads a plugin variable from the runtime.
+	 * @param runtime Runtime to inspect.
+	 * @param pluginId Plugin identifier to inspect.
+	 * @param name Plugin variable name.
+	 * @return Variable value, or empty when missing.
+	 */
+	QString pluginVariable(const WorldRuntime &runtime, const QString &pluginId, const QString &name)
+	{
+		QString value;
+		if (!runtime.findPluginVariable(pluginId, name, value))
+			return {};
+		return value;
+	}
+
+	/**
+	 * @brief Reads a deferred-connect plugin variable from the runtime.
 	 * @param runtime Runtime to inspect.
 	 * @param name Plugin variable name.
 	 * @return Variable value, or empty when missing.
 	 */
 	QString pluginVariable(const WorldRuntime &runtime, const QString &name)
 	{
-		QString value;
-		if (!runtime.findPluginVariable(kDeferredConnectPluginId, name, value))
-			return {};
-		return value;
+		return pluginVariable(runtime, kDeferredConnectPluginId, name);
 	}
 
 	/**
@@ -105,6 +151,107 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 		Q_OBJECT
 
 	private slots:
+		static void hiddenConnectDisconnectMessagesDoNotSuppressPluginLifecycleCallbacks()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeHiddenMessageLifecyclePlugin(pluginsDir));
+
+			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			runtime.setWorldAttribute(QStringLiteral("show_connect_disconnect"), QStringLiteral("0"));
+
+			WorldChildWindow window(QStringLiteral("Hidden Messages"));
+			window.resize(640, 480);
+			window.setRuntime(&runtime);
+			window.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&window));
+
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("hidden_messages.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+
+			QVERIFY(QMetaObject::invokeMethod(&runtime, "connected", Qt::DirectConnection));
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kHiddenMessagePluginId, QStringLiteral("connect_marker")),
+			    QStringLiteral("connected"), 5000);
+
+			QVERIFY(QMetaObject::invokeMethod(&runtime, "disconnected", Qt::DirectConnection));
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kHiddenMessagePluginId, QStringLiteral("disconnect_marker")),
+			    QStringLiteral("disconnected"), 5000);
+		}
+
+		static void hiddenConnectDisconnectMessagesDoNotSuppressLifecycleActions()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeHiddenMessageLifecyclePlugin(pluginsDir));
+
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			runtime.setWorldAttribute(QStringLiteral("show_connect_disconnect"), QStringLiteral("0"));
+			runtime.setWorldMultilineAttribute(QStringLiteral("connect_text"),
+			                                   QStringLiteral("hidden_connect_text"));
+
+			WorldChildWindow window(QStringLiteral("Hidden Messages"));
+			window.resize(640, 480);
+			window.setRuntime(&runtime);
+			window.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&window));
+
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("hidden_messages.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy disconnectedSpy(&runtime, &WorldRuntime::disconnected);
+			QVERIFY(disconnectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QByteArray received;
+			auto       hasReceivedConnectText = [&acceptedSocket, &received]
+			{
+				if (acceptedSocket->bytesAvailable() == 0)
+					acceptedSocket->waitForReadyRead(10);
+				received += acceptedSocket->readAll();
+				return received.contains("hidden_connect_text");
+			};
+			QTRY_VERIFY_WITH_TIMEOUT(hasReceivedConnectText(), 5000);
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kHiddenMessagePluginId, QStringLiteral("connect_marker")),
+			    QStringLiteral("connected"), 5000);
+
+			runtime.disconnectFromWorld();
+			if (disconnectedSpy.isEmpty())
+				QVERIFY(disconnectedSpy.wait(5000));
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kHiddenMessagePluginId, QStringLiteral("disconnect_marker")),
+			    QStringLiteral("disconnected"), 5000);
+		}
+
 		static void teardownPluginCloseRunsBeforeSaveStateWithQueuedAsyncCallback()
 		{
 			QTemporaryDir tempDir;

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -526,6 +526,19 @@ end
 	}
 
 	/**
+	 * @brief Applies shared runtime setup for telnet ordering tests.
+	 * @param runtime Runtime to configure.
+	 * @param startupDirectory Temporary startup directory containing plugin fixtures.
+	 */
+	void configureTelnetOrderingRuntime(WorldRuntime &runtime, const QString &startupDirectory)
+	{
+		runtime.setStartupDirectory(startupDirectory);
+		runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+		runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+		runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+	}
+
+	/**
 	 * @brief Extracts a saved plugin-state variable from a state XML document.
 	 * @param xml State XML text.
 	 * @param name Variable name to find.
@@ -1065,8 +1078,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldRuntime runtime;
-			runtime.setStartupDirectory(tempDir.path());
-			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			configureTelnetOrderingRuntime(runtime, tempDir.path());
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger());
 			runtime.markTriggersChanged();
 
@@ -1110,8 +1122,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldRuntime runtime;
-			runtime.setStartupDirectory(tempDir.path());
-			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			configureTelnetOrderingRuntime(runtime, tempDir.path());
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger());
 			runtime.markTriggersChanged();
 
@@ -1154,8 +1165,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldRuntime runtime;
-			runtime.setStartupDirectory(tempDir.path());
-			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			configureTelnetOrderingRuntime(runtime, tempDir.path());
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger(kTelnetAfterLine));
 			runtime.markTriggersChanged();
 
@@ -1200,8 +1210,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 				QSKIP("Local TCP listen is unavailable in this environment.");
 
 			WorldRuntime runtime;
-			runtime.setStartupDirectory(tempDir.path());
-			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			configureTelnetOrderingRuntime(runtime, tempDir.path());
 			runtime.setWorldAttribute(QStringLiteral("detect_pueblo"), QStringLiteral("1"));
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger(kTelnetAfterLine));
 			runtime.markTriggersChanged();

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -536,6 +536,8 @@ end
 		runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
 		runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
 		runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+		runtime.setWorldAttribute(QStringLiteral("enable_scripts"), QStringLiteral("y"));
+		runtime.setWorldAttribute(QStringLiteral("script_language"), QStringLiteral("Lua"));
 	}
 
 	/**

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -8,9 +8,12 @@
 
 #include "NativePluginRegistry.h"
 #include "WorldChildWindow.h"
+#include "WorldCommandProcessorUtils.h"
 #include "WorldDocument.h"
+#include "WorldOptions.h"
 #include "WorldRuntime.h"
 #include "WorldView.h"
+#include "scripting/ScriptingErrors.h"
 
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QDir>
@@ -30,9 +33,31 @@
 
 namespace
 {
-	const QString kDeferredConnectPluginId = QStringLiteral("abcdeffedcbaabcdeffedcba");
-	const QString kTeardownStatePluginId   = QStringLiteral("fedcbaabcdeffedcbaabcdef");
-	const QString kHiddenMessagePluginId   = QStringLiteral("112233445566778899aabbcc");
+	const QString           kDeferredConnectPluginId = QStringLiteral("abcdeffedcbaabcdeffedcba");
+	const QString           kTeardownStatePluginId   = QStringLiteral("fedcbaabcdeffedcbaabcdef");
+	const QString           kHiddenMessagePluginId   = QStringLiteral("112233445566778899aabbcc");
+	const QString           kNestedCallPluginId      = QStringLiteral("2233445566778899aabbccdd");
+	const QString           kTelnetOrderingPluginId  = QStringLiteral("00112233445566778899aabb");
+	const QString           kTelnetTriggerLine       = QStringLiteral("qxv-lattice-17");
+	const QString           kTelnetAfterLine         = QStringLiteral("qxv-after-64");
+
+	constexpr unsigned char IAC  = 0xFF;
+	constexpr unsigned char SB   = 0xFA;
+	constexpr unsigned char SE   = 0xF0;
+	constexpr unsigned char GMCP = 201;
+
+	/**
+	 * @brief Builds a byte array from unsigned byte literals.
+	 * @param raw Raw byte values.
+	 * @return Byte array containing the values.
+	 */
+	QByteArray              bytes(std::initializer_list<unsigned char> raw)
+	{
+		QByteArray out;
+		for (const unsigned char c : raw)
+			out.append(static_cast<char>(c));
+		return out;
+	}
 
 	/**
 	 * @brief Writes text to a test fixture file.
@@ -40,7 +65,7 @@ namespace
 	 * @param text Text to write.
 	 * @return `true` when the file was written completely.
 	 */
-	bool          writeTextFile(const QString &path, const QString &text)
+	bool writeTextFile(const QString &path, const QString &text)
 	{
 		QFile file(path);
 		if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
@@ -94,6 +119,216 @@ end
   </plugin>
 </muclient>
 )xml"));
+	}
+
+	/**
+	 * @brief Writes a plugin fixture whose telnet subnegotiation callback sends a command.
+	 * @param pluginsDir Plugin fixture directory.
+	 * @param insertTriggerLineBeforeGmcp Whether packet receive should inject a trigger line before GMCP.
+	 * @return `true` when the plugin fixture was written.
+	 */
+	bool writeTelnetOrderingPlugin(const QString &pluginsDir, const bool insertTriggerLineBeforeGmcp = false)
+	{
+		const QString pluginPath = QDir(pluginsDir).filePath(QStringLiteral("telnet_ordering.xml"));
+		QString       script     = QStringLiteral(R"lua(
+function qcb_append_order(marker)
+  local current = GetVariable("callback_order") or ""
+  if current ~= "" then
+    current = current .. ","
+  end
+  SetVariable("callback_order", current .. marker)
+end
+
+function qcb_mark_trigger(arg)
+  qcb_append_order("trigger")
+end
+
+function OnPluginTelnetSubnegotiation(msg_type, data)
+  qcb_append_order("telnet")
+  Send("qcmd-telnet-b73")
+end
+)lua");
+		if (insertTriggerLineBeforeGmcp)
+		{
+			script += QStringLiteral(R"lua(
+
+function OnPluginPacketReceived(packet)
+  local gmcp = string.char(255, 250, 201)
+  local transformed = string.gsub(packet, gmcp, "qxv-lattice-17\r\n" .. gmcp, 1)
+  return transformed
+end
+)lua");
+		}
+		return writeTextFile(pluginPath, QStringLiteral(R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<muclient>
+  <plugin
+    name="TelnetOrdering"
+    author="QMud Test"
+    id=")xml") + kTelnetOrderingPluginId + QStringLiteral(R"xml("
+    language="lua"
+    enabled="y"
+    save_state="n"
+    sequence="100">
+)xml") + QStringLiteral("    <script><![CDATA[") +
+		                                     script + QStringLiteral("]]></script>\n") +
+		                                     QStringLiteral(R"xml(  </plugin>
+</muclient>
+)xml"));
+	}
+
+	/**
+	 * @brief Writes a plugin fixture whose routine sends a command.
+	 * @param pluginsDir Plugin fixture directory.
+	 * @return `true` when the plugin fixture was written.
+	 */
+	bool writeNestedCallPluginSendPlugin(const QString &pluginsDir)
+	{
+		const QString pluginPath = QDir(pluginsDir).filePath(QStringLiteral("nested_call_send.xml"));
+		return writeTextFile(pluginPath, QStringLiteral(R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<muclient>
+  <plugin
+    name="NestedCallSend"
+    author="QMud Test"
+    id=")xml") + kNestedCallPluginId + QStringLiteral(R"xml("
+    language="lua"
+    enabled="y"
+    save_state="n"
+    sequence="100">
+    <script><![CDATA[
+function qcb_nested_priority_check(arg)
+  Send("qcmd-nested-p54")
+end
+]]></script>
+  </plugin>
+</muclient>
+)xml"));
+	}
+
+	/**
+	 * @brief Creates a script trigger that sends a command when matched text arrives.
+	 * @param match Trigger match text.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeTelnetOrderingTrigger(const QString &match = kTelnetTriggerLine)
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), match);
+		trigger.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToScript));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		trigger.children.insert(QStringLiteral("send"),
+		                        QStringLiteral("CallPlugin(\"%1\", \"qcb_mark_trigger\", \"\")\n"
+		                                       "Send(\"qcmd-trigger-a91\")")
+		                            .arg(kTelnetOrderingPluginId));
+		return trigger;
+	}
+
+	/**
+	 * @brief Creates a direct script trigger whose Lua body sends multiple commands.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeLuaSendPriorityTrigger()
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), QStringLiteral("qxv-priority-line-38"));
+		trigger.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToScript));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		trigger.children.insert(QStringLiteral("send"),
+		                        QStringLiteral("Send(\"qcmd-lua-a91\")\nSend(\"qcmd-lua-b26\")"));
+		return trigger;
+	}
+
+	/**
+	 * @brief Creates a direct script trigger whose Lua body executes a command.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeLuaExecutePriorityTrigger()
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), QStringLiteral("qxv-lua-execute-line-73"));
+		trigger.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToScript));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		trigger.children.insert(QStringLiteral("send"), QStringLiteral("Execute(\"qcmd-lua-execute-c52\")"));
+		return trigger;
+	}
+
+	/**
+	 * @brief Creates a direct script trigger whose Lua body mixes Send and Execute commands.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeLuaMixedPriorityTrigger()
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), QStringLiteral("qxv-lua-mixed-line-84"));
+		trigger.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToScript));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		trigger.children.insert(QStringLiteral("send"), QStringLiteral("Send(\"qcmd-lua-mixed-a19\")\n"
+		                                                               "Execute(\"qcmd-lua-mixed-b42\")\n"
+		                                                               "Send(\"qcmd-lua-mixed-c86\")"));
+		return trigger;
+	}
+
+	/**
+	 * @brief Creates a direct script trigger whose Lua body calls a plugin routine.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeLuaCallPluginPriorityTrigger()
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), QStringLiteral("qxv-callplugin-line-52"));
+		trigger.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToScript));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		trigger.children.insert(QStringLiteral("send"),
+		                        QStringLiteral("CallPlugin(\"%1\", \"qcb_nested_priority_check\", \"\")")
+		                            .arg(kNestedCallPluginId));
+		return trigger;
+	}
+
+	/**
+	 * @brief Creates a named callback trigger whose Lua function sends a command.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeNamedCallbackQueueNormalTrigger()
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), QStringLiteral("qxv-callback-line-61"));
+		trigger.attributes.insert(QStringLiteral("script"), QStringLiteral("qcb_priority_check"));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		return trigger;
+	}
+
+	/**
+	 * @brief Creates an execute trigger whose command should claim the direct trigger priority band.
+	 * @param match Trigger match text.
+	 * @return Trigger fixture.
+	 */
+	WorldRuntime::Trigger makeExecuteQueuePriorityTrigger(const QString &match)
+	{
+		WorldRuntime::Trigger trigger;
+		trigger.attributes.insert(QStringLiteral("enabled"), QStringLiteral("y"));
+		trigger.attributes.insert(QStringLiteral("match"), match);
+		trigger.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToExecute));
+		trigger.attributes.insert(QStringLiteral("sequence"), QStringLiteral("100"));
+		trigger.children.insert(QStringLiteral("send"), QStringLiteral("qcmd-execute-a14"));
+		return trigger;
+	}
+
+	/**
+	 * @brief Decodes queued command payloads for assertions.
+	 * @param runtime Runtime whose queue should be inspected.
+	 * @return Queue payloads in dispatch order.
+	 */
+	QStringList queuedPayloads(const WorldRuntime &runtime)
+	{
+		QStringList payloads;
+		for (const QString &entry : runtime.queuedCommands())
+			payloads.push_back(QMudCommandQueue::decodeQueueEntry(entry).payload);
+		return payloads;
 	}
 
 	/**
@@ -250,6 +485,545 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QTRY_COMPARE_WITH_TIMEOUT(
 			    pluginVariable(runtime, kHiddenMessagePluginId, QStringLiteral("disconnect_marker")),
 			    QStringLiteral("disconnected"), 5000);
+		}
+
+		static void executeTriggerSendCommandEntersPriorityQueueBand()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.triggersMutable().push_back(
+			    makeExecuteQueuePriorityTrigger(QStringLiteral("qxv-execute-line-42")));
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			const QByteArray triggerLine = QByteArrayLiteral("qxv-execute-line-42\r\n");
+			QCOMPARE(acceptedSocket->write(triggerLine), static_cast<qint64>(triggerLine.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-execute-a14"), QStringLiteral("qcmd-tail-z77")}), 5000);
+		}
+
+		static void directLuaTriggerSendCommandsEnterPriorityQueueBand()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+			runtime.setWorldAttribute(QStringLiteral("enable_scripts"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("script_language"), QStringLiteral("Lua"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.triggersMutable().push_back(makeLuaSendPriorityTrigger());
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			const QByteArray triggerLine = QByteArrayLiteral("qxv-priority-line-38\r\n");
+			QCOMPARE(acceptedSocket->write(triggerLine), static_cast<qint64>(triggerLine.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-lua-a91"), QStringLiteral("qcmd-lua-b26"),
+			                 QStringLiteral("qcmd-tail-z77")}),
+			    5000);
+		}
+
+		static void directLuaTriggerExecuteCommandEntersPriorityQueueBand()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+			runtime.setWorldAttribute(QStringLiteral("enable_scripts"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("script_language"), QStringLiteral("Lua"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.triggersMutable().push_back(makeLuaExecutePriorityTrigger());
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			const QByteArray triggerLine = QByteArrayLiteral("qxv-lua-execute-line-73\r\n");
+			QCOMPARE(acceptedSocket->write(triggerLine), static_cast<qint64>(triggerLine.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-lua-execute-c52"), QStringLiteral("qcmd-tail-z77")}), 5000);
+		}
+
+		static void directLuaTriggerMixedSendAndExecuteCommandsPreservePriorityOrder()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+			runtime.setWorldAttribute(QStringLiteral("enable_scripts"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("script_language"), QStringLiteral("Lua"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.triggersMutable().push_back(makeLuaMixedPriorityTrigger());
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			const QByteArray triggerLine = QByteArrayLiteral("qxv-lua-mixed-line-84\r\n");
+			QCOMPARE(acceptedSocket->write(triggerLine), static_cast<qint64>(triggerLine.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-lua-mixed-a19"), QStringLiteral("qcmd-lua-mixed-b42"),
+			                 QStringLiteral("qcmd-lua-mixed-c86"), QStringLiteral("qcmd-tail-z77")}),
+			    5000);
+		}
+
+		static void namedLuaTriggerCallbackSendDoesNotEnterDirectActionPriorityQueueBand()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+			runtime.setWorldAttribute(QStringLiteral("enable_scripts"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("script_language"), QStringLiteral("Lua"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.setLuaScriptText(
+			    QStringLiteral("function qcb_priority_check(name, line, wildcards, styles)\n"
+			                   "  Send(\"qcmd-callback-e71\")\n"
+			                   "end\n"));
+			runtime.triggersMutable().push_back(makeNamedCallbackQueueNormalTrigger());
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			const QByteArray triggerLine = QByteArrayLiteral("qxv-callback-line-61\r\n");
+			QCOMPARE(acceptedSocket->write(triggerLine), static_cast<qint64>(triggerLine.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-tail-z77"), QStringLiteral("qcmd-callback-e71")}), 5000);
+		}
+
+		static void directLuaTriggerCallPluginSendDoesNotInheritDirectActionPriorityQueueBand()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeNestedCallPluginSendPlugin(pluginsDir));
+
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			runtime.setWorldAttribute(QStringLiteral("enable_triggers"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("enable_trigger_sounds"), QStringLiteral("n"));
+			runtime.setWorldAttribute(QStringLiteral("enable_scripts"), QStringLiteral("y"));
+			runtime.setWorldAttribute(QStringLiteral("script_language"), QStringLiteral("Lua"));
+			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
+			runtime.triggersMutable().push_back(makeLuaCallPluginPriorityTrigger());
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("nested_call_send.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
+			const QByteArray triggerLine = QByteArrayLiteral("qxv-callplugin-line-52\r\n");
+			QCOMPARE(acceptedSocket->write(triggerLine), static_cast<qint64>(triggerLine.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-tail-z77"), QStringLiteral("qcmd-nested-p54")}), 5000);
+		}
+
+		static void telnetSubnegotiationCallbacksPreserveStreamOrderAfterCompletedTriggerLine()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeTelnetOrderingPlugin(pluginsDir));
+
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger());
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QByteArray payload = kTelnetTriggerLine.toUtf8() + QByteArrayLiteral("\r\n");
+			payload += bytes({IAC, SB, GMCP, 'q', '7', 'x', IAC, SE});
+			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QByteArray received;
+			auto       receivedBothCommands = [&]
+			{
+				if (acceptedSocket->bytesAvailable() == 0)
+					acceptedSocket->waitForReadyRead(10);
+				received += acceptedSocket->readAll();
+				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
+			};
+			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
+			    QStringLiteral("trigger,telnet"), 5000);
+			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
+		}
+
+		static void telnetSubnegotiationCallbacksUsePacketTransformedStreamOrder()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeTelnetOrderingPlugin(pluginsDir, true));
+
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger());
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QByteArray payload = bytes({IAC, SB, GMCP, 'q', '7', 'x', IAC, SE});
+			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QByteArray received;
+			auto       receivedBothCommands = [&]
+			{
+				if (acceptedSocket->bytesAvailable() == 0)
+					acceptedSocket->waitForReadyRead(10);
+				received += acceptedSocket->readAll();
+				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
+			};
+			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
+			    QStringLiteral("trigger,telnet"), 5000);
+			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
+		}
+
+		static void telnetSubnegotiationCallbacksRebaseOffsetsAfterFilteredBytes()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeTelnetOrderingPlugin(pluginsDir));
+
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger(kTelnetAfterLine));
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QByteArray payload(10, '\0');
+			payload += bytes({IAC, SB, GMCP, 'q', '7', 'x', IAC, SE});
+			payload += kTelnetAfterLine.toUtf8() + QByteArrayLiteral("\r\n");
+			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QByteArray received;
+			auto       receivedBothCommands = [&]
+			{
+				if (acceptedSocket->bytesAvailable() == 0)
+					acceptedSocket->waitForReadyRead(10);
+				received += acceptedSocket->readAll();
+				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
+			};
+			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
+			    QStringLiteral("telnet,trigger"), 5000);
+			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
+		}
+
+		static void telnetSubnegotiationCallbacksRebaseOffsetsAfterRemovedPuebloMarker()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeTelnetOrderingPlugin(pluginsDir));
+
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+			runtime.setWorldAttribute(QStringLiteral("detect_pueblo"), QStringLiteral("1"));
+			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger(kTelnetAfterLine));
+			runtime.markTriggersChanged();
+
+			WorldView view;
+			view.resize(640, 480);
+			view.setRuntime(&runtime);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QByteArray payload = QByteArrayLiteral("</xch_mudtext>\r\n");
+			payload += bytes({IAC, SB, GMCP, 'q', '7', 'x', IAC, SE});
+			payload += kTelnetAfterLine.toUtf8() + QByteArrayLiteral("\r\n");
+			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
+			QVERIFY(acceptedSocket->flush());
+
+			QByteArray received;
+			auto       receivedBothCommands = [&]
+			{
+				if (acceptedSocket->bytesAvailable() == 0)
+					acceptedSocket->waitForReadyRead(10);
+				received += acceptedSocket->readAll();
+				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
+			};
+			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
+			    QStringLiteral("telnet,trigger"), 5000);
+			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
 		}
 
 		static void teardownPluginCloseRunsBeforeSaveStateWithQueuedAsyncCallback()

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -16,18 +16,21 @@
 #include <QFile>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QHostAddress>
+#include <QScopeGuard>
 #include <QScopedPointer>
 #include <QTcpServer>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QTcpSocket>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QTemporaryDir>
+#include <QXmlStreamReader>
 #include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 
 namespace
 {
 	const QString kDeferredConnectPluginId = QStringLiteral("abcdeffedcbaabcdeffedcba");
+	const QString kTeardownStatePluginId   = QStringLiteral("fedcbaabcdeffedcbaabcdef");
 
 	/**
 	 * @brief Writes text to a test fixture file.
@@ -72,6 +75,26 @@ namespace
 			return {};
 		return value;
 	}
+
+	/**
+	 * @brief Extracts a saved plugin-state variable from a state XML document.
+	 * @param xml State XML text.
+	 * @param name Variable name to find.
+	 * @return Saved variable value, or empty when missing.
+	 */
+	QString savedStateVariable(const QString &xml, const QString &name)
+	{
+		QXmlStreamReader reader(xml);
+		while (!reader.atEnd())
+		{
+			reader.readNext();
+			if (!reader.isStartElement() || reader.name() != QLatin1String("variable"))
+				continue;
+			if (reader.attributes().value(QStringLiteral("name")) == name)
+				return reader.readElementText();
+		}
+		return {};
+	}
 } // namespace
 
 /**
@@ -82,6 +105,86 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 		Q_OBJECT
 
 	private slots:
+		static void teardownPluginCloseRunsBeforeSaveStateWithQueuedAsyncCallback()
+		{
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString originalCurrentPath = QDir::currentPath();
+			QVERIFY(QDir::setCurrent(tempDir.path()));
+			const auto restoreCurrentPath =
+			    qScopeGuard([originalCurrentPath]() { QDir::setCurrent(originalCurrentPath); });
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			const QString stateDir   = QDir(tempDir.path()).filePath(QStringLiteral("state"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(QDir().mkpath(stateDir));
+
+			const QString pluginPath = QDir(pluginsDir).filePath(QStringLiteral("teardown_state.xml"));
+			QVERIFY(writeTextFile(pluginPath, QStringLiteral(R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<muclient>
+  <plugin
+    name="TeardownState"
+    author="QMud Test"
+    id="fedcbaabcdeffedcbaabcdef"
+    language="lua"
+    enabled="y"
+    save_state="y"
+    sequence="100">
+    <script><![CDATA[
+function OnPluginClose()
+  SetVariable("close_marker", "closed")
+end
+
+function OnPluginAsyncResult(request_id, api_name, status, payload)
+  SetVariable("async_marker", "ran")
+end
+
+function OnPluginSaveState()
+  SetVariable("save_marker", (GetVariable("close_marker") or "missing") .. ":saved")
+end
+]]></script>
+  </plugin>
+</muclient>
+)xml")));
+
+			const QString worldId   = QStringLiteral("aaaaaaaaaaaaaaaaaaaaaaaa");
+			const QString statePath = QDir(stateDir).filePath(
+			    worldId + QStringLiteral("-") + kTeardownStatePluginId + QStringLiteral("-state.xml"));
+			{
+				WorldView view;
+				view.resize(640, 480);
+				view.show();
+				QVERIFY(QTest::qWaitForWindowExposed(&view));
+
+				WorldRuntime runtime;
+				runtime.setStartupDirectory(tempDir.path());
+				runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
+				runtime.setStateFilesDirectory(stateDir);
+				runtime.setWorldAttribute(QStringLiteral("id"), worldId);
+				view.setRuntime(&runtime);
+				QCoreApplication::processEvents();
+
+				QString loadError;
+				QVERIFY2(runtime.loadPluginFile(QStringLiteral("teardown_state.xml"), &loadError),
+				         qPrintable(loadError));
+				QCOMPARE(runtime.plugins().size(), 1);
+				QCOMPARE(runtime.plugins().constFirst().attributes.value(QStringLiteral("id")),
+				         kTeardownStatePluginId);
+				QVERIFY(runtime.plugins().constFirst().saveState);
+				QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
+				runtime.dispatchPluginAsyncResult(kTeardownStatePluginId, 1, QStringLiteral("teardown-test"),
+				                                  true, 0, QStringLiteral("queued"));
+			}
+
+			QString savedText;
+			QVERIFY(readTextFile(statePath, savedText));
+			QCOMPARE(savedStateVariable(savedText, QStringLiteral("close_marker")), QStringLiteral("closed"));
+			QCOMPARE(savedStateVariable(savedText, QStringLiteral("save_marker")),
+			         QStringLiteral("closed:saved"));
+			QCOMPARE(savedStateVariable(savedText, QStringLiteral("async_marker")), QString());
+		}
+
 		static void nativeShimPluginSourceSurvivesWorldSaveReload()
 		{
 			QTemporaryDir tempDir;

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -377,6 +377,53 @@ end
 	}
 
 	/**
+	 * @brief Test fixture binding a runtime to a view and command processor.
+	 */
+	struct RuntimeCommandHarness
+	{
+			/**
+			 * @brief Constructs and wires the runtime command-processing path.
+			 * @param boundRuntime Runtime to bind.
+			 */
+			explicit RuntimeCommandHarness(WorldRuntime &boundRuntime) : runtime(boundRuntime)
+			{
+				view.resize(640, 480);
+				processor.setView(&view);
+				processor.setRuntime(&runtime);
+				runtime.setCommandProcessor(&processor);
+				view.setRuntime(&runtime);
+				QObject::connect(&runtime, &WorldRuntime::incomingStyledLineReceived, &processor,
+				                 &WorldCommandProcessor::onIncomingStyledLineReceived);
+				QObject::connect(&runtime, &WorldRuntime::incomingStyledLinePartialReceived, &processor,
+				                 &WorldCommandProcessor::onIncomingStyledLinePartialReceived);
+			}
+
+			/**
+			 * @brief Detaches runtime pointers before members are destroyed.
+			 */
+			~RuntimeCommandHarness()
+			{
+				view.setRuntime(nullptr);
+				runtime.setCommandProcessor(nullptr);
+				processor.setRuntime(nullptr);
+			}
+
+			/**
+			 * @brief Shows the view and waits until exposed.
+			 * @return `true` when the view is exposed.
+			 */
+			bool showAndWait()
+			{
+				view.show();
+				return QTest::qWaitForWindowExposed(&view);
+			}
+
+			WorldRuntime         &runtime;
+			WorldView             view;
+			WorldCommandProcessor processor;
+	};
+
+	/**
 	 * @brief Decodes queued command payloads for assertions.
 	 * @param runtime Runtime whose queue should be inspected.
 	 * @return Queue payloads in dispatch order.
@@ -559,11 +606,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			    makeExecuteQueuePriorityTrigger(QStringLiteral("qxv-execute-line-42")));
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
@@ -604,11 +648,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			    makeMultilineExecuteTrigger(QStringLiteral("qxv-execute-multiline-18")));
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
@@ -650,11 +691,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			    makeMultilineExecuteAlias(QStringLiteral("qxv-alias-multiline-29")));
 			runtime.markAliasesChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
@@ -693,11 +731,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.timersMutable().push_back(makeMultilineExecuteTimer());
 			runtime.markTimersChanged();
 
-			WorldCommandProcessor processor;
-			processor.setRuntime(&runtime);
-			runtime.setCommandProcessor(&processor);
-
-			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			RuntimeCommandHarness harness(runtime);
+			QSignalSpy            connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
 			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
 			QVERIFY(serverAcceptedSpy.isValid());
@@ -708,17 +743,18 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
 			QVERIFY(!acceptedSocket.isNull());
 
+			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
+			         eOK);
+			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
+			                          5000);
+
 			runtime.timersMutable().first().nextFireTime = QDateTime::currentDateTime().addMSecs(-1);
 
-			QByteArray received;
-			auto       receivedTimerCommands = [&acceptedSocket, &received]
-			{
-				if (acceptedSocket->bytesAvailable() == 0)
-					acceptedSocket->waitForReadyRead(10);
-				received += acceptedSocket->readAll();
-				return received == QByteArrayLiteral("qcmd-timer-multi-a23\r\nqcmd-timer-multi-b58\r\n");
-			};
-			QTRY_VERIFY_WITH_TIMEOUT(receivedTimerCommands(), 5000);
+			QTRY_COMPARE_WITH_TIMEOUT(
+			    queuedPayloads(runtime),
+			    (QStringList{QStringLiteral("qcmd-tail-z77"), QStringLiteral("qcmd-timer-multi-a23"),
+			                 QStringLiteral("qcmd-timer-multi-b58")}),
+			    5000);
 		}
 
 		static void directLuaTriggerSendCommandsEnterPriorityQueueBand()
@@ -736,11 +772,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeLuaSendPriorityTrigger());
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
@@ -784,11 +817,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeLuaExecutePriorityTrigger());
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
@@ -830,11 +860,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeLuaMixedPriorityTrigger());
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
@@ -882,11 +909,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeNamedCallbackQueueNormalTrigger());
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
 			QVERIFY(connectedSpy.isValid());
@@ -937,11 +961,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeLuaCallPluginPriorityTrigger());
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QString loadError;
 			QVERIFY2(runtime.loadPluginFile(QStringLiteral("nested_call_send.xml"), &loadError),
@@ -992,11 +1013,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger());
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QString loadError;
 			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),
@@ -1052,11 +1070,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger());
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QString loadError;
 			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),
@@ -1111,11 +1126,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger(kTelnetAfterLine));
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QString loadError;
 			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),
@@ -1173,11 +1185,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			runtime.triggersMutable().push_back(makeTelnetOrderingTrigger(kTelnetAfterLine));
 			runtime.markTriggersChanged();
 
-			WorldView view;
-			view.resize(640, 480);
-			view.setRuntime(&runtime);
-			view.show();
-			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			RuntimeCommandHarness harness(runtime);
+			QVERIFY(harness.showAndWait());
 
 			QString loadError;
 			QVERIFY2(runtime.loadPluginFile(QStringLiteral("telnet_ordering.xml"), &loadError),

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -141,14 +141,6 @@ function qcb_append_order(marker)
   SetVariable("callback_order", current .. marker)
 end
 
-function qcb_append_send_order(command)
-  local current = GetVariable("send_order") or ""
-  if current ~= "" then
-    current = current .. ","
-  end
-  SetVariable("send_order", current .. command)
-end
-
 function qcb_mark_trigger(arg)
   qcb_append_order("trigger")
 end
@@ -156,11 +148,6 @@ end
 function OnPluginTelnetSubnegotiation(msg_type, data)
   qcb_append_order("telnet")
   Send("qcmd-telnet-b73")
-end
-
-function OnPluginSend(command)
-  qcb_append_send_order(command)
-  return false
 end
 )lua");
 		if (insertTriggerLineBeforeGmcp)
@@ -511,18 +498,28 @@ end
 	}
 
 	/**
-	 * @brief Verifies callback and send order recorded by the telnet ordering plugin.
+	 * @brief Verifies callback order and socket send order for telnet ordering tests.
 	 * @param runtime Runtime to inspect.
+	 * @param acceptedSocket Accepted test-server socket receiving client commands.
 	 * @param callbackOrder Expected callback order marker list.
 	 */
-	void verifyTelnetCallbackAndSendOrder(const WorldRuntime &runtime, const QString &callbackOrder)
+	void verifyTelnetCallbackAndSocketSendOrder(const WorldRuntime &runtime, QTcpSocket *acceptedSocket,
+	                                            const QString &callbackOrder)
 	{
 		QTRY_COMPARE_WITH_TIMEOUT(
 		    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")), callbackOrder,
 		    5000);
-		QTRY_COMPARE_WITH_TIMEOUT(
-		    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("send_order")),
-		    QStringLiteral("qcmd-trigger-a91,qcmd-telnet-b73"), 5000);
+
+		QByteArray received;
+		auto       receivedBothCommands = [&]
+		{
+			if (acceptedSocket->bytesAvailable() == 0)
+				acceptedSocket->waitForReadyRead(10);
+			received += acceptedSocket->readAll();
+			return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
+		};
+		QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
+		QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
 	}
 
 	/**
@@ -1107,7 +1104,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("trigger,telnet"));
+			verifyTelnetCallbackAndSocketSendOrder(runtime, acceptedSocket.data(),
+			                                       QStringLiteral("trigger,telnet"));
 		}
 
 		static void telnetSubnegotiationCallbacksUsePacketTransformedStreamOrder()
@@ -1150,7 +1148,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("trigger,telnet"));
+			verifyTelnetCallbackAndSocketSendOrder(runtime, acceptedSocket.data(),
+			                                       QStringLiteral("trigger,telnet"));
 		}
 
 		static void telnetSubnegotiationCallbacksRebaseOffsetsAfterFilteredBytes()
@@ -1195,7 +1194,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("telnet,trigger"));
+			verifyTelnetCallbackAndSocketSendOrder(runtime, acceptedSocket.data(),
+			                                       QStringLiteral("telnet,trigger"));
 		}
 
 		static void telnetSubnegotiationCallbacksRebaseOffsetsAfterRemovedPuebloMarker()
@@ -1241,7 +1241,8 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("telnet,trigger"));
+			verifyTelnetCallbackAndSocketSendOrder(runtime, acceptedSocket.data(),
+			                                       QStringLiteral("telnet,trigger"));
 		}
 
 		static void teardownPluginCloseRunsBeforeSaveStateWithQueuedAsyncCallback()

--- a/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
+++ b/tests/integration/tst_WorldRuntime_PluginLifecycle.cpp
@@ -39,6 +39,7 @@ namespace
 	const QString           kHiddenMessagePluginId   = QStringLiteral("112233445566778899aabbcc");
 	const QString           kNestedCallPluginId      = QStringLiteral("2233445566778899aabbccdd");
 	const QString           kTelnetOrderingPluginId  = QStringLiteral("00112233445566778899aabb");
+	const QString           kTimerCommandPluginId    = QStringLiteral("33445566778899aabbccddee");
 	const QString           kTelnetTriggerLine       = QStringLiteral("qxv-lattice-17");
 	const QString           kTelnetAfterLine         = QStringLiteral("qxv-after-64");
 
@@ -140,6 +141,14 @@ function qcb_append_order(marker)
   SetVariable("callback_order", current .. marker)
 end
 
+function qcb_append_send_order(command)
+  local current = GetVariable("send_order") or ""
+  if current ~= "" then
+    current = current .. ","
+  end
+  SetVariable("send_order", current .. command)
+end
+
 function qcb_mark_trigger(arg)
   qcb_append_order("trigger")
 end
@@ -147,6 +156,11 @@ end
 function OnPluginTelnetSubnegotiation(msg_type, data)
   qcb_append_order("telnet")
   Send("qcmd-telnet-b73")
+end
+
+function OnPluginSend(command)
+  qcb_append_send_order(command)
+  return false
 end
 )lua");
 		if (insertTriggerLineBeforeGmcp)
@@ -198,6 +212,39 @@ end
     <script><![CDATA[
 function qcb_nested_priority_check(arg)
   Send("qcmd-nested-p54")
+end
+]]></script>
+  </plugin>
+</muclient>
+)xml"));
+	}
+
+	/**
+	 * @brief Writes a plugin fixture that records command callbacks.
+	 * @param pluginsDir Plugin fixture directory.
+	 * @return `true` when the plugin fixture was written.
+	 */
+	bool writeTimerCommandRecorderPlugin(const QString &pluginsDir)
+	{
+		const QString pluginPath = QDir(pluginsDir).filePath(QStringLiteral("timer_command_recorder.xml"));
+		return writeTextFile(pluginPath, QStringLiteral(R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<muclient>
+  <plugin
+    name="TimerCommandRecorder"
+    author="QMud Test"
+    id=")xml") + kTimerCommandPluginId + QStringLiteral(R"xml("
+    language="lua"
+    enabled="y"
+    save_state="n"
+    sequence="100">
+    <script><![CDATA[
+function OnPluginCommand(command)
+  local current = GetVariable("timer_commands") or ""
+  if current ~= "" then
+    current = current .. ","
+  end
+  SetVariable("timer_commands", current .. command)
+  return false
 end
 ]]></script>
   </plugin>
@@ -362,6 +409,7 @@ end
 		WorldRuntime::Timer timer;
 		timer.attributes.insert(QStringLiteral("name"), QStringLiteral("qxv-timer-multiline-41"));
 		timer.attributes.insert(QStringLiteral("enabled"), QStringLiteral("1"));
+		timer.attributes.insert(QStringLiteral("active_closed"), QStringLiteral("1"));
 		timer.attributes.insert(QStringLiteral("send_to"), QString::number(eSendToExecute));
 		timer.attributes.insert(QStringLiteral("at_time"), QStringLiteral("0"));
 		timer.attributes.insert(QStringLiteral("hour"), QStringLiteral("0"));
@@ -460,6 +508,21 @@ end
 	QString pluginVariable(const WorldRuntime &runtime, const QString &name)
 	{
 		return pluginVariable(runtime, kDeferredConnectPluginId, name);
+	}
+
+	/**
+	 * @brief Verifies callback and send order recorded by the telnet ordering plugin.
+	 * @param runtime Runtime to inspect.
+	 * @param callbackOrder Expected callback order marker list.
+	 */
+	void verifyTelnetCallbackAndSendOrder(const WorldRuntime &runtime, const QString &callbackOrder)
+	{
+		QTRY_COMPARE_WITH_TIMEOUT(
+		    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")), callbackOrder,
+		    5000);
+		QTRY_COMPARE_WITH_TIMEOUT(
+		    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("send_order")),
+		    QStringLiteral("qcmd-trigger-a91,qcmd-telnet-b73"), 5000);
 	}
 
 	/**
@@ -721,40 +784,34 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 
 		static void executeTimerMultilineActionRunsEachCommandWithoutBlankLines()
 		{
-			QTcpServer server;
-			if (!server.listen(QHostAddress::LocalHost, 0))
-				QSKIP("Local TCP listen is unavailable in this environment.");
+			QTemporaryDir tempDir;
+			QVERIFY(tempDir.isValid());
+
+			const QString pluginsDir = QDir(tempDir.path()).filePath(QStringLiteral("worlds/plugins"));
+			QVERIFY(QDir().mkpath(pluginsDir));
+			QVERIFY(writeTimerCommandRecorderPlugin(pluginsDir));
 
 			WorldRuntime runtime;
+			runtime.setStartupDirectory(tempDir.path());
+			runtime.setPluginsDirectory(QStringLiteral("worlds/plugins"));
 			runtime.setWorldAttribute(QStringLiteral("enable_timers"), QStringLiteral("y"));
-			runtime.setWorldAttribute(QStringLiteral("speed_walk_delay"), QStringLiteral("60000"));
 			runtime.timersMutable().push_back(makeMultilineExecuteTimer());
 			runtime.markTimersChanged();
 
 			RuntimeCommandHarness harness(runtime);
-			QSignalSpy            connectedSpy(&runtime, &WorldRuntime::connected);
-			QVERIFY(connectedSpy.isValid());
-			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
-			QVERIFY(serverAcceptedSpy.isValid());
+			QVERIFY(harness.showAndWait());
 
-			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
-			QVERIFY(connectedSpy.wait(5000));
-			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
-			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
-			QVERIFY(!acceptedSocket.isNull());
-
-			QCOMPARE(runtime.sendCommand(QStringLiteral("qcmd-tail-z77"), false, true, true, false, false),
-			         eOK);
-			QTRY_COMPARE_WITH_TIMEOUT(queuedPayloads(runtime), (QStringList{QStringLiteral("qcmd-tail-z77")}),
-			                          5000);
+			QString loadError;
+			QVERIFY2(runtime.loadPluginFile(QStringLiteral("timer_command_recorder.xml"), &loadError),
+			         qPrintable(loadError));
+			QTRY_VERIFY_WITH_TIMEOUT(!runtime.plugins().constFirst().installPending, 5000);
 
 			runtime.timersMutable().first().nextFireTime = QDateTime::currentDateTime().addMSecs(-1);
 
+			QTRY_COMPARE_WITH_TIMEOUT(runtime.timersFiredThisSession(), 1, 5000);
 			QTRY_COMPARE_WITH_TIMEOUT(
-			    queuedPayloads(runtime),
-			    (QStringList{QStringLiteral("qcmd-tail-z77"), QStringLiteral("qcmd-timer-multi-a23"),
-			                 QStringLiteral("qcmd-timer-multi-b58")}),
-			    5000);
+			    pluginVariable(runtime, kTimerCommandPluginId, QStringLiteral("timer_commands")),
+			    QStringLiteral("qcmd-timer-multi-a23,qcmd-timer-multi-b58"), 5000);
 		}
 
 		static void directLuaTriggerSendCommandsEnterPriorityQueueBand()
@@ -1036,19 +1093,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			QByteArray received;
-			auto       receivedBothCommands = [&]
-			{
-				if (acceptedSocket->bytesAvailable() == 0)
-					acceptedSocket->waitForReadyRead(10);
-				received += acceptedSocket->readAll();
-				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
-			};
-			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
-			QTRY_COMPARE_WITH_TIMEOUT(
-			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
-			    QStringLiteral("trigger,telnet"), 5000);
-			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
+			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("trigger,telnet"));
 		}
 
 		static void telnetSubnegotiationCallbacksUsePacketTransformedStreamOrder()
@@ -1092,19 +1137,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			QByteArray received;
-			auto       receivedBothCommands = [&]
-			{
-				if (acceptedSocket->bytesAvailable() == 0)
-					acceptedSocket->waitForReadyRead(10);
-				received += acceptedSocket->readAll();
-				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
-			};
-			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
-			QTRY_COMPARE_WITH_TIMEOUT(
-			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
-			    QStringLiteral("trigger,telnet"), 5000);
-			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
+			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("trigger,telnet"));
 		}
 
 		static void telnetSubnegotiationCallbacksRebaseOffsetsAfterFilteredBytes()
@@ -1150,19 +1183,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			QByteArray received;
-			auto       receivedBothCommands = [&]
-			{
-				if (acceptedSocket->bytesAvailable() == 0)
-					acceptedSocket->waitForReadyRead(10);
-				received += acceptedSocket->readAll();
-				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
-			};
-			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
-			QTRY_COMPARE_WITH_TIMEOUT(
-			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
-			    QStringLiteral("telnet,trigger"), 5000);
-			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
+			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("telnet,trigger"));
 		}
 
 		static void telnetSubnegotiationCallbacksRebaseOffsetsAfterRemovedPuebloMarker()
@@ -1209,19 +1230,7 @@ class tst_WorldRuntime_PluginLifecycle : public QObject
 			QCOMPARE(acceptedSocket->write(payload), static_cast<qint64>(payload.size()));
 			QVERIFY(acceptedSocket->flush());
 
-			QByteArray received;
-			auto       receivedBothCommands = [&]
-			{
-				if (acceptedSocket->bytesAvailable() == 0)
-					acceptedSocket->waitForReadyRead(10);
-				received += acceptedSocket->readAll();
-				return received.contains("qcmd-trigger-a91\r\n") && received.contains("qcmd-telnet-b73\r\n");
-			};
-			QTRY_VERIFY_WITH_TIMEOUT(receivedBothCommands(), 5000);
-			QTRY_COMPARE_WITH_TIMEOUT(
-			    pluginVariable(runtime, kTelnetOrderingPluginId, QStringLiteral("callback_order")),
-			    QStringLiteral("telnet,trigger"), 5000);
-			QVERIFY(received.indexOf("qcmd-trigger-a91\r\n") < received.indexOf("qcmd-telnet-b73\r\n"));
+			verifyTelnetCallbackAndSendOrder(runtime, QStringLiteral("telnet,trigger"));
 		}
 
 		static void teardownPluginCloseRunsBeforeSaveStateWithQueuedAsyncCallback()

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -2347,6 +2347,14 @@ function OnPluginEnable()
          empty_plugin_variable_case_ok and
          empty_plugin_variable_list_ok
 end
+function empty_plugin_variable_status_value(value)
+  return table.concat({
+    tostring(empty_plugin_variable_ok),
+    tostring(empty_plugin_variable_case_ok),
+    tostring(empty_plugin_variable_list_ok),
+    empty_plugin_variable_status or "no-status"
+  }, "|")
+end
 )lua"),
 	                       &runtime);
 
@@ -2358,11 +2366,16 @@ end
 	LuaBatchDispatchResult result;
 	dispatchWorkerAndWait(executor, request, result);
 	QVERIFY(result.boolResultValid);
-	QVERIFY2(result.boolResult,
-	         qPrintable(luaGlobalString(engine->luaState(), "empty_plugin_variable_status")));
-	QVERIFY(luaGlobalBoolean(engine->luaState(), "empty_plugin_variable_ok"));
-	QVERIFY(luaGlobalBoolean(engine->luaState(), "empty_plugin_variable_case_ok"));
-	QVERIFY(luaGlobalBoolean(engine->luaState(), "empty_plugin_variable_list_ok"));
+
+	LuaBatchDispatchRequest statusRequest = request;
+	statusRequest.kind                    = LuaBatchDispatchKind::StringInOut;
+	statusRequest.functionName            = QStringLiteral("empty_plugin_variable_status_value");
+	statusRequest.stringArg               = QStringLiteral("ignored");
+	statusRequest.miniWindowSnapshotArg   = {};
+	LuaBatchDispatchResult statusResult;
+	dispatchWorkerAndWait(executor, statusRequest, statusResult);
+	QVERIFY2(result.boolResult, qPrintable(statusResult.stringResult));
+	QCOMPARE(statusResult.stringResult, QStringLiteral("true|true|true|1|active|true|1|active"));
 	teardownWorkerEngine(executor, engine);
 }
 


### PR DESCRIPTION
## Summary

- Preload openssl libs on Windows. Fixes a problem with some qt plugins on windows bypassing the QMUD_HOME/lib directory lib include resulting in multiple versions of the lib being loaded in some systems.
- Fix command option shortcut parity drift. Fixes #108 
- Fix potential segfaults around lua engine teardown. Fixes #109 
- Fix incorrect show_connect_disconnect gating. Fixes #110
- Split send-to-world/queue action/execute lines properly. Fixes #112
- Refactor TelnetProcessor. Add direct trigger priority queue. Allows triggers to actually fire when they should when sends are issued early due to things like GMCP (eg mappers walking) by deferring sends (not those related to protocol etc) until telnet payload has been decoded entirely while also providing a priority lane for triggers so they can be injected with priority at the queue but without breaking FIFO ordering.
- Add RunnerScrab to contributors.

## Scope

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- Command option shortcuts should now work properly as in MUSHclient.
- Send to World/Queue/Execute should now be split properly on \n as well as MUSHclient only split on \r\n and Qt widgets use \n for newlines. This should also handle properly plugins regardless of line ending style.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

