### PR TITLE
Use DontUseNativeDialog for font dialogs on Mac. Properly separate MushReader from passive TTS engine. Adjust Ctrl-R semantics. Fix tab button navigation in plugins dialog. Fix typo on QMUD_ENABLE_SOUND disabling lua audio.

### DIFF
--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -792,8 +792,8 @@ namespace
 		return styleRuns ? CallbackWildcardDomain::Trigger : CallbackWildcardDomain::Alias;
 	}
 
-	void                         seedCallbackMiniWindowSnapshot(const LuaCallbackEngine             *engine,
-	                                                            const LuaCallbackMiniWindowSnapshot *snapshot);
+	void seedCallbackMiniWindowSnapshot(const LuaCallbackEngine             *engine,
+	                                    const LuaCallbackMiniWindowSnapshot *snapshot);
 
 	LuaCallbackExecutionContext *activeCallbackContext(const LuaCallbackEngine *engine)
 	{
@@ -838,10 +838,10 @@ namespace
 	}
 
 	bool
-	     flushDeferredRuntimeMutationsFromContext(const LuaCallbackEngine     *engine,
-	                                              LuaCallbackExecutionContext &context, WorldRuntime *runtime,
-	                                              DeferredRuntimeMutationFlushPolicy policy =
-	                                                  DeferredRuntimeMutationFlushPolicy::AllowSynchronousBridge);
+	flushDeferredRuntimeMutationsFromContext(const LuaCallbackEngine     *engine,
+	                                         LuaCallbackExecutionContext &context, WorldRuntime *runtime,
+	                                         DeferredRuntimeMutationFlushPolicy policy =
+	                                             DeferredRuntimeMutationFlushPolicy::AllowSynchronousBridge);
 	bool flushDeferredRuntimeMutations(const LuaCallbackEngine *engine, WorldRuntime *runtime);
 
 	void finishDeferredMiniWindowBatch(WorldRuntime *runtime)
@@ -1272,15 +1272,15 @@ namespace
 			WorldRuntime::StyleSpan span;
 			const auto              forePacked = static_cast<unsigned int>(run.textColour);
 			const auto              backPacked = static_cast<unsigned int>(run.backColour);
-			span.length    = static_cast<int>(qBound(static_cast<qsizetype>(0), run.text.size(),
-			                                         static_cast<qsizetype>(std::numeric_limits<int>::max())));
-			span.fore      = QColor(static_cast<int>((forePacked >> 0u) & 0xFFu),
-			                        static_cast<int>((forePacked >> 8u) & 0xFFu),
-			                        static_cast<int>((forePacked >> 16u) & 0xFFu));
-			span.back      = QColor(static_cast<int>((backPacked >> 0u) & 0xFFu),
-			                        static_cast<int>((backPacked >> 8u) & 0xFFu),
-			                        static_cast<int>((backPacked >> 16u) & 0xFFu));
-			span.bold      = (run.style & kStyleHilite) != 0;
+			span.length = static_cast<int>(qBound(static_cast<qsizetype>(0), run.text.size(),
+			                                      static_cast<qsizetype>(std::numeric_limits<int>::max())));
+			span.fore   = QColor(static_cast<int>((forePacked >> 0u) & 0xFFu),
+			                     static_cast<int>((forePacked >> 8u) & 0xFFu),
+			                     static_cast<int>((forePacked >> 16u) & 0xFFu));
+			span.back   = QColor(static_cast<int>((backPacked >> 0u) & 0xFFu),
+			                     static_cast<int>((backPacked >> 8u) & 0xFFu),
+			                     static_cast<int>((backPacked >> 16u) & 0xFFu));
+			span.bold   = (run.style & kStyleHilite) != 0;
 			span.underline = (run.style & kStyleUnderline) != 0;
 			span.blink     = (run.style & kStyleBlink) != 0;
 			span.inverse   = (run.style & kStyleInverse) != 0;
@@ -2154,9 +2154,9 @@ namespace
 
 	QString makeCallbackVariableValueKey(const QString &pluginId, const QString &name);
 
-	bool    tryResolveCallbackVariableValueFromCache(const LuaCallbackEngine *engine, const QString &pluginId,
-	                                                 const QString &name, QString &value, bool &pluginAvailable,
-	                                                 bool &cacheHit)
+	bool tryResolveCallbackVariableValueFromCache(const LuaCallbackEngine *engine, const QString &pluginId,
+	                                              const QString &name, QString &value, bool &pluginAvailable,
+	                                              bool &cacheHit)
 	{
 		cacheHit            = false;
 		pluginAvailable     = false;
@@ -7999,9 +7999,9 @@ namespace
 		{
 			if (snapshot->hasLineBufferCountDelta)
 			{
-				const int oldLineCount        = context->hasBufferedLineCount ? context->bufferedLineCount
-				                                                              : snapshot->lineBufferDeltaCount;
-				context->bufferedLineCount    = qMax(0, snapshot->lineBufferDeltaCount);
+				const int oldLineCount     = context->hasBufferedLineCount ? context->bufferedLineCount
+				                                                           : snapshot->lineBufferDeltaCount;
+				context->bufferedLineCount = qMax(0, snapshot->lineBufferDeltaCount);
 				context->hasBufferedLineCount = true;
 				for (int lineNumber = context->bufferedLineCount + 1; lineNumber <= oldLineCount;
 				     ++lineNumber)
@@ -8960,7 +8960,7 @@ namespace
 		const bool forbidSyncBridge = policy == DeferredRuntimeMutationFlushPolicy::ForbidSynchronousBridge ||
 		                              callbackScopeSyncBridgeForbidden();
 
-		bool flushed = false;
+		bool       flushed = false;
 		if (QThread::currentThread() != targetRuntime->thread() && forbidSyncBridge)
 		{
 			if (auto *mutableEngine = const_cast<LuaCallbackEngine *>(engine); mutableEngine)
@@ -9309,8 +9309,8 @@ namespace
 	int callbackOutputFlags(const LuaCallbackEngine *engine, WorldRuntime *runtime, const bool note,
 	                        const bool horizontalRule)
 	{
-		int           flags        = horizontalRule ? WorldRuntime::LineHorizontalRule
-		                                            : (note ? WorldRuntime::LineNote : WorldRuntime::LineOutput);
+		int           flags = horizontalRule ? WorldRuntime::LineHorizontalRule
+		                                     : (note ? WorldRuntime::LineNote : WorldRuntime::LineOutput);
 		const QString logAttribute = note ? QStringLiteral("log_notes") : QStringLiteral("log_output");
 		if (isEnabledValue(resolveWorldAttributeValueForApi(engine, runtime, logAttribute)))
 			flags |= WorldRuntime::LineLog;
@@ -10574,26 +10574,6 @@ static int yieldModalStringResult(lua_State *L, const LuaCallbackEngine *engine,
 	return lua_yieldk(L, 0, 0, continuation);
 }
 
-#ifdef QMUD_LUACALLBACKENGINE_TEST_MINIMAL_BINDINGS
-static int luaTestYieldModalNumber(lua_State *L)
-{
-	const auto *engine = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	LuaPendingModalStringRequest request;
-	request.guiCallable    = []() -> QString { return {}; };
-	request.resultCallback = [](quint64, const QString &) {};
-	return yieldModalStringResult(L, engine, std::move(request), luaModalNumberContinuation);
-}
-
-static int luaTestYieldModalString(lua_State *L)
-{
-	const auto *engine = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	LuaPendingModalStringRequest request;
-	request.guiCallable    = []() -> QString { return {}; };
-	request.resultCallback = [](quint64, const QString &) {};
-	return yieldModalStringResult(L, engine, std::move(request));
-}
-#endif
-
 #ifndef NDEBUG
 static QString qmudMmStartupDiagEngineLabel(const LuaCallbackEngine *engine)
 {
@@ -10655,17 +10635,17 @@ static auto runOnMainWindowThread(Func &&func, std::invoke_result_t<Func, MainWi
 
 		auto       mutation = std::make_shared<DecayedFunc>(std::forward<Func>(func));
 		const bool queued   = QMetaObject::invokeMethod(
-            app.data(),
-            [mutation]() mutable
-            {
-                if (!mutation)
-                    return;
-                MainWindow *frame = resolveMainWindow();
-                if (!frame)
-                    return;
-                static_cast<void>((*mutation)(frame));
-            },
-            Qt::QueuedConnection);
+		    app.data(),
+		    [mutation]() mutable
+		    {
+			    if (!mutation)
+				    return;
+			    MainWindow *frame = resolveMainWindow();
+			    if (!frame)
+				    return;
+			    static_cast<void>((*mutation)(frame));
+		    },
+		    Qt::QueuedConnection);
 		if (!queued)
 		{
 			qWarning().noquote() << QStringLiteral(
@@ -10679,12 +10659,12 @@ static auto runOnMainWindowThread(Func &&func, std::invoke_result_t<Func, MainWi
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app.data(),
 	                                                         [&]
 	                                                         {
-                                                               MainWindow *frame = resolveMainWindow();
-                                                               if (!frame)
-                                                                   return;
-                                                               result    = func(frame);
-                                                               completed = true;
-                                                           });
+		                                                       MainWindow *frame = resolveMainWindow();
+		                                                       if (!frame)
+			                                                       return;
+		                                                       result    = func(frame);
+		                                                       completed = true;
+	                                                         });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] runOnMainWindowThread failed: %1")
@@ -10777,12 +10757,12 @@ template <typename Func> static MainWindowMutationDispatchResult dispatchMainWin
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app.data(),
 	                                                         [&]
 	                                                         {
-                                                               MainWindow *frame = resolveMainWindow();
-                                                               if (!frame)
-                                                                   return;
-                                                               result    = (*mutation)(frame);
-                                                               completed = true;
-                                                           });
+		                                                       MainWindow *frame = resolveMainWindow();
+		                                                       if (!frame)
+			                                                       return;
+		                                                       result    = (*mutation)(frame);
+		                                                       completed = true;
+	                                                         });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] dispatchMainWindowMutation failed: %1")
@@ -10831,9 +10811,9 @@ static auto runOnGuiThread(Func &&func, std::invoke_result_t<Func> fallbackValue
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app.data(),
 	                                                         [&]
 	                                                         {
-                                                               result    = func();
-                                                               completed = true;
-                                                           });
+		                                                       result    = func();
+		                                                       completed = true;
+	                                                         });
 	if (!bridged)
 	{
 		qWarning().noquote()
@@ -10927,9 +10907,9 @@ static bool dispatchAppControllerMutation(AppController *app, Func &&func,
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app,
 	                                                         [&]
 	                                                         {
-                                                               (*mutation)(*app);
-                                                               completed = true;
-                                                           });
+		                                                       (*mutation)(*app);
+		                                                       completed = true;
+	                                                         });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] dispatchAppControllerMutation failed: %1")
@@ -11272,7 +11252,7 @@ LuaBatchDispatchResult LuaCallbackEngine::resumeSuspendedModalString(const quint
 	const QVector<QString> previousCallingPluginIdStack = m_callingPluginIdStack;
 	m_callingPluginIdStack                              = suspended->callingPluginIdStack;
 	const auto restoreCallingPluginIdStack              = qScopeGuard(
-        [this, previousCallingPluginIdStack] { m_callingPluginIdStack = previousCallingPluginIdStack; });
+	    [this, previousCallingPluginIdStack] { m_callingPluginIdStack = previousCallingPluginIdStack; });
 	Q_UNUSED(restoreCallingPluginIdStack);
 
 	pushActiveCallbackContext(this, std::move(suspended->context));
@@ -11319,8 +11299,8 @@ LuaBatchDispatchResult LuaCallbackEngine::resumeSuspendedModalString(const quint
 	}
 
 	LuaCallbackExecutionContext completedContext = takeActiveCallbackContext(this);
-	const auto                  unrefThread      = qScopeGuard([this, registryRef = suspended->registryRef]
-                                         { luaL_unref(m_state, LUA_REGISTRYINDEX, registryRef); });
+	const auto unrefThread = qScopeGuard([this, registryRef = suspended->registryRef]
+	                                     { luaL_unref(m_state, LUA_REGISTRYINDEX, registryRef); });
 	Q_UNUSED(unrefThread);
 	if (status != LUA_OK)
 	{
@@ -11489,28 +11469,28 @@ static int luaActivateNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, title, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        bool activated = false;
-                        if (const MainWindow *mw = resolveMainWindow())
-                            activated = mw->activateNotepad(title, targetRuntimeOnMain);
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("ActivateNotepad"), activated, 0);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("ActivateNotepad"), false, 0);
-                }
-            });
+		    engine, runtime,
+		    [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, title, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        bool activated = false;
+				        if (const MainWindow *mw = resolveMainWindow())
+					        activated = mw->activateNotepad(title, targetRuntimeOnMain);
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ActivateNotepad"), activated, 0);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("ActivateNotepad"), false, 0);
+			    }
+		    });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -12992,13 +12972,13 @@ static int luaCloseNotepad(lua_State *L)
 		{
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-                engine, runtime,
-                [title, querySave, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-                {
-                    const bool closed = targetRuntime.closeNotepad(title, querySave);
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                              QStringLiteral("CloseNotepad"), closed, 0);
-                });
+			    engine, runtime,
+			    [title, querySave, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+			    {
+				    const bool closed = targetRuntime.closeNotepad(title, querySave);
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("CloseNotepad"), closed, 0);
+			    });
 			if (accepted)
 				invalidateCallbackNotepadDocumentCache(engine, runtime, title, worldId);
 			lua_pushnumber(L, accepted ? 1 : 0);
@@ -13486,11 +13466,11 @@ static int luaDiscardQueue(lua_State *L)
 	return 1;
 }
 
-static int     addTimerInternal(const LuaCallbackEngine *engine, const QString &rawName, int hour, int minute,
-                                double second, const QString &responseText, int flags, const QString &scriptName);
-static QString makeAutoName(const QString &prefix);
-static void    applyTimerDefaults(WorldRuntime::Timer &timer);
-static void    resetTimerFields(WorldRuntime::Timer &timer);
+static int addTimerInternal(const LuaCallbackEngine *engine, const QString &rawName, int hour, int minute,
+                            double second, const QString &responseText, int flags, const QString &scriptName);
+static QString                       makeAutoName(const QString &prefix);
+static void                          applyTimerDefaults(WorldRuntime::Timer &timer);
+static void                          resetTimerFields(WorldRuntime::Timer &timer);
 static QList<WorldRuntime::Trigger> &mutableTriggerList(WorldRuntime *runtime, WorldRuntime::Plugin *plugin);
 static QList<WorldRuntime::Alias>   &mutableAliasList(WorldRuntime *runtime, WorldRuntime::Plugin *plugin);
 static QList<WorldRuntime::Timer>   &mutableTimerList(WorldRuntime *runtime, WorldRuntime::Plugin *plugin);
@@ -13550,12 +13530,12 @@ static auto runOnRuntimeThread(WorldRuntime *runtime, Func &&func, std::invoke_r
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(runtimeGuard.data(),
 	                                                         [&]
 	                                                         {
-                                                               if (runtimeGuard)
-                                                               {
-                                                                   result    = func();
-                                                                   completed = true;
-                                                               }
-                                                           });
+		                                                       if (runtimeGuard)
+		                                                       {
+			                                                       result    = func();
+			                                                       completed = true;
+		                                                       }
+	                                                         });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] runOnRuntimeThread failed: %1")
@@ -13592,12 +13572,12 @@ static auto runOnRuntimeThreadNoDeferredFlush(WorldRuntime *runtime, Func &&func
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(runtimeGuard.data(),
 	                                                         [&]
 	                                                         {
-                                                               if (runtimeGuard)
-                                                               {
-                                                                   result    = func();
-                                                                   completed = true;
-                                                               }
-                                                           });
+		                                                       if (runtimeGuard)
+		                                                       {
+			                                                       result    = func();
+			                                                       completed = true;
+		                                                       }
+	                                                         });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral(
@@ -13637,12 +13617,12 @@ static auto runOnRuntimeThreadAllowNestedEvents(WorldRuntime *runtime, Func &&fu
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(runtimeGuard.data(),
 	                                                         [&]
 	                                                         {
-                                                               if (runtimeGuard)
-                                                               {
-                                                                   result    = func();
-                                                                   completed = true;
-                                                               }
-                                                           });
+		                                                       if (runtimeGuard)
+		                                                       {
+			                                                       result    = func();
+			                                                       completed = true;
+		                                                       }
+	                                                         });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral(
@@ -13763,14 +13743,14 @@ static bool enqueueRuntimeThreadDeferredMutationNoResult(const LuaCallbackEngine
 		const QPointer<WorldRuntime> runtimeGuard(runtime);
 		auto                         invokeShared = std::make_shared<decltype(invoke)>(std::move(invoke));
 		const bool                   queued       = QMetaObject::invokeMethod(
-            runtime,
-            [runtimeGuard, invokeShared]() mutable
-            {
-                if (!runtimeGuard || !invokeShared)
-                    return;
-                (*invokeShared)(*runtimeGuard);
-            },
-            Qt::QueuedConnection);
+		    runtime,
+		    [runtimeGuard, invokeShared]() mutable
+		    {
+			    if (!runtimeGuard || !invokeShared)
+				    return;
+			    (*invokeShared)(*runtimeGuard);
+		    },
+		    Qt::QueuedConnection);
 		if (!queued && runtimeGuard)
 		{
 			if (callbackScopeSyncBridgeForbidden())
@@ -13837,14 +13817,14 @@ static int enqueueRuntimeThreadAsyncStatusResult(lua_State *L, const LuaCallback
 	auto          funcCopy         = DecayedFunc(std::forward<Func>(func));
 	auto          okCopy           = DecayedOkFunc(std::forward<OkFunc>(okFunc));
 	const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-        engine, runtime,
-        [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy),
-         okCopy = std::move(okCopy)](WorldRuntime &targetRuntime) mutable
-        {
-            const int status = funcCopy(targetRuntime);
-            emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
-		                                     QString());
-        });
+	    engine, runtime,
+	    [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy),
+	     okCopy = std::move(okCopy)](WorldRuntime &targetRuntime) mutable
+	    {
+		    const int status = funcCopy(targetRuntime);
+		    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
+		                          QString());
+	    });
 
 	lua_pushnumber(L, accepted ? acceptedCode : enqueueFailureCode);
 	if (accepted && requestId != 0)
@@ -14100,7 +14080,7 @@ static bool mapTriggerCallbackBufferIndexToAbsoluteLineNumber(const LuaCallbackE
 
 	const qint64 offset = static_cast<qint64>(lineNumber) -
 	                      static_cast<qint64>(context->triggerMatchedLineBufferIndexAtDispatch);
-	absoluteLineNumber = context->triggerMatchedLineAbsoluteNumberAtDispatch + offset;
+	absoluteLineNumber  = context->triggerMatchedLineAbsoluteNumberAtDispatch + offset;
 	return absoluteLineNumber > 0;
 }
 
@@ -15527,39 +15507,39 @@ static bool resolveNotepadListForApi(const LuaCallbackEngine *engine, WorldRunti
 		return false;
 	const auto ownerToken = reinterpret_cast<quintptr>(runtime);
 	const bool resolved   = runOnMainWindowThread(
-        [&](const MainWindow *frame) -> bool
-        {
-            auto *mdi = frame->findChild<QMdiArea *>();
-            if (!mdi)
-                return true;
+	    [&](const MainWindow *frame) -> bool
+	    {
+		    auto *mdi = frame->findChild<QMdiArea *>();
+		    if (!mdi)
+			    return true;
 
-            for (const QList<QMdiSubWindow *> windows = mdi->subWindowList(QMdiArea::CreationOrder);
-                 QMdiSubWindow *sub : windows)
-            {
-                auto *text = qobject_cast<TextChildWindow *>(sub);
-                if (!text)
-                    continue;
-                if (!all)
-                {
-                    if (const auto relatedToken = text->property("worldRuntimeToken").toULongLong();
-                        relatedToken == ownerToken)
-                    {
-                        // Matched this runtime instance.
-                    }
-                    else
-                    {
-                        if (relatedToken != 0)
-                            continue;
-                        if (const QString related = text->property("worldId").toString();
-                            related.isEmpty() || related.compare(worldId, Qt::CaseInsensitive) != 0)
-                            continue;
-                    }
-                }
-                titles.push_back(text->windowTitle());
-            }
-            return true;
-        },
-        false);
+		    for (const QList<QMdiSubWindow *> windows = mdi->subWindowList(QMdiArea::CreationOrder);
+		         QMdiSubWindow *sub : windows)
+		    {
+			    auto *text = qobject_cast<TextChildWindow *>(sub);
+			    if (!text)
+				    continue;
+			    if (!all)
+			    {
+				    if (const auto relatedToken = text->property("worldRuntimeToken").toULongLong();
+				        relatedToken == ownerToken)
+				    {
+					    // Matched this runtime instance.
+				    }
+				    else
+				    {
+					    if (relatedToken != 0)
+						    continue;
+					    if (const QString related = text->property("worldId").toString();
+					        related.isEmpty() || related.compare(worldId, Qt::CaseInsensitive) != 0)
+						    continue;
+				    }
+			    }
+			    titles.push_back(text->windowTitle());
+		    }
+		    return true;
+	    },
+	    false);
 	if (!resolved)
 		return false;
 	cacheCallbackNotepadList(engine, key, !titles.isEmpty(), titles);
@@ -16422,35 +16402,35 @@ static int luaDoCommand(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [cmdName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, cmdName, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        int deferredResult = eNoSuchCommand;
-                        if (const MainWindow *mw = resolveMainWindow())
-                        {
-                            if (QAction *action = mw->actionForCommand(cmdName))
-                            {
-                                action->trigger();
-                                deferredResult = eOK;
-                            }
-                        }
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("DoCommand"), deferredResult == eOK,
-				                                                           deferredResult);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("DoCommand"), false, eNoSuchCommand);
-                }
-            });
+		    engine, runtime,
+		    [cmdName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, cmdName, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        int deferredResult = eNoSuchCommand;
+				        if (const MainWindow *mw = resolveMainWindow())
+				        {
+					        if (QAction *action = mw->actionForCommand(cmdName))
+					        {
+						        action->trigger();
+						        deferredResult = eOK;
+					        }
+				        }
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("DoCommand"), deferredResult == eOK,
+				                              deferredResult);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("DoCommand"), false, eNoSuchCommand);
+			    }
+		    });
 		lua_pushnumber(L, accepted ? eOK : eNoSuchCommand);
 		if (accepted && requestId != 0)
 		{
@@ -16689,13 +16669,13 @@ static int luaExecute(lua_State *L)
 	{
 		const bool triggerPriority = context->directTriggerScriptActionPriority;
 		const int  results         = enqueueRuntimeThreadAsyncStatusResult(
-            L, engine, runtime, QStringLiteral("Execute"), eOK, eWorldClosed,
-            [input, triggerPriority](const WorldRuntime &targetRuntime) -> int
-            {
-                return triggerPriority ? targetRuntime.executeCommandWithTriggerPriority(input)
-			                                    : targetRuntime.executeCommand(input);
-            },
-            [](const int status) { return status == eOK; });
+		    L, engine, runtime, QStringLiteral("Execute"), eOK, eWorldClosed,
+		    [input, triggerPriority](const WorldRuntime &targetRuntime) -> int
+		    {
+			    return triggerPriority ? targetRuntime.executeCommandWithTriggerPriority(input)
+			                           : targetRuntime.executeCommand(input);
+		    },
+		    [](const int status) { return status == eOK; });
 		return results;
 	}
 	const int result = runOnRuntimeThreadDeferredMutation(
@@ -18095,7 +18075,7 @@ static int luaGetScriptTime(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const double                          scriptSeconds =
-        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.scriptTimeSeconds : 0.0;
+	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.scriptTimeSeconds : 0.0;
 	lua_pushnumber(L, scriptSeconds);
 	return 1;
 }
@@ -19256,32 +19236,32 @@ static int luaImportXML(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [xml, callbackPluginId, requestId, encodeImportPayload](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, xml, callbackPluginId, requestId, encodeImportPayload]
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        AppController::ImportResult result;
-                        if (AppController *targetApp = AppController::instance())
-                            result = targetApp->importXmlFromText(xml, mask);
-                        else
-                            result.errorMessage = QStringLiteral("App controller is not available");
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("ImportXML"), result.ok, result.ok ? eOK : -1,
-				                                                           encodeImportPayload(result));
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("ImportXML"), false, -1,
-				                                     QStringLiteral("error=Failed%20to%20queue%20ImportXML"));
-                }
-            });
+		    engine, runtime,
+		    [xml, callbackPluginId, requestId, encodeImportPayload](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, xml, callbackPluginId, requestId, encodeImportPayload]
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        AppController::ImportResult result;
+				        if (AppController *targetApp = AppController::instance())
+					        result = targetApp->importXmlFromText(xml, mask);
+				        else
+					        result.errorMessage = QStringLiteral("App controller is not available");
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ImportXML"), result.ok, result.ok ? eOK : -1,
+				                              encodeImportPayload(result));
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("ImportXML"), false, -1,
+				                          QStringLiteral("error=Failed%20to%20queue%20ImportXML"));
+			    }
+		    });
 		lua_pushnumber(L, accepted ? 0 : -1);
 		if (accepted && requestId != 0)
 		{
@@ -19413,35 +19393,35 @@ static int luaLogSend(lua_State *L)
 		    resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("display_my_input")));
 		const QPointer<WorldRuntime> runtimeGuard(runtime);
 		const int                    results = enqueueRuntimeThreadAsyncOkStatusResult(
-            L, engine, runtime, QStringLiteral("LogSend"), eWorldClosed,
-            [runtimeGuard, text, echo](WorldRuntime &) -> int
-            {
-                if (!runtimeGuard)
-                    return eWorldClosed;
-                const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
-                if (sendResult == eOK)
-                    runtimeGuard->logInputCommand(text);
-                return sendResult;
-            });
+		    L, engine, runtime, QStringLiteral("LogSend"), eWorldClosed,
+		    [runtimeGuard, text, echo](WorldRuntime &) -> int
+		    {
+			    if (!runtimeGuard)
+				    return eWorldClosed;
+			    const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
+			    if (sendResult == eOK)
+				    runtimeGuard->logInputCommand(text);
+			    return sendResult;
+		    });
 		if (lua_tointeger(L, -results) == eOK)
 			updateCallbackSendCommandSnapshots(engine, runtime, text, echo, false, false, false);
 		return results;
 	}
 	const QPointer<WorldRuntime> runtimeGuard(runtime);
 	const int                    result = runOnRuntimeThreadDeferredMutation(
-        engine, runtime,
-        [runtimeGuard, text]() -> int
-        {
-            if (!runtimeGuard)
-                return eWorldClosed;
-            const bool echo =
-                isEnabledValue(runtimeGuard->worldAttributeValue(QStringLiteral("display_my_input")));
-            const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
-            if (sendResult == eOK)
-                runtimeGuard->logInputCommand(text);
-            return sendResult;
-        },
-        eWorldClosed);
+	    engine, runtime,
+	    [runtimeGuard, text]() -> int
+	    {
+		    if (!runtimeGuard)
+			    return eWorldClosed;
+		    const bool echo =
+		        isEnabledValue(runtimeGuard->worldAttributeValue(QStringLiteral("display_my_input")));
+		    const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
+		    if (sendResult == eOK)
+			    runtimeGuard->logInputCommand(text);
+		    return sendResult;
+	    },
+	    eWorldClosed);
 	lua_pushnumber(L, result);
 	return 1;
 }
@@ -19955,7 +19935,7 @@ static int luaGetNoteColourBack(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const long                            noteColour =
-        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourBack : 0;
+	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourBack : 0;
 	lua_pushnumber(L, static_cast<lua_Number>(noteColour));
 	return 1;
 }
@@ -19984,7 +19964,7 @@ static int luaGetNoteColourFore(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const long                            noteColour =
-        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourFore : 0;
+	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourFore : 0;
 	lua_pushnumber(L, static_cast<lua_Number>(noteColour));
 	return 1;
 }
@@ -20312,27 +20292,27 @@ static int luaOpen(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [path, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, path, callbackPluginId, requestId]
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        const bool opened =
-                            AppController::instance() && AppController::instance()->openDocumentFile(path);
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("Open"), opened, opened ? eOK : -1, path);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, QStringLiteral("Open"),
-				                                     false, -1, path);
-                }
-            });
+		    engine, runtime,
+		    [path, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, path, callbackPluginId, requestId]
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        const bool opened =
+				            AppController::instance() && AppController::instance()->openDocumentFile(path);
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("Open"), opened, opened ? eOK : -1, path);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, QStringLiteral("Open"),
+				                          false, -1, path);
+			    }
+		    });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -20372,18 +20352,18 @@ static int luaOpenBrowser(lua_State *L)
 		QPointer<QCoreApplication> app = QCoreApplication::instance();
 		QPointer<WorldRuntime>     runtimeGuard(runtime);
 		const bool                 queued = app && QMetaObject::invokeMethod(
-                                       app.data(),
-                                       [runtimeGuard, urlText, callbackPluginId, requestId]
-                                       {
-                                           WorldRuntime *targetRuntime = runtimeGuard.data();
-                                           if (!targetRuntime)
-                                               return;
-                                           const bool ok = QDesktopServices::openUrl(QUrl(urlText));
-                                           emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
-			                                                                     QStringLiteral("OpenBrowser"), ok,
-                                                                 ok ? eOK : eCouldNotOpenFile);
-                                       },
-                                       Qt::QueuedConnection);
+		                                               app.data(),
+		                                               [runtimeGuard, urlText, callbackPluginId, requestId]
+		                                               {
+			                               WorldRuntime *targetRuntime = runtimeGuard.data();
+			                               if (!targetRuntime)
+				                               return;
+			                               const bool ok = QDesktopServices::openUrl(QUrl(urlText));
+			                               emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
+			                                                     QStringLiteral("OpenBrowser"), ok,
+			                                                     ok ? eOK : eCouldNotOpenFile);
+		                                               },
+		                                               Qt::QueuedConnection);
 		lua_pushnumber(L, queued ? eOK : eCouldNotOpenFile);
 		if (queued && requestId != 0)
 		{
@@ -20422,9 +20402,9 @@ static int luaPasteCommand(lua_State *L)
 		                                   : static_cast<int>(expectedInput.size());
 		const int     selectionStart = std::clamp(snapshot.inputSelectionStartColumn - 1, 0, inputLength);
 		const int     selectionEnd =
-            snapshot.inputSelectionEndColumn <= selectionStart
-		            ? selectionStart
-		            : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
+		    snapshot.inputSelectionEndColumn <= selectionStart
+		        ? selectionStart
+		        : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
 		const QString replaced = selectionEnd > selectionStart
 		                             ? expectedInput.mid(selectionStart, selectionEnd - selectionStart)
 		                             : QString();
@@ -20928,9 +20908,9 @@ static int luaAudioIsPlaying(lua_State *L)
 	const int     buffer  = normalizeLuaAudioBuffer(L, 1, 0);
 	QMudNativePluginRegistry::LuaAudioRuntimeBufferState bufferState;
 	const int                                            status =
-        (buffer > 0 && QMudNativePluginRegistry::luaAudioRuntimeBufferState(runtime, buffer, bufferState))
-	                                                   ? luaAudioSoundStatus(engine, runtime, buffer)
-	                                                   : -3;
+	    (buffer > 0 && QMudNativePluginRegistry::luaAudioRuntimeBufferState(runtime, buffer, bufferState))
+	        ? luaAudioSoundStatus(engine, runtime, buffer)
+	        : -3;
 	lua_pushboolean(L, status == 1 || status == 2);
 	return 1;
 }
@@ -22071,19 +22051,19 @@ static int luaTransparency(lua_State *L)
 		QPointer<QCoreApplication> app = QCoreApplication::instance();
 		QPointer<WorldRuntime>     runtimeGuard(runtime);
 		const bool                 queued = app && QMetaObject::invokeMethod(
-                                       app.data(),
-                                       [runtimeGuard, callbackPluginId, requestId, applyTransparency]
-                                       {
-                                           WorldRuntime *targetRuntime = runtimeGuard.data();
-                                           if (!targetRuntime)
-                                               return;
-                                           MainWindow *window = resolveMainWindow();
-                                           const bool  ok = window && applyTransparency(window);
-                                           emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
-			                                                                     QStringLiteral("Transparency"), ok,
-                                                                 ok ? eOK : eBadParameter);
-                                       },
-                                       Qt::QueuedConnection);
+		                                               app.data(),
+		                                               [runtimeGuard, callbackPluginId, requestId, applyTransparency]
+		                                               {
+			                               WorldRuntime *targetRuntime = runtimeGuard.data();
+			                               if (!targetRuntime)
+				                               return;
+			                               MainWindow *window = resolveMainWindow();
+			                               const bool  ok     = window && applyTransparency(window);
+			                               emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
+			                                                     QStringLiteral("Transparency"), ok,
+			                                                     ok ? eOK : eBadParameter);
+		                                               },
+		                                               Qt::QueuedConnection);
 		lua_pushboolean(L, queued);
 		if (queued && requestId != 0)
 		{
@@ -22419,9 +22399,9 @@ static int luaSetToolBarPosition(lua_State *L)
 					                  const ToolBarDockState &sa = s_toolbarStates.value(a);
 					                  const ToolBarDockState &sb = s_toolbarStates.value(b);
 					                  const int               primaryA =
-                                          area == Qt::LeftToolBarArea || area == Qt::RightToolBarArea
-					                                        ? sa.pos.y()
-					                                        : sa.pos.x();
+					                      area == Qt::LeftToolBarArea || area == Qt::RightToolBarArea
+					                          ? sa.pos.y()
+					                          : sa.pos.x();
 					                  const int primaryB =
 					                      area == Qt::LeftToolBarArea || area == Qt::RightToolBarArea
 					                          ? sb.pos.y()
@@ -23137,9 +23117,9 @@ static int luaSpellCheckCommand(lua_State *L)
 		                                   ? std::numeric_limits<int>::max()
 		                                   : static_cast<int>(expectedInput.size());
 		int           selectionStart = std::clamp(snapshot.inputSelectionStartColumn - 1, 0, inputLength);
-		int           selectionEnd   = snapshot.inputSelectionEndColumn <= selectionStart
-		                                   ? selectionStart
-		                                   : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
+		int selectionEnd = snapshot.inputSelectionEndColumn <= selectionStart
+		                       ? selectionStart
+		                       : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
 		if (endCol > startCol && startCol >= 0 && endCol >= 0)
 		{
 			selectionStart = std::clamp(startCol, 0, inputLength);
@@ -23171,16 +23151,16 @@ static int luaSpellCheckCommand(lua_State *L)
 
 		const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [expectedInput, selectionStart, selectionEnd, all, replacement, callbackPluginId, requestId,
-             applySpellCheckReplacement](WorldRuntime &targetRuntime)
-            {
-                const bool applied = applySpellCheckReplacement(targetRuntime, expectedInput, selectionStart,
-			                                                        selectionEnd, all, replacement);
-                emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-			                              QStringLiteral("SpellCheckCommand"), applied, applied ? 0 : -1,
-                                      applied ? QStringLiteral("1") : QString());
-            });
+		    engine, runtime,
+		    [expectedInput, selectionStart, selectionEnd, all, replacement, callbackPluginId, requestId,
+		     applySpellCheckReplacement](WorldRuntime &targetRuntime)
+		    {
+			    const bool applied = applySpellCheckReplacement(targetRuntime, expectedInput, selectionStart,
+			                                                    selectionEnd, all, replacement);
+			    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+			                          QStringLiteral("SpellCheckCommand"), applied, applied ? 0 : -1,
+			                          applied ? QStringLiteral("1") : QString());
+		    });
 		if (!accepted)
 		{
 			lua_pushnumber(L, -1);
@@ -23546,28 +23526,28 @@ static int luaAppendToNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, title, contents, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        bool ok = false;
-                        if (MainWindow *mw = resolveMainWindow())
-                            ok = mw->appendToNotepad(title, contents, false, targetRuntimeOnMain);
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("AppendToNotepad"), ok, 0);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("AppendToNotepad"), false, 0);
-                }
-            });
+		    engine, runtime,
+		    [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, title, contents, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        bool ok = false;
+				        if (MainWindow *mw = resolveMainWindow())
+					        ok = mw->appendToNotepad(title, contents, false, targetRuntimeOnMain);
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("AppendToNotepad"), ok, 0);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("AppendToNotepad"), false, 0);
+			    }
+		    });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, false);
 		lua_pushboolean(L, accepted);
@@ -23601,28 +23581,28 @@ static int luaReplaceNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, title, contents, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        bool ok = false;
-                        if (MainWindow *mw = resolveMainWindow())
-                            ok = mw->appendToNotepad(title, contents, true, targetRuntimeOnMain);
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("ReplaceNotepad"), ok, 0);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("ReplaceNotepad"), false, 0);
-                }
-            });
+		    engine, runtime,
+		    [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, title, contents, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        bool ok = false;
+				        if (MainWindow *mw = resolveMainWindow())
+					        ok = mw->appendToNotepad(title, contents, true, targetRuntimeOnMain);
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ReplaceNotepad"), ok, 0);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("ReplaceNotepad"), false, 0);
+			    }
+		    });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, true);
 		lua_pushboolean(L, accepted);
@@ -23656,28 +23636,28 @@ static int luaSendToNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, title, contents, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        bool ok = false;
-                        if (MainWindow *mw = resolveMainWindow())
-                            ok = mw->sendToNotepad(title, contents, targetRuntimeOnMain);
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("SendToNotepad"), ok, 0);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("SendToNotepad"), false, 0);
-                }
-            });
+		    engine, runtime,
+		    [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, title, contents, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        bool ok = false;
+				        if (MainWindow *mw = resolveMainWindow())
+					        ok = mw->sendToNotepad(title, contents, targetRuntimeOnMain);
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("SendToNotepad"), ok, 0);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("SendToNotepad"), false, 0);
+			    }
+		    });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, true);
 		lua_pushboolean(L, accepted);
@@ -25623,9 +25603,9 @@ static int luaGetInfo(lua_State *L)
 			if (runtime && !callbackNoFlushRuntimeReadBridgeForbidden(engine, inCallback))
 			{
 				const auto resolveBackground = [&]() -> long { return runtime->backgroundColour(); };
-				backgroundValue              = inCallback
-				                                   ? runOnRuntimeThreadNoDeferredFlush(runtime, resolveBackground, 0L)
-				                                   : runOnRuntimeThread(runtime, resolveBackground, 0L);
+				backgroundValue = inCallback
+				                      ? runOnRuntimeThreadNoDeferredFlush(runtime, resolveBackground, 0L)
+				                      : runOnRuntimeThread(runtime, resolveBackground, 0L);
 				cacheCallbackBackgroundColour(engine, backgroundValue);
 			}
 			else
@@ -26599,37 +26579,37 @@ static int luaUtilsSendToFront(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [titlePrefix, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, titlePrefix, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        bool found = false;
-                        for (QWidget *widget : QApplication::topLevelWidgets())
-                        {
-                            if (!widget)
-                                continue;
-                            if (const QString title = widget->windowTitle(); !title.startsWith(titlePrefix))
-                                continue;
-                            widget->raise();
-                            widget->activateWindow();
-                            found = true;
-                            break;
-                        }
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("SendToFront"), found, found ? eOK : -1);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("SendToFront"), false, -1);
-                }
-            });
+		    engine, runtime,
+		    [titlePrefix, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, titlePrefix, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        bool found = false;
+				        for (QWidget *widget : QApplication::topLevelWidgets())
+				        {
+					        if (!widget)
+						        continue;
+					        if (const QString title = widget->windowTitle(); !title.startsWith(titlePrefix))
+						        continue;
+					        widget->raise();
+					        widget->activateWindow();
+					        found = true;
+					        break;
+				        }
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("SendToFront"), found, found ? eOK : -1);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("SendToFront"), false, -1);
+			    }
+		    });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -26861,29 +26841,29 @@ static int luaUtilsShellExecute(lua_State *L)
 			const QString callbackPluginId = engine->pluginId();
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-                engine, runtime,
-                [url, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-                {
-                    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                    const bool                   queued = enqueueOnMainThread(
-                        [runtimeGuard, url, callbackPluginId, requestId]()
-                        {
-                            WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                            if (!targetRuntimeOnMain)
-                                return;
-                            const bool opened = QDesktopServices::openUrl(url);
-                            emitPluginAsyncResult(
-                                *targetRuntimeOnMain, callbackPluginId, requestId,
-                                QStringLiteral("ShellExecute"), opened, opened ? eOK : eCouldNotOpenFile,
-                                opened ? QString() : QStringLiteral("Failed to open target."));
-                        });
-                    if (!queued)
-                    {
-                        emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-					                              QStringLiteral("ShellExecute"), false, eCouldNotOpenFile,
-					                              QStringLiteral("Failed to open target."));
-                    }
-                });
+			    engine, runtime,
+			    [url, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+			    {
+				    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+				    const bool                   queued = enqueueOnMainThread(
+				        [runtimeGuard, url, callbackPluginId, requestId]()
+				        {
+					        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+					        if (!targetRuntimeOnMain)
+						        return;
+					        const bool opened = QDesktopServices::openUrl(url);
+					        emitPluginAsyncResult(
+					            *targetRuntimeOnMain, callbackPluginId, requestId,
+					            QStringLiteral("ShellExecute"), opened, opened ? eOK : eCouldNotOpenFile,
+					            opened ? QString() : QStringLiteral("Failed to open target."));
+				        });
+				    if (!queued)
+				    {
+					    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+					                          QStringLiteral("ShellExecute"), false, eCouldNotOpenFile,
+					                          QStringLiteral("Failed to open target."));
+				    }
+			    });
 			lua_pushboolean(L, accepted ? 1 : 0);
 			if (accepted && requestId != 0)
 			{
@@ -27881,15 +27861,6 @@ static MultiListBoxRequest parseUtilsMultiListBoxRequest(lua_State *L)
 	return request;
 }
 
-#ifdef QMUD_LUACALLBACKENGINE_TEST_MINIMAL_BINDINGS
-static int luaTestUtilsMultiListBox(lua_State *L)
-{
-	(void)parseUtilsMultiListBoxRequest(L);
-	lua_pushnil(L);
-	return 1;
-}
-#endif
-
 static int luaUtilsMultiListBox(lua_State *L)
 {
 	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
@@ -28001,29 +27972,29 @@ static int luaUtilsActivateNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, title, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        bool activated = false;
-                        if (const MainWindow *mw = resolveMainWindow())
-                            activated = mw->activateNotepad(title, targetRuntimeOnMain);
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("ActivateNotepad"), activated,
-                                              activated ? eOK : -1);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("ActivateNotepad"), false, -1);
-                }
-            });
+		    engine, runtime,
+		    [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, title, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        bool activated = false;
+				        if (const MainWindow *mw = resolveMainWindow())
+					        activated = mw->activateNotepad(title, targetRuntimeOnMain);
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ActivateNotepad"), activated,
+				                              activated ? eOK : -1);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("ActivateNotepad"), false, -1);
+			    }
+		    });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -28051,28 +28022,28 @@ static int luaUtilsAppendToNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [title, contents, replace, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, title, contents, replace, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        bool ok = false;
-                        if (MainWindow *mw = resolveMainWindow())
-                            ok = mw->appendToNotepad(title, contents, replace, targetRuntimeOnMain);
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("AppendToNotepad"), ok, ok ? eOK : -1);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("AppendToNotepad"), false, -1);
-                }
-            });
+		    engine, runtime,
+		    [title, contents, replace, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, title, contents, replace, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        bool ok = false;
+				        if (MainWindow *mw = resolveMainWindow())
+					        ok = mw->appendToNotepad(title, contents, replace, targetRuntimeOnMain);
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("AppendToNotepad"), ok, ok ? eOK : -1);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("AppendToNotepad"), false, -1);
+			    }
+		    });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, replace);
 		lua_pushboolean(L, accepted);
@@ -29632,26 +29603,26 @@ static int luaProgressGc(lua_State *L)
 			const QString callbackPluginId = engine->pluginId();
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-                engine, runtime,
-                [closeDialog, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-                {
-                    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                    const bool                   queued = enqueueOnMainThread(
-                        [runtimeGuard, closeDialog, callbackPluginId, requestId]()
-                        {
-                            WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                            if (!targetRuntimeOnMain)
-                                return;
-                            const bool closed = closeDialog(nullptr);
-                            emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-					                                                    QStringLiteral("ProgressClose"), closed, closed ? eOK : -1);
-                        });
-                    if (!queued)
-                    {
-                        emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-					                              QStringLiteral("ProgressClose"), false, -1);
-                    }
-                });
+			    engine, runtime,
+			    [closeDialog, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+			    {
+				    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+				    const bool                   queued = enqueueOnMainThread(
+				        [runtimeGuard, closeDialog, callbackPluginId, requestId]()
+				        {
+					        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+					        if (!targetRuntimeOnMain)
+						        return;
+					        const bool closed = closeDialog(nullptr);
+					        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+					                              QStringLiteral("ProgressClose"), closed, closed ? eOK : -1);
+				        });
+				    if (!queued)
+				    {
+					    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+					                          QStringLiteral("ProgressClose"), false, -1);
+				    }
+			    });
 			if (!accepted)
 				static_cast<void>(runOnMainWindowThread(closeDialog, false, true));
 		}
@@ -29696,57 +29667,57 @@ static int luaProgressNew(lua_State *L)
 		    {
 			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
 			    const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, title, handle, callbackPluginId, asyncRequestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
+			        [runtimeGuard, title, handle, callbackPluginId, asyncRequestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
 
-                        QProgressDialog *dialog = nullptr;
-                        if (MainWindow *frame = resolveMainWindow())
-                        {
-                            auto *newDialog = new QProgressDialog(frame);
-                            newDialog->setWindowTitle(title);
-                            newDialog->setLabelText(QString());
-                            newDialog->setCancelButtonText(QStringLiteral("Cancel"));
-                            newDialog->setRange(0, 100);
-                            newDialog->setValue(0);
-                            newDialog->setAutoClose(false);
-                            newDialog->setAutoReset(false);
-                            QObject::connect(newDialog, &QProgressDialog::canceled, newDialog,
-					                                           [handle]()
-					                                           {
-                                                 const std::lock_guard<std::mutex> lock(handle->mutex);
-                                                 handle->lastKnownCanceled    = true;
-                                                 handle->hasLastKnownCanceled = true;
-                                             });
-                            newDialog->show();
-                            dialog = newDialog;
-                        }
+				        QProgressDialog *dialog = nullptr;
+				        if (MainWindow *frame = resolveMainWindow())
+				        {
+					        auto *newDialog = new QProgressDialog(frame);
+					        newDialog->setWindowTitle(title);
+					        newDialog->setLabelText(QString());
+					        newDialog->setCancelButtonText(QStringLiteral("Cancel"));
+					        newDialog->setRange(0, 100);
+					        newDialog->setValue(0);
+					        newDialog->setAutoClose(false);
+					        newDialog->setAutoReset(false);
+					        QObject::connect(newDialog, &QProgressDialog::canceled, newDialog,
+					                         [handle]()
+					                         {
+						                         const std::lock_guard<std::mutex> lock(handle->mutex);
+						                         handle->lastKnownCanceled    = true;
+						                         handle->hasLastKnownCanceled = true;
+					                         });
+					        newDialog->show();
+					        dialog = newDialog;
+				        }
 
-                        QString pendingStatus;
-                        bool    hasPendingStatus = false;
-                        {
-                            const std::lock_guard<std::mutex> lock(handle->mutex);
-                            handle->dialog               = dialog;
-                            handle->createPending        = false;
-                            handle->lastKnownCanceled    = false;
-                            handle->hasLastKnownCanceled = dialog != nullptr;
-                            if (dialog && handle->hasPendingStatus)
-                            {
-                                pendingStatus            = handle->pendingStatus;
-                                hasPendingStatus         = true;
-                                handle->pendingStatus    = {};
-                                handle->hasPendingStatus = false;
-                            }
-                        }
-                        if (dialog && hasPendingStatus)
-                            dialog->setLabelText(pendingStatus);
+				        QString pendingStatus;
+				        bool    hasPendingStatus = false;
+				        {
+					        const std::lock_guard<std::mutex> lock(handle->mutex);
+					        handle->dialog               = dialog;
+					        handle->createPending        = false;
+					        handle->lastKnownCanceled    = false;
+					        handle->hasLastKnownCanceled = dialog != nullptr;
+					        if (dialog && handle->hasPendingStatus)
+					        {
+						        pendingStatus            = handle->pendingStatus;
+						        hasPendingStatus         = true;
+						        handle->pendingStatus    = {};
+						        handle->hasPendingStatus = false;
+					        }
+				        }
+				        if (dialog && hasPendingStatus)
+					        dialog->setLabelText(pendingStatus);
 
-                        const bool ok = dialog != nullptr;
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, asyncRequestId,
-				                                                QStringLiteral("ProgressNew"), ok, ok ? eOK : -1);
-                    });
+				        const bool ok = dialog != nullptr;
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, asyncRequestId,
+				                              QStringLiteral("ProgressNew"), ok, ok ? eOK : -1);
+			        });
 			    if (!queued)
 			    {
 				    {
@@ -29832,35 +29803,35 @@ static int luaProgressSetStatus(lua_State *L)
 		    {
 			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
 			    const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, handle, status, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        QPointer<QProgressDialog> dialog;
-                        bool                      pendingCreate = false;
-                        {
-                            const std::lock_guard<std::mutex> lock(handle->mutex);
-                            dialog        = handle->dialog;
-                            pendingCreate = handle->createPending;
-                            if (!dialog)
-                            {
-                                handle->pendingStatus    = status;
-                                handle->hasPendingStatus = true;
-                            }
-                            else
-                            {
-                                handle->pendingStatus    = {};
-                                handle->hasPendingStatus = false;
-                            }
-                        }
-                        const bool applied = dialog != nullptr;
-                        if (dialog)
-                            dialog->setLabelText(status);
-                        const bool ok = applied || pendingCreate;
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                QStringLiteral("ProgressSetStatus"), ok, ok ? eOK : -1);
-                    });
+			        [runtimeGuard, handle, status, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        QPointer<QProgressDialog> dialog;
+				        bool                      pendingCreate = false;
+				        {
+					        const std::lock_guard<std::mutex> lock(handle->mutex);
+					        dialog        = handle->dialog;
+					        pendingCreate = handle->createPending;
+					        if (!dialog)
+					        {
+						        handle->pendingStatus    = status;
+						        handle->hasPendingStatus = true;
+					        }
+					        else
+					        {
+						        handle->pendingStatus    = {};
+						        handle->hasPendingStatus = false;
+					        }
+				        }
+				        const bool applied = dialog != nullptr;
+				        if (dialog)
+					        dialog->setLabelText(status);
+				        const bool ok = applied || pendingCreate;
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ProgressSetStatus"), ok, ok ? eOK : -1);
+			        });
 			    if (!queued)
 			    {
 				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
@@ -29915,36 +29886,36 @@ static int luaProgressSetRange(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [handle, start, end, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, handle, start, end, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        QPointer<QProgressDialog> dialog;
-                        bool                      pendingCreate = false;
-                        {
-                            const std::lock_guard<std::mutex> lock(handle->mutex);
-                            dialog        = handle->dialog;
-                            pendingCreate = handle->createPending;
-                        }
-                        const bool applied = dialog != nullptr;
-                        if (dialog)
-                            dialog->setRange(start, end);
-                        const bool ok = applied || pendingCreate;
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("ProgressSetRange"), ok, ok ? eOK : -1);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("ProgressSetRange"), false, -1);
-                }
-            });
+		    engine, runtime,
+		    [handle, start, end, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, handle, start, end, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        QPointer<QProgressDialog> dialog;
+				        bool                      pendingCreate = false;
+				        {
+					        const std::lock_guard<std::mutex> lock(handle->mutex);
+					        dialog        = handle->dialog;
+					        pendingCreate = handle->createPending;
+				        }
+				        const bool applied = dialog != nullptr;
+				        if (dialog)
+					        dialog->setRange(start, end);
+				        const bool ok = applied || pendingCreate;
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ProgressSetRange"), ok, ok ? eOK : -1);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("ProgressSetRange"), false, -1);
+			    }
+		    });
 		if (!accepted)
 		{
 			// No callback-local progress state is modified here.
@@ -29984,36 +29955,36 @@ static int luaProgressSetPosition(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [handle, pos, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, handle, pos, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        QPointer<QProgressDialog> dialog;
-                        bool                      pendingCreate = false;
-                        {
-                            const std::lock_guard<std::mutex> lock(handle->mutex);
-                            dialog        = handle->dialog;
-                            pendingCreate = handle->createPending;
-                        }
-                        const bool applied = dialog != nullptr;
-                        if (dialog)
-                            dialog->setValue(pos);
-                        const bool ok = applied || pendingCreate;
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("ProgressSetPosition"), ok, ok ? eOK : -1);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("ProgressSetPosition"), false, -1);
-                }
-            });
+		    engine, runtime,
+		    [handle, pos, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, handle, pos, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        QPointer<QProgressDialog> dialog;
+				        bool                      pendingCreate = false;
+				        {
+					        const std::lock_guard<std::mutex> lock(handle->mutex);
+					        dialog        = handle->dialog;
+					        pendingCreate = handle->createPending;
+				        }
+				        const bool applied = dialog != nullptr;
+				        if (dialog)
+					        dialog->setValue(pos);
+				        const bool ok = applied || pendingCreate;
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ProgressSetPosition"), ok, ok ? eOK : -1);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("ProgressSetPosition"), false, -1);
+			    }
+		    });
 		if (!accepted)
 		{
 			// No callback-local progress state is modified here.
@@ -30070,36 +30041,36 @@ static int luaProgressStep(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [handle, step, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-                const bool                   queued = enqueueOnMainThread(
-                    [runtimeGuard, handle, step, callbackPluginId, requestId]()
-                    {
-                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-                        if (!targetRuntimeOnMain)
-                            return;
-                        QPointer<QProgressDialog> dialog;
-                        bool                      pendingCreate = false;
-                        {
-                            const std::lock_guard<std::mutex> lock(handle->mutex);
-                            dialog        = handle->dialog;
-                            pendingCreate = handle->createPending;
-                        }
-                        const bool applied = dialog != nullptr;
-                        if (dialog)
-                            dialog->setValue(dialog->value() + step);
-                        const bool ok = applied || pendingCreate;
-                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                                                           QStringLiteral("ProgressStep"), ok, ok ? eOK : -1);
-                    });
-                if (!queued)
-                {
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                                     QStringLiteral("ProgressStep"), false, -1);
-                }
-            });
+		    engine, runtime,
+		    [handle, step, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+			    const bool                   queued = enqueueOnMainThread(
+			        [runtimeGuard, handle, step, callbackPluginId, requestId]()
+			        {
+				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+				        if (!targetRuntimeOnMain)
+					        return;
+				        QPointer<QProgressDialog> dialog;
+				        bool                      pendingCreate = false;
+				        {
+					        const std::lock_guard<std::mutex> lock(handle->mutex);
+					        dialog        = handle->dialog;
+					        pendingCreate = handle->createPending;
+				        }
+				        const bool applied = dialog != nullptr;
+				        if (dialog)
+					        dialog->setValue(dialog->value() + step);
+				        const bool ok = applied || pendingCreate;
+				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                              QStringLiteral("ProgressStep"), ok, ok ? eOK : -1);
+			        });
+			    if (!queued)
+			    {
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("ProgressStep"), false, -1);
+			    }
+		    });
 		if (!accepted)
 		{
 			// No callback-local progress state is modified here.
@@ -30705,30 +30676,30 @@ static int pushDispatchSendCommandResult(lua_State *L, const LuaCallbackEngine *
 		    context && context->directTriggerScriptActionPriority && !queue && !immediate;
 		const QPointer<WorldRuntime> runtimeGuard(runtime);
 		const int                    results = enqueueRuntimeThreadAsyncOkStatusResult(
-            L, engine, runtime, apiName, eWorldClosed,
-            [runtimeGuard, text, echo, queue, log, history, immediate, actionSourceOverride,
-             directTriggerPrioritySend](WorldRuntime &) -> int
-            {
-                if (!runtimeGuard)
-                    return eWorldClosed;
-                if (actionSourceOverride.active)
-                {
-                    const unsigned short previousActionSource = runtimeGuard->currentActionSource();
-                    runtimeGuard->setCurrentActionSource(actionSourceOverride.source);
-                    [[maybe_unused]] const auto restoreActionSource = qScopeGuard(
-                        [runtimeGuard, previousActionSource]
-                        {
-                            if (runtimeGuard)
-                                runtimeGuard->setCurrentActionSource(previousActionSource);
-                        });
-                    return directTriggerPrioritySend
-				                                  ? runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history)
-				                                  : runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
-                }
-                if (directTriggerPrioritySend)
-                    return runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history);
-                return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
-            });
+		    L, engine, runtime, apiName, eWorldClosed,
+		    [runtimeGuard, text, echo, queue, log, history, immediate, actionSourceOverride,
+		     directTriggerPrioritySend](WorldRuntime &) -> int
+		    {
+			    if (!runtimeGuard)
+				    return eWorldClosed;
+			    if (actionSourceOverride.active)
+			    {
+				    const unsigned short previousActionSource = runtimeGuard->currentActionSource();
+				    runtimeGuard->setCurrentActionSource(actionSourceOverride.source);
+				    [[maybe_unused]] const auto restoreActionSource = qScopeGuard(
+				        [runtimeGuard, previousActionSource]
+				        {
+					        if (runtimeGuard)
+						        runtimeGuard->setCurrentActionSource(previousActionSource);
+				        });
+				    return directTriggerPrioritySend
+				               ? runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history)
+				               : runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
+			    }
+			    if (directTriggerPrioritySend)
+				    return runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history);
+			    return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
+		    });
 		if (lua_tointeger(L, -results) == eOK)
 			updateCallbackSendCommandSnapshots(engine, runtime, text, echo, queue, log, immediate);
 		return results;
@@ -30736,14 +30707,14 @@ static int pushDispatchSendCommandResult(lua_State *L, const LuaCallbackEngine *
 
 	const QPointer<WorldRuntime> runtimeGuard(runtime);
 	const int                    result = runOnRuntimeThreadDeferredMutation(
-        engine, runtime,
-        [runtimeGuard, text, echo, queue, log, history, immediate]() -> int
-        {
-            if (!runtimeGuard)
-                return eWorldClosed;
-            return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
-        },
-        eWorldClosed);
+	    engine, runtime,
+	    [runtimeGuard, text, echo, queue, log, history, immediate]() -> int
+	    {
+		    if (!runtimeGuard)
+			    return eWorldClosed;
+		    return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
+	    },
+	    eWorldClosed);
 	lua_pushnumber(L, result);
 	return 1;
 }
@@ -30884,7 +30855,7 @@ static int luaConnect(lua_State *L)
 		}
 		const QString host = resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("site"));
 		const auto    port = static_cast<quint16>(
-            resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("port")).toUInt());
+		    resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("port")).toUInt());
 		enqueueRuntimeThreadDeferredMutationNoResult(engine, runtime,
 		                                             [host, port](WorldRuntime &targetRuntime)
 		                                             { targetRuntime.connectToWorld(host, port); });
@@ -31234,12 +31205,12 @@ static int pushAcceleratorRegistrationResult(lua_State *L, const LuaCallbackEngi
 
 		const QString pluginId = engine ? engine->pluginId() : QString();
 		const int     results  = enqueueRuntimeThreadAsyncOkStatusResult(
-            L, engine, runtime, apiName, eWorldClosed,
-            [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
-            {
-                return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo,
-			                                                   pluginId);
-            });
+		    L, engine, runtime, apiName, eWorldClosed,
+		    [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
+		    {
+			    return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo,
+			                                              pluginId);
+		    });
 		if (lua_tointeger(L, -results) == eOK)
 		{
 			if (remove)
@@ -31252,12 +31223,12 @@ static int pushAcceleratorRegistrationResult(lua_State *L, const LuaCallbackEngi
 
 	const QString pluginId = engine ? engine->pluginId() : QString();
 	const int     result   = runOnRuntimeThreadDeferredMutation(
-        engine, runtime,
-        [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
-        {
-            return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo, pluginId);
-        },
-        eWorldClosed);
+	    engine, runtime,
+	    [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
+	    {
+		    return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo, pluginId);
+	    },
+	    eWorldClosed);
 	lua_pushnumber(L, result);
 	return 1;
 }
@@ -31353,7 +31324,7 @@ static int luaAcceleratorList(lua_State *L)
 		const auto    keyCode   = static_cast<quint16>(row.key & 0xFFFF);
 		const auto    virt      = static_cast<quint32>(row.key >> 16 & 0xFFFFFFFF);
 		const QString keyString = AcceleratorUtils::acceleratorToString(virt, keyCode);
-		const QString line      = QStringLiteral("%1 = %2%3")
+		const QString line = QStringLiteral("%1 = %2%3")
 		                         .arg(keyString.isEmpty() ? QStringLiteral("<unknown>") : keyString, row.text,
 		                              acceleratorSendTag(row.sendTo));
 		const QByteArray bytes = line.toUtf8();
@@ -31476,26 +31447,26 @@ static int luaGetLinesInBufferCount(lua_State *L)
 	WorldRuntime::LineEntry currentEntry;
 	bool                    hasLineEntry = false;
 	const bool              resolved =
-        inCallback ? runOnRuntimeThreadNoDeferredFlush(
-                         runtime,
-                         [&]() -> bool
-                         {
-                             lineCount = runtime->luaContextLinesInBufferCount();
-                             if (lineCount > 0)
-                                 hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
-                             return true;
-                         },
-                         false)
-	                            : runOnRuntimeThread(
-                         runtime,
-                         [&]() -> bool
-                         {
-                             lineCount = runtime->luaContextLinesInBufferCount();
-                             if (lineCount > 0)
-                                 hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
-                             return true;
-                         },
-                         false);
+	    inCallback ? runOnRuntimeThreadNoDeferredFlush(
+	                     runtime,
+	                     [&]() -> bool
+	                     {
+		                     lineCount = runtime->luaContextLinesInBufferCount();
+		                     if (lineCount > 0)
+			                     hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
+		                     return true;
+	                     },
+	                     false)
+	               : runOnRuntimeThread(
+	                     runtime,
+	                     [&]() -> bool
+	                     {
+		                     lineCount = runtime->luaContextLinesInBufferCount();
+		                     if (lineCount > 0)
+			                     hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
+		                     return true;
+	                     },
+	                     false);
 	if (resolved)
 	{
 		cacheCallbackLineCount(engine, lineCount);
@@ -31753,7 +31724,7 @@ static int luaGetTrace(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const bool                            enabled =
-        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.traceEnabled : false;
+	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.traceEnabled : false;
 	lua_pushboolean(L, enabled);
 	return 1;
 }
@@ -31946,9 +31917,9 @@ static WorldRuntime *findWorldRuntimeByAttribute(const LuaCallbackEngine *engine
 	                             {
 		                             auto         *mutableRuntime = const_cast<WorldRuntime *>(runtime);
 		                             const QString attr           = runOnRuntimeThread(
-                                         mutableRuntime, [mutableRuntime, &attributeName]() -> QString
-                                         { return mutableRuntime->worldAttributeValue(attributeName); },
-                                         QString());
+		                                 mutableRuntime, [mutableRuntime, &attributeName]() -> QString
+		                                 { return mutableRuntime->worldAttributeValue(attributeName); },
+		                                 QString());
 		                             return attr.compare(value, Qt::CaseInsensitive) == 0;
 	                             });
 }
@@ -33219,7 +33190,7 @@ static QVariant resolvePluginInfoValueForApi(const LuaCallbackEngine *engine, Wo
 	}
 	const QString selfPluginId      = engine->pluginId().trimmed();
 	const bool    targetsSelfPlugin = !selfPluginId.isEmpty() && effectivePluginId.trimmed().compare(
-                                                                  selfPluginId, Qt::CaseInsensitive) == 0;
+	                                                                 selfPluginId, Qt::CaseInsensitive) == 0;
 	if (targetsSelfPlugin)
 	{
 		if (infoType == 1)
@@ -36300,12 +36271,12 @@ static int luaSetTriggerOption(lua_State *L)
 	{
 		const QString textValue = luaOptionValue(L, 3);
 		const int     result    = applyTriggerMutation(
-            [textValue](WorldRuntime::Trigger &trigger) -> int
-            {
-                trigger.children.insert(QStringLiteral("send"), textValue);
-                applyTriggerDefaults(trigger);
-                return eOK;
-            });
+		    [textValue](WorldRuntime::Trigger &trigger) -> int
+		    {
+			    trigger.children.insert(QStringLiteral("send"), textValue);
+			    applyTriggerDefaults(trigger);
+			    return eOK;
+		    });
 		lua_pushnumber(L, result);
 		return 1;
 	}
@@ -36638,12 +36609,12 @@ static int luaSetAliasOption(lua_State *L)
 	{
 		const QString textValue = luaOptionValue(L, 3);
 		const int     result    = applyAliasMutation(
-            [textValue](WorldRuntime::Alias &alias) -> int
-            {
-                alias.children.insert(QStringLiteral("send"), textValue);
-                applyAliasDefaults(alias);
-                return eOK;
-            });
+		    [textValue](WorldRuntime::Alias &alias) -> int
+		    {
+			    alias.children.insert(QStringLiteral("send"), textValue);
+			    applyAliasDefaults(alias);
+			    return eOK;
+		    });
 		lua_pushnumber(L, result);
 		return 1;
 	}
@@ -36878,12 +36849,12 @@ static int luaSetTimerOption(lua_State *L)
 	{
 		const QString textValue = luaOptionValue(L, 3);
 		const int     result    = applyTimerMutation(
-            [textValue](WorldRuntime::Timer &timer) -> int
-            {
-                timer.children.insert(QStringLiteral("send"), textValue);
-                applyTimerDefaults(timer);
-                return eOK;
-            });
+		    [textValue](WorldRuntime::Timer &timer) -> int
+		    {
+			    timer.children.insert(QStringLiteral("send"), textValue);
+			    applyTimerDefaults(timer);
+			    return eOK;
+		    });
 		lua_pushnumber(L, result);
 		return 1;
 	}
@@ -38460,22 +38431,22 @@ static int luaArrayExport(lua_State *L)
 	QStringList keys;
 	QStringList values;
 	const int   status = runOnRuntimeThread(
-        runtime,
-        [&]() -> int
-        {
-            if (!runtime->arrayExists(name))
-                return eArrayDoesNotExist;
-            keys = runtime->arrayListKeys(name);
-            values.reserve(keys.size());
-            for (const QString &key : keys)
-            {
-                QString value;
-                runtime->arrayGet(name, key, value);
-                values.push_back(value);
-            }
-            return eOK;
-        },
-        eBadParameter);
+	    runtime,
+	    [&]() -> int
+	    {
+		    if (!runtime->arrayExists(name))
+			    return eArrayDoesNotExist;
+		    keys = runtime->arrayListKeys(name);
+		    values.reserve(keys.size());
+		    for (const QString &key : keys)
+		    {
+			    QString value;
+			    runtime->arrayGet(name, key, value);
+			    values.push_back(value);
+		    }
+		    return eOK;
+	    },
+	    eBadParameter);
 	if (status != eOK)
 	{
 		lua_pushnumber(L, status);
@@ -38569,15 +38540,15 @@ static int luaArrayExportKeys(lua_State *L)
 	}
 	QStringList keys;
 	const int   status = runOnRuntimeThread(
-        runtime,
-        [&]() -> int
-        {
-            if (!runtime->arrayExists(name))
-                return eArrayDoesNotExist;
-            keys = runtime->arrayListKeys(name);
-            return eOK;
-        },
-        eBadParameter);
+	    runtime,
+	    [&]() -> int
+	    {
+		    if (!runtime->arrayExists(name))
+			    return eArrayDoesNotExist;
+		    keys = runtime->arrayListKeys(name);
+		    return eOK;
+	    },
+	    eBadParameter);
 	if (status != eOK)
 	{
 		lua_pushnumber(L, status);
@@ -38921,22 +38892,22 @@ static int luaArrayList(lua_State *L)
 	QStringList      keys;
 	QVector<QString> values;
 	const bool       exists = runOnRuntimeThread(
-        runtime,
-        [&]() -> bool
-        {
-            if (!runtime->arrayExists(name))
-                return false;
-            keys = runtime->arrayListKeys(name);
-            values.reserve(keys.size());
-            for (const QString &key : keys)
-            {
-                QString value;
-                runtime->arrayGet(name, key, value);
-                values.push_back(value);
-            }
-            return true;
-        },
-        false);
+	    runtime,
+	    [&]() -> bool
+	    {
+		    if (!runtime->arrayExists(name))
+			    return false;
+		    keys = runtime->arrayListKeys(name);
+		    values.reserve(keys.size());
+		    for (const QString &key : keys)
+		    {
+			    QString value;
+			    runtime->arrayGet(name, key, value);
+			    values.push_back(value);
+		    }
+		    return true;
+	    },
+	    false);
 	if (!exists)
 		return 0;
 	lua_newtable(L);
@@ -38973,14 +38944,14 @@ static int enqueueDatabaseAsyncStatusResult(lua_State *L, const LuaCallbackEngin
 	auto          okCopy           = DecayedOkFunc(std::forward<OkFunc>(okFunc));
 	auto          payloadCopy      = DecayedPayloadFunc(std::forward<PayloadFunc>(payloadFunc));
 	const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-        engine, runtime,
-        [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy), okCopy = std::move(okCopy),
-         payloadCopy = std::move(payloadCopy)](WorldRuntime &targetRuntime) mutable
-        {
-            const int status = funcCopy(targetRuntime);
-            emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
-		                                     payloadCopy(status));
-        });
+	    engine, runtime,
+	    [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy), okCopy = std::move(okCopy),
+	     payloadCopy = std::move(payloadCopy)](WorldRuntime &targetRuntime) mutable
+	    {
+		    const int status = funcCopy(targetRuntime);
+		    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
+		                          payloadCopy(status));
+	    });
 	lua_pushnumber(L, accepted ? acceptedCode : enqueueFailureCode);
 	if (accepted && requestId != 0)
 	{
@@ -39183,21 +39154,21 @@ static bool resolveDatabaseColumnsForApi(const LuaCallbackEngine *engine, WorldR
 		return false;
 	int        resolvedColumns = eBadParameter;
 	const bool resolved        = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedColumns = runtime->databaseColumns(name);
-                                               return true;
-                                           },
-                                           false)
+	                                              runtime,
+	                                              [&]() -> bool
+	                                              {
+		                                       resolvedColumns = runtime->databaseColumns(name);
+		                                       return true;
+	                                              },
+	                                              false)
 	                                        : runOnRuntimeThread(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedColumns = runtime->databaseColumns(name);
-                                               return true;
-                                           },
-                                           false);
+	                                              runtime,
+	                                              [&]() -> bool
+	                                              {
+		                                       resolvedColumns = runtime->databaseColumns(name);
+		                                       return true;
+	                                              },
+	                                              false);
 	if (!resolved)
 		return false;
 	columns = resolvedColumns;
@@ -39270,9 +39241,9 @@ static bool resolveDatabaseColumnNameForApi(const LuaCallbackEngine *engine, Wor
 		bool snapshotAvailable = false;
 		if (const auto *database = callbackDatabaseSnapshotForApi(engine, name, snapshotAvailable))
 		{
-			const bool found = database->stmtPrepared && column >= 1 &&
-			                   column <= database->columnNames.size() &&
-			                   !database->columnNames.at(column - 1).isEmpty();
+			const bool    found    = database->stmtPrepared && column >= 1 &&
+			                         column <= database->columnNames.size() &&
+			                         !database->columnNames.at(column - 1).isEmpty();
 			const QString resolved = found ? database->columnNames.at(column - 1) : QString();
 			cacheCallbackDatabaseColumnName(engine, name, column, found, resolved);
 			if (!found)
@@ -39352,21 +39323,21 @@ static bool resolveDatabaseColumnTextForApi(const LuaCallbackEngine *engine, Wor
 	QString    resolvedColumnText = {};
 	const bool resolved           = inCallback
 	                                    ? runOnRuntimeThreadNoDeferredFlush(
-                                    runtime,
-                                    [&]() -> bool
-                                    {
-                                        resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
-                                        return true;
-                                    },
-                                    false)
+	                                          runtime,
+	                                          [&]() -> bool
+	                                          {
+		                                resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
+		                                return true;
+	                                          },
+	                                          false)
 	                                    : runOnRuntimeThread(
-                                    runtime,
-                                    [&]() -> bool
-                                    {
-                                        resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
-                                        return true;
-                                    },
-                                    false);
+	                                          runtime,
+	                                          [&]() -> bool
+	                                          {
+		                                resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
+		                                return true;
+	                                          },
+	                                          false);
 	if (!resolved)
 		return false;
 	cacheCallbackDatabaseColumnText(engine, name, column, ok, resolvedColumnText);
@@ -39461,21 +39432,21 @@ static bool resolveDatabaseColumnTypeForApi(const LuaCallbackEngine *engine, Wor
 		return false;
 	int        resolvedType = eBadParameter;
 	const bool resolved     = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedType = runtime->databaseColumnType(name, column);
-                                               return true;
-                                           },
-                                           false)
+	                                           runtime,
+	                                           [&]() -> bool
+	                                           {
+		                                       resolvedType = runtime->databaseColumnType(name, column);
+		                                       return true;
+	                                           },
+	                                           false)
 	                                     : runOnRuntimeThread(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedType = runtime->databaseColumnType(name, column);
-                                               return true;
-                                           },
-                                           false);
+	                                           runtime,
+	                                           [&]() -> bool
+	                                           {
+		                                       resolvedType = runtime->databaseColumnType(name, column);
+		                                       return true;
+	                                           },
+	                                           false);
 	if (!resolved)
 		return false;
 	columnType = resolvedType;
@@ -39508,21 +39479,21 @@ static bool resolveDatabaseTotalChangesForApi(const LuaCallbackEngine *engine, W
 		return false;
 	int        resolvedChanges = eBadParameter;
 	const bool resolved        = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedChanges = runtime->databaseTotalChanges(name);
-                                               return true;
-                                           },
-                                           false)
+	                                              runtime,
+	                                              [&]() -> bool
+	                                              {
+		                                       resolvedChanges = runtime->databaseTotalChanges(name);
+		                                       return true;
+	                                              },
+	                                              false)
 	                                        : runOnRuntimeThread(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedChanges = runtime->databaseTotalChanges(name);
-                                               return true;
-                                           },
-                                           false);
+	                                              runtime,
+	                                              [&]() -> bool
+	                                              {
+		                                       resolvedChanges = runtime->databaseTotalChanges(name);
+		                                       return true;
+	                                              },
+	                                              false);
 	if (!resolved)
 		return false;
 	changes = resolvedChanges;
@@ -39555,21 +39526,21 @@ static bool resolveDatabaseChangesForApi(const LuaCallbackEngine *engine, WorldR
 		return false;
 	int        resolvedChanges = eBadParameter;
 	const bool resolved        = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedChanges = runtime->databaseChanges(name);
-                                               return true;
-                                           },
-                                           false)
+	                                              runtime,
+	                                              [&]() -> bool
+	                                              {
+		                                       resolvedChanges = runtime->databaseChanges(name);
+		                                       return true;
+	                                              },
+	                                              false)
 	                                        : runOnRuntimeThread(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedChanges = runtime->databaseChanges(name);
-                                               return true;
-                                           },
-                                           false);
+	                                              runtime,
+	                                              [&]() -> bool
+	                                              {
+		                                       resolvedChanges = runtime->databaseChanges(name);
+		                                       return true;
+	                                              },
+	                                              false);
 	if (!resolved)
 		return false;
 	changes = resolvedChanges;
@@ -39648,21 +39619,21 @@ static bool resolveDatabaseListForApi(const LuaCallbackEngine *engine, WorldRunt
 		return false;
 	QStringList resolvedDatabaseNames;
 	const bool  resolved = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedDatabaseNames = runtime->databaseList();
-                                               return true;
-                                           },
-                                           false)
+	                                        runtime,
+	                                        [&]() -> bool
+	                                        {
+		                                       resolvedDatabaseNames = runtime->databaseList();
+		                                       return true;
+	                                        },
+	                                        false)
 	                                  : runOnRuntimeThread(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedDatabaseNames = runtime->databaseList();
-                                               return true;
-                                           },
-                                           false);
+	                                        runtime,
+	                                        [&]() -> bool
+	                                        {
+		                                       resolvedDatabaseNames = runtime->databaseList();
+		                                       return true;
+	                                        },
+	                                        false);
 	if (!resolved)
 		return false;
 	databaseNames = resolvedDatabaseNames;
@@ -39786,21 +39757,21 @@ static bool resolveDatabaseColumnNamesForApi(const LuaCallbackEngine *engine, Wo
 		return false;
 	QStringList resolvedNames;
 	const bool  resolved = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedNames = runtime->databaseColumnNames(name);
-                                               return true;
-                                           },
-                                           false)
+	                                        runtime,
+	                                        [&]() -> bool
+	                                        {
+		                                       resolvedNames = runtime->databaseColumnNames(name);
+		                                       return true;
+	                                        },
+	                                        false)
 	                                  : runOnRuntimeThread(
-                                           runtime,
-                                           [&]() -> bool
-                                           {
-                                               resolvedNames = runtime->databaseColumnNames(name);
-                                               return true;
-                                           },
-                                           false);
+	                                        runtime,
+	                                        [&]() -> bool
+	                                        {
+		                                       resolvedNames = runtime->databaseColumnNames(name);
+		                                       return true;
+	                                        },
+	                                        false);
 	if (!resolved)
 		return false;
 	const bool found = !resolvedNames.isEmpty();
@@ -39865,11 +39836,11 @@ static bool resolveDatabaseColumnValuesForApi(const LuaCallbackEngine *engine, W
 	QVector<QVariant> resolvedValues;
 	const bool        found     = inCallback
 	                                  ? runOnRuntimeThreadNoDeferredFlush(
-                                 runtime, [&]() -> bool
-                                 { return runtime->databaseColumnValues(name, resolvedValues); }, false)
+	                                        runtime, [&]() -> bool
+	                                        { return runtime->databaseColumnValues(name, resolvedValues); }, false)
 	                                  : runOnRuntimeThread(
-                                 runtime, [&]() -> bool
-                                 { return runtime->databaseColumnValues(name, resolvedValues); }, false);
+	                                        runtime, [&]() -> bool
+	                                        { return runtime->databaseColumnValues(name, resolvedValues); }, false);
 	const bool        hasValues = found && !resolvedValues.isEmpty();
 	cacheCallbackDatabaseColumnValues(engine, name, hasValues, resolvedValues);
 	if (!hasValues)
@@ -40294,43 +40265,43 @@ static int luaDatabaseGetField(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-            engine, runtime,
-            [name, sql, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-            {
-                QVariant value;
-                QString  payload = QStringLiteral("null:");
-                int      status  = targetRuntime.databasePrepare(name, sql);
-                bool     ok      = status == SQLITE_OK;
-                if (ok)
-                {
-                    const auto finalize =
-                        qScopeGuard([&]() { static_cast<void>(targetRuntime.databaseFinalize(name)); });
-                    status = targetRuntime.databaseStep(name);
-                    if (status == SQLITE_ROW)
-                    {
-                        if (targetRuntime.databaseColumnValue(name, 1, value))
-                        {
-                            status  = eOK;
-                            payload = encodeDatabaseFieldAsyncPayload(value);
-                        }
-                        else
-                        {
-                            status = kDbErrorColumnOutOfRange;
-                            ok     = false;
-                        }
-                    }
-                    else if (status == SQLITE_DONE)
-                    {
-                        status = eOK;
-                    }
-                    else
-                    {
-                        ok = false;
-                    }
-                }
-                emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-			                                     QStringLiteral("DatabaseGetField"), ok, status, payload);
-            });
+		    engine, runtime,
+		    [name, sql, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+		    {
+			    QVariant value;
+			    QString  payload = QStringLiteral("null:");
+			    int      status  = targetRuntime.databasePrepare(name, sql);
+			    bool     ok      = status == SQLITE_OK;
+			    if (ok)
+			    {
+				    const auto finalize =
+				        qScopeGuard([&]() { static_cast<void>(targetRuntime.databaseFinalize(name)); });
+				    status = targetRuntime.databaseStep(name);
+				    if (status == SQLITE_ROW)
+				    {
+					    if (targetRuntime.databaseColumnValue(name, 1, value))
+					    {
+						    status  = eOK;
+						    payload = encodeDatabaseFieldAsyncPayload(value);
+					    }
+					    else
+					    {
+						    status = kDbErrorColumnOutOfRange;
+						    ok     = false;
+					    }
+				    }
+				    else if (status == SQLITE_DONE)
+				    {
+					    status = eOK;
+				    }
+				    else
+				    {
+					    ok = false;
+				    }
+			    }
+			    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+			                          QStringLiteral("DatabaseGetField"), ok, status, payload);
+		    });
 		lua_pushnil(L);
 		if (accepted && requestId != 0)
 		{
@@ -40948,15 +40919,15 @@ static int luaCallPlugin(lua_State *L)
 
 		const int                    callerTopBefore = lua_gettop(L);
 		const LuaBatchDispatchResult dispatchResult  = runtime->dispatchLuaCallPluginMarshalling(
-            QSharedPointer<LuaCallbackEngine>(targetEngine, [](LuaCallbackEngine  */*unused*/) {}), routine,
-            L, 1, engine->pluginId(), callPluginMiniWindowSnapshot);
+		    QSharedPointer<LuaCallbackEngine>(targetEngine, [](LuaCallbackEngine  */*unused*/) {}), routine,
+		    L, 1, engine->pluginId(), callPluginMiniWindowSnapshot);
 		const bool marshallingExecuted = dispatchResult.boolResultValid ? dispatchResult.boolResult : false;
 		const bool sameState           = dispatchResult.marshallingSameState;
 		CallPluginLuaMarshallingResult marshalling;
-		marshalling.error        = dispatchResult.marshallingErrorValid
-		                               ? static_cast<CallPluginLuaMarshallingError>(dispatchResult.marshallingError)
-		                               : CallPluginLuaMarshallingError::NoSuchRoutine;
-		marshalling.index        = dispatchResult.marshallingIndex;
+		marshalling.error = dispatchResult.marshallingErrorValid
+		                        ? static_cast<CallPluginLuaMarshallingError>(dispatchResult.marshallingError)
+		                        : CallPluginLuaMarshallingError::NoSuchRoutine;
+		marshalling.index = dispatchResult.marshallingIndex;
 		marshalling.typeName     = dispatchResult.marshallingTypeName;
 		marshalling.runtimeError = dispatchResult.marshallingRuntimeError;
 		marshalling.returnCount  = dispatchResult.marshallingReturnCount;
@@ -40977,8 +40948,8 @@ static int luaCallPlugin(lua_State *L)
 			lua_pushnumber(L, eBadParameter);
 			const int     displayIndex = marshalling.index - 1 + 3; // plugin ID + routine removed
 			const QString error        = QStringLiteral("Cannot pass argument #%1 (%2 type) to CallPlugin")
-			                          .arg(displayIndex)
-			                          .arg(QString::fromLatin1(marshalling.typeName));
+			                                 .arg(displayIndex)
+			                                 .arg(QString::fromLatin1(marshalling.typeName));
 			pushLuaUtf8String(L, error);
 			return 2;
 		}
@@ -42633,8 +42604,8 @@ static int luaWindowOutputText(lua_State *L)
 				    {
 					    WorldRuntime::WindowOutputMetrics deferredMetrics;
 					    const int                         deferredResult = targetRuntime.windowOutputText(
-                            name, fontId, text, left, top, right, bottom, colour, mouseUp, hotspotPrefix,
-                            pluginId, &deferredMetrics);
+					        name, fontId, text, left, top, right, bottom, colour, mouseUp, hotspotPrefix,
+					        pluginId, &deferredMetrics);
 					    emitPluginAsyncResult(
 					        targetRuntime, pluginId, asyncRequestId, QStringLiteral("WindowOutputText"),
 					        deferredResult == eOK, deferredResult,
@@ -43408,8 +43379,8 @@ static int luaWindowBlendImage(lua_State *L)
 		}
 		const quint32 randomSeed     = QRandomGenerator::global()->generate();
 		const int     callbackResult = MiniWindowUtils::blendImage(
-            *shadow, imageId, left, top, right, bottom, mode, opacity, srcLeft, srcTop, srcRight, srcBottom,
-            callbackMiniWindowSeededRandomUnit(randomSeed));
+		    *shadow, imageId, left, top, right, bottom, mode, opacity, srcLeft, srcTop, srcRight, srcBottom,
+		    callbackMiniWindowSeededRandomUnit(randomSeed));
 		if (callbackResult != eOK)
 		{
 			lua_pushnumber(L, callbackResult);
@@ -43605,13 +43576,13 @@ static int luaWindowWrite(lua_State *L)
 			const QString callbackPluginId = engine->pluginId();
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-                engine, runtime,
-                [name, trimmedFileName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-                {
-                    const int status = targetRuntime.windowWrite(name, trimmedFileName);
-                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                              QStringLiteral("WindowWrite"), status == eOK, status, QString());
-                });
+			    engine, runtime,
+			    [name, trimmedFileName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+			    {
+				    const int status = targetRuntime.windowWrite(name, trimmedFileName);
+				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                          QStringLiteral("WindowWrite"), status == eOK, status, QString());
+			    });
 			lua_pushnumber(L, accepted ? eOK : eBadParameter);
 			if (accepted && requestId != 0)
 			{
@@ -44619,393 +44590,12 @@ static void extendLuaPackagePath(lua_State *L, const QString &appDir)
 }
 #endif
 
-#ifdef QMUD_LUACALLBACKENGINE_TEST_MINIMAL_BINDINGS
-static int luaTestGetInfo(lua_State *L)
-{
-	auto *engine = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	if (!engine)
-	{
-		lua_pushnil(L);
-		return 1;
-	}
-	WorldRuntime *runtime  = engine->worldRuntimeForBridgedCall();
-	const int     infoType = static_cast<int>(luaL_checkinteger(L, 1));
-	if (infoType == 56)
-	{
-		pushLuaString(L, qmudHomeDirectoryForGetInfo56(engine));
-		return 1;
-	}
-	if (!runtime)
-	{
-		lua_pushnil(L);
-		return 1;
-	}
-	if (infoType == 86)
-	{
-		if (const auto *snapshot = engine->currentDispatchMiniWindowSnapshot();
-		    snapshot && snapshot->commandUiHasFrameData &&
-		    snapshot->commandUiValues.value(QStringLiteral("selectedWordResolved")).toBool())
-		{
-			const QByteArray bytes =
-			    snapshot->commandUiValues.value(QStringLiteral("selectedWord")).toString().toLocal8Bit();
-			lua_pushlstring(L, bytes.constData(), bytes.size());
-			return 1;
-		}
-		pushLuaUtf8String(L, "");
-		return 1;
-	}
-	if (infoType >= 290 && infoType <= 293)
-	{
-		const auto *snapshot = engine->currentDispatchMiniWindowSnapshot();
-		if (!snapshot)
-		{
-			lua_pushnumber(L, 0);
-			return 1;
-		}
-		const QString key = [infoType]()
-		{
-			switch (infoType)
-			{
-			case 290:
-				return QStringLiteral("outputTextRectLeft");
-			case 291:
-				return QStringLiteral("outputTextRectTop");
-			case 292:
-				return QStringLiteral("outputTextRectRight");
-			default:
-				return QStringLiteral("outputTextRectBottom");
-			}
-		}();
-		lua_pushnumber(L, snapshot->commandUiValues.value(key).toInt());
-		return 1;
-	}
-	if (infoType == 283 || infoType == 284)
-	{
-		const auto *snapshot = engine->currentDispatchMiniWindowSnapshot();
-		if (!snapshot)
-		{
-			lua_pushnumber(L, -1);
-			return 1;
-		}
-		const QString key = (infoType == 283) ? QStringLiteral("lastMouseX") : QStringLiteral("lastMouseY");
-		lua_pushnumber(L, snapshot->commandUiValues.value(key, -1).toInt());
-		return 1;
-	}
-
-	const auto pushRelative = [L, engine](const QString &path, const bool trailingSlash)
-	{
-		pushLuaString(L, qmudHomeRelativePathForGetInfo(engine, path, trailingSlash));
-		return 1;
-	};
-	const auto pushAttribute = [&](const QString &key, const bool trailingSlash)
-	{ return pushRelative(runtime->worldAttributeValue(key), trailingSlash); };
-
-	switch (infoType)
-	{
-	case 9:
-		return pushAttribute(QStringLiteral("new_activity_sound"), false);
-	case 10:
-		return pushAttribute(QStringLiteral("script_editor"), false);
-	case 35:
-		return pushAttribute(QStringLiteral("script_filename"), false);
-	case 40:
-		return pushAttribute(QStringLiteral("auto_log_file_name"), false);
-	case 50:
-		return pushAttribute(QStringLiteral("beep_sound"), false);
-	case 59:
-	case 64:
-		return pushRelative(qmudHomeForLuaFileApi(engine), true);
-	case 78:
-		return pushAttribute(QStringLiteral("foreground_image"), false);
-	case 79:
-		return pushAttribute(QStringLiteral("background_image"), false);
-	default:
-		break;
-	}
-
-	const WorldRuntime::RuntimeCountersSnapshot snapshot = runtime->runtimeCountersSnapshot(true);
-	switch (infoType)
-	{
-	case 51:
-		return pushRelative(snapshot.logFileName, false);
-	case 54:
-		return pushRelative(snapshot.worldFilePath, false);
-	case 57:
-		return pushRelative(snapshot.defaultWorldDirectory, true);
-	case 58:
-		return pushRelative(snapshot.defaultLogDirectory, true);
-	case 60:
-		return pushRelative(snapshot.pluginsDirectory, true);
-	case 66:
-	case 68:
-		return pushRelative(snapshot.startupDirectory, true);
-	case 67:
-		return pushRelative(
-		    QFileInfo(QMudPluginPathUtils::normalizeSeparators(snapshot.worldFilePath)).path(), true);
-	case 69:
-		return pushRelative(snapshot.translatorFile, false);
-	case 74:
-		return pushRelative(QDir(snapshot.startupDirectory).filePath(QStringLiteral("sounds")), true);
-	case 76:
-		return pushRelative(snapshot.firstSpecialFontPath, false);
-	case 82:
-		return pushRelative(snapshot.preferencesDatabaseName, false);
-	case 84:
-		return pushRelative(snapshot.fileBrowsingDirectory, true);
-	case 85:
-		return pushRelative(snapshot.stateFilesDirectory, true);
-	default:
-		lua_pushnil(L);
-		return 1;
-	}
-}
-
-static int luaTestNote(lua_State *L)
-{
-	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	WorldRuntime *runtime = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
-	if (!runtime)
-		return 0;
-	const QString text = QString::fromUtf8(luaL_optstring(L, 1, ""));
-	enqueueRuntimeThreadDeferredMutationNoResult(engine, runtime, [text](WorldRuntime &targetRuntime)
-	                                             { targetRuntime.outputText(text, true, true); });
-	return 0;
-}
-
-static int luaTestSaveState(lua_State *L)
-{
-	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	WorldRuntime *runtime = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
-	if (!runtime)
-	{
-		lua_pushnumber(L, ePluginCouldNotSaveState);
-		return 1;
-	}
-	const QString pluginId = engine->pluginId();
-	enqueueRuntimeThreadDeferredMutationNoResult(
-	    engine, runtime, [pluginId](WorldRuntime &targetRuntime)
-	    { static_cast<void>(targetRuntime.savePluginState(pluginId, true)); });
-	lua_pushnumber(L, eOK);
-	lua_pushnumber(L, 1);
-	return 2;
-}
-
-static int luaTestWindowCreate(lua_State *L)
-{
-	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	WorldRuntime *runtime = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
-	if (!runtime)
-	{
-		lua_pushnumber(L, eNoSuchWindow);
-		return 1;
-	}
-	const QString name     = QString::fromUtf8(luaL_checkstring(L, 1));
-	const int     left     = static_cast<int>(luaL_checkinteger(L, 2));
-	const int     top      = static_cast<int>(luaL_checkinteger(L, 3));
-	const int     width    = static_cast<int>(luaL_checkinteger(L, 4));
-	const int     height   = static_cast<int>(luaL_checkinteger(L, 5));
-	const int     position = static_cast<int>(luaL_checkinteger(L, 6));
-	const int     flags    = static_cast<int>(luaL_checkinteger(L, 7));
-	const QString pluginId = engine->pluginId();
-	enqueueRuntimeThreadDeferredMutationNoResult(
-	    engine, runtime,
-	    [name, left, top, width, height, position, flags, pluginId](WorldRuntime &targetRuntime)
-	    {
-		    static_cast<void>(targetRuntime.windowCreate(name, left, top, width, height, position, flags,
-		                                                 QColor(), pluginId));
-	    });
-	lua_pushnumber(L, eOK);
-	return 1;
-}
-
-static int luaTestWindowPosition(lua_State *L)
-{
-	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	WorldRuntime *runtime = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
-	if (!runtime)
-	{
-		lua_pushnumber(L, eNoSuchWindow);
-		return 1;
-	}
-	const QString name     = QString::fromUtf8(luaL_checkstring(L, 1));
-	const int     left     = static_cast<int>(luaL_checkinteger(L, 2));
-	const int     top      = static_cast<int>(luaL_checkinteger(L, 3));
-	const int     position = static_cast<int>(luaL_checkinteger(L, 4));
-	const int     flags    = static_cast<int>(luaL_checkinteger(L, 5));
-	enqueueRuntimeThreadDeferredMutationNoResult(
-	    engine, runtime, [name, left, top, position, flags](WorldRuntime &targetRuntime)
-	    { static_cast<void>(targetRuntime.windowPosition(name, left, top, position, flags)); });
-	lua_pushnumber(L, eOK);
-	return 1;
-}
-
-static int luaTestWindowResize(lua_State *L)
-{
-	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	WorldRuntime *runtime = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
-	if (!runtime)
-	{
-		lua_pushnumber(L, eNoSuchWindow);
-		return 1;
-	}
-	const QString name   = QString::fromUtf8(luaL_checkstring(L, 1));
-	const int     width  = static_cast<int>(luaL_checkinteger(L, 2));
-	const int     height = static_cast<int>(luaL_checkinteger(L, 3));
-	const long    colour = static_cast<long>(luaL_optinteger(L, 4, -1));
-	enqueueRuntimeThreadDeferredMutationNoResult(
-	    engine, runtime, [name, width, height, colour](WorldRuntime &targetRuntime)
-	    { static_cast<void>(targetRuntime.windowResize(name, width, height, colour)); });
-	lua_pushnumber(L, eOK);
-	return 1;
-}
-
-static int luaTestWindowAddHotspot(lua_State *L)
-{
-	auto         *engine  = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	WorldRuntime *runtime = engine ? engine->worldRuntimeForBridgedCall() : nullptr;
-	if (!runtime)
-	{
-		lua_pushnumber(L, eNoSuchWindow);
-		return 1;
-	}
-	const QString name      = QString::fromUtf8(luaL_checkstring(L, 1));
-	const QString hotspotId = QString::fromUtf8(luaL_checkstring(L, 2));
-	const int     left      = static_cast<int>(luaL_checkinteger(L, 3));
-	const int     top       = static_cast<int>(luaL_checkinteger(L, 4));
-	const int     right     = static_cast<int>(luaL_checkinteger(L, 5));
-	const int     bottom    = static_cast<int>(luaL_checkinteger(L, 6));
-	const QString pluginId  = engine->pluginId();
-	enqueueRuntimeThreadDeferredMutationNoResult(
-	    engine, runtime,
-	    [name, hotspotId, left, top, right, bottom, pluginId](WorldRuntime &targetRuntime)
-	    {
-		    static_cast<void>(targetRuntime.windowAddHotspot(name, hotspotId, left, top, right, bottom,
-		                                                     QString(), QString(), QString(), QString(),
-		                                                     QString(), QString(), 0, 0, pluginId));
-	    });
-	lua_pushnumber(L, eOK);
-	return 1;
-}
-
-static int luaTestWindowList(lua_State *L)
-{
-	auto *engine = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	if (const auto *snapshot = engine ? engine->currentDispatchMiniWindowSnapshot() : nullptr)
-		return pushOptionalStringList(L, snapshot->windowNames);
-	return pushOptionalStringList(L, QStringList());
-}
-
-static int luaTestWindowInfo(lua_State *L)
-{
-	auto         *engine   = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	const QString name     = QString::fromUtf8(luaL_checkstring(L, 1));
-	const int     info     = static_cast<int>(luaL_checkinteger(L, 2));
-	const auto   *snapshot = engine ? engine->currentDispatchMiniWindowSnapshot() : nullptr;
-	const auto    window   = snapshot ? snapshot->windowInfoByWindow.value(name)
-	                                  : LuaCallbackMiniWindowSnapshot::WindowInfoSnapshot{};
-	QVariant      value;
-	switch (info)
-	{
-	case 1:
-		value = window.locationX;
-		break;
-	case 2:
-		value = window.locationY;
-		break;
-	case 3:
-		value = window.width;
-		break;
-	case 4:
-		value = window.height;
-		break;
-	case 14:
-		value = window.lastMouseX;
-		break;
-	case 15:
-		value = window.lastMouseY;
-		break;
-	case 16:
-		value = window.lastMouseUpdate;
-		break;
-	case 17:
-		value = window.clientMouseX;
-		break;
-	case 18:
-		value = window.clientMouseY;
-		break;
-	default:
-		value = QVariant();
-		break;
-	}
-	pushVariant(L, value);
-	return 1;
-}
-
-static int luaTestWindowHotspotList(lua_State *L)
-{
-	auto         *engine = static_cast<LuaCallbackEngine *>(lua_touserdata(L, lua_upvalueindex(1)));
-	const QString name   = QString::fromUtf8(luaL_checkstring(L, 1));
-	if (const auto *snapshot = engine ? engine->currentDispatchMiniWindowSnapshot() : nullptr)
-		return pushOptionalStringList(L, snapshot->hotspotIdsByWindow.value(name));
-	return pushOptionalStringList(L, QStringList());
-}
-#endif
-
 void LuaCallbackEngine::registerWorldBindings()
 {
 #ifdef QMUD_ENABLE_LUA_SCRIPTING
 	if (!m_state)
 		return;
 
-#ifdef QMUD_LUACALLBACKENGINE_TEST_MINIMAL_BINDINGS
-	auto registerWorldFn = [this](const char *name, const lua_CFunction fn)
-	{
-		lua_pushlightuserdata(m_state, this);
-		lua_pushcclosure(m_state, fn, 1);
-		lua_setglobal(m_state, name);
-	};
-	static const LuaBindingEntry kMinimalWorldBindings[] = {
-	    {"ColourNote",            luaColourNote           },
-	    {"ColourTell",            luaColourTell           },
-	    {"GetInfo",               luaTestGetInfo          },
-	    {"GetPluginID",           luaGetPluginID          },
-	    {"GetPluginInfo",         luaGetPluginInfo        },
-	    {"GetPluginName",         luaGetPluginName        },
-	    {"GetPluginVariable",     luaGetPluginVariable    },
-	    {"GetPluginVariableList", luaGetPluginVariableList},
-	    {"Note",	              luaNote                 },
-	    {"SaveState",             luaTestSaveState        },
-	    {"Tell",	              luaTell                 },
-	    {"TestYieldModalNumber",  luaTestYieldModalNumber },
-	    {"TestYieldModalString",  luaTestYieldModalString },
-	    {"WindowAddHotspot",      luaTestWindowAddHotspot },
-	    {"WindowCreate",          luaTestWindowCreate     },
-	    {"WindowHotspotList",     luaTestWindowHotspotList},
-	    {"WindowInfo",            luaTestWindowInfo       },
-	    {"WindowList",            luaTestWindowList       },
-	    {"WindowPosition",        luaTestWindowPosition   },
-	    {"WindowResize",          luaTestWindowResize     },
-	    {nullptr,                 nullptr                 },
-	};
-	for (const LuaBindingEntry *entry = kMinimalWorldBindings; entry->name != nullptr; ++entry)
-		registerWorldFn(entry->name, entry->function);
-	registerAudioLibrary(m_state, this);
-	lua_newtable(m_state);
-	lua_pushlightuserdata(m_state, this);
-	lua_pushcclosure(m_state, luaUtilsInfo, 1);
-	lua_setfield(m_state, -2, "info");
-	lua_pushlightuserdata(m_state, this);
-	lua_pushcclosure(m_state, luaTestUtilsMultiListBox, 1);
-	lua_setfield(m_state, -2, "multilistbox");
-	lua_pushlightuserdata(m_state, this);
-	lua_pushcclosure(m_state, luaUtilsReadDir, 1);
-	lua_setfield(m_state, -2, "readdir");
-	lua_setglobal(m_state, "utils");
-	lua_pushnumber(m_state, eOK);
-	lua_setglobal(m_state, "eOK");
-	m_worldBindingsReady = true;
-	return;
-#else
 	registerErrorDescriptions(m_state);
 	registerColourNames(m_state);
 	registerExtendedColours(m_state);
@@ -45592,7 +45182,6 @@ void LuaCallbackEngine::registerWorldBindings()
 	registerCheckFunction(m_state);
 
 	m_worldBindingsReady = true;
-#endif
 #endif
 }
 

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -66,7 +66,6 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QFontDatabase>
-#include <QFontDialog>
 #include <QFontMetrics>
 #include <QGuiApplication>
 #include <QHostInfo>
@@ -793,8 +792,8 @@ namespace
 		return styleRuns ? CallbackWildcardDomain::Trigger : CallbackWildcardDomain::Alias;
 	}
 
-	void seedCallbackMiniWindowSnapshot(const LuaCallbackEngine             *engine,
-	                                    const LuaCallbackMiniWindowSnapshot *snapshot);
+	void                         seedCallbackMiniWindowSnapshot(const LuaCallbackEngine             *engine,
+	                                                            const LuaCallbackMiniWindowSnapshot *snapshot);
 
 	LuaCallbackExecutionContext *activeCallbackContext(const LuaCallbackEngine *engine)
 	{
@@ -839,10 +838,10 @@ namespace
 	}
 
 	bool
-	flushDeferredRuntimeMutationsFromContext(const LuaCallbackEngine     *engine,
-	                                         LuaCallbackExecutionContext &context, WorldRuntime *runtime,
-	                                         DeferredRuntimeMutationFlushPolicy policy =
-	                                             DeferredRuntimeMutationFlushPolicy::AllowSynchronousBridge);
+	     flushDeferredRuntimeMutationsFromContext(const LuaCallbackEngine     *engine,
+	                                              LuaCallbackExecutionContext &context, WorldRuntime *runtime,
+	                                              DeferredRuntimeMutationFlushPolicy policy =
+	                                                  DeferredRuntimeMutationFlushPolicy::AllowSynchronousBridge);
 	bool flushDeferredRuntimeMutations(const LuaCallbackEngine *engine, WorldRuntime *runtime);
 
 	void finishDeferredMiniWindowBatch(WorldRuntime *runtime)
@@ -1273,15 +1272,15 @@ namespace
 			WorldRuntime::StyleSpan span;
 			const auto              forePacked = static_cast<unsigned int>(run.textColour);
 			const auto              backPacked = static_cast<unsigned int>(run.backColour);
-			span.length = static_cast<int>(qBound(static_cast<qsizetype>(0), run.text.size(),
-			                                      static_cast<qsizetype>(std::numeric_limits<int>::max())));
-			span.fore   = QColor(static_cast<int>((forePacked >> 0u) & 0xFFu),
-			                     static_cast<int>((forePacked >> 8u) & 0xFFu),
-			                     static_cast<int>((forePacked >> 16u) & 0xFFu));
-			span.back   = QColor(static_cast<int>((backPacked >> 0u) & 0xFFu),
-			                     static_cast<int>((backPacked >> 8u) & 0xFFu),
-			                     static_cast<int>((backPacked >> 16u) & 0xFFu));
-			span.bold   = (run.style & kStyleHilite) != 0;
+			span.length    = static_cast<int>(qBound(static_cast<qsizetype>(0), run.text.size(),
+			                                         static_cast<qsizetype>(std::numeric_limits<int>::max())));
+			span.fore      = QColor(static_cast<int>((forePacked >> 0u) & 0xFFu),
+			                        static_cast<int>((forePacked >> 8u) & 0xFFu),
+			                        static_cast<int>((forePacked >> 16u) & 0xFFu));
+			span.back      = QColor(static_cast<int>((backPacked >> 0u) & 0xFFu),
+			                        static_cast<int>((backPacked >> 8u) & 0xFFu),
+			                        static_cast<int>((backPacked >> 16u) & 0xFFu));
+			span.bold      = (run.style & kStyleHilite) != 0;
 			span.underline = (run.style & kStyleUnderline) != 0;
 			span.blink     = (run.style & kStyleBlink) != 0;
 			span.inverse   = (run.style & kStyleInverse) != 0;
@@ -2155,9 +2154,9 @@ namespace
 
 	QString makeCallbackVariableValueKey(const QString &pluginId, const QString &name);
 
-	bool tryResolveCallbackVariableValueFromCache(const LuaCallbackEngine *engine, const QString &pluginId,
-	                                              const QString &name, QString &value, bool &pluginAvailable,
-	                                              bool &cacheHit)
+	bool    tryResolveCallbackVariableValueFromCache(const LuaCallbackEngine *engine, const QString &pluginId,
+	                                                 const QString &name, QString &value, bool &pluginAvailable,
+	                                                 bool &cacheHit)
 	{
 		cacheHit            = false;
 		pluginAvailable     = false;
@@ -8000,9 +7999,9 @@ namespace
 		{
 			if (snapshot->hasLineBufferCountDelta)
 			{
-				const int oldLineCount     = context->hasBufferedLineCount ? context->bufferedLineCount
-				                                                           : snapshot->lineBufferDeltaCount;
-				context->bufferedLineCount = qMax(0, snapshot->lineBufferDeltaCount);
+				const int oldLineCount        = context->hasBufferedLineCount ? context->bufferedLineCount
+				                                                              : snapshot->lineBufferDeltaCount;
+				context->bufferedLineCount    = qMax(0, snapshot->lineBufferDeltaCount);
 				context->hasBufferedLineCount = true;
 				for (int lineNumber = context->bufferedLineCount + 1; lineNumber <= oldLineCount;
 				     ++lineNumber)
@@ -8961,7 +8960,7 @@ namespace
 		const bool forbidSyncBridge = policy == DeferredRuntimeMutationFlushPolicy::ForbidSynchronousBridge ||
 		                              callbackScopeSyncBridgeForbidden();
 
-		bool       flushed = false;
+		bool flushed = false;
 		if (QThread::currentThread() != targetRuntime->thread() && forbidSyncBridge)
 		{
 			if (auto *mutableEngine = const_cast<LuaCallbackEngine *>(engine); mutableEngine)
@@ -9310,8 +9309,8 @@ namespace
 	int callbackOutputFlags(const LuaCallbackEngine *engine, WorldRuntime *runtime, const bool note,
 	                        const bool horizontalRule)
 	{
-		int           flags = horizontalRule ? WorldRuntime::LineHorizontalRule
-		                                     : (note ? WorldRuntime::LineNote : WorldRuntime::LineOutput);
+		int           flags        = horizontalRule ? WorldRuntime::LineHorizontalRule
+		                                            : (note ? WorldRuntime::LineNote : WorldRuntime::LineOutput);
 		const QString logAttribute = note ? QStringLiteral("log_notes") : QStringLiteral("log_output");
 		if (isEnabledValue(resolveWorldAttributeValueForApi(engine, runtime, logAttribute)))
 			flags |= WorldRuntime::LineLog;
@@ -10656,17 +10655,17 @@ static auto runOnMainWindowThread(Func &&func, std::invoke_result_t<Func, MainWi
 
 		auto       mutation = std::make_shared<DecayedFunc>(std::forward<Func>(func));
 		const bool queued   = QMetaObject::invokeMethod(
-		    app.data(),
-		    [mutation]() mutable
-		    {
-			    if (!mutation)
-				    return;
-			    MainWindow *frame = resolveMainWindow();
-			    if (!frame)
-				    return;
-			    static_cast<void>((*mutation)(frame));
-		    },
-		    Qt::QueuedConnection);
+            app.data(),
+            [mutation]() mutable
+            {
+                if (!mutation)
+                    return;
+                MainWindow *frame = resolveMainWindow();
+                if (!frame)
+                    return;
+                static_cast<void>((*mutation)(frame));
+            },
+            Qt::QueuedConnection);
 		if (!queued)
 		{
 			qWarning().noquote() << QStringLiteral(
@@ -10680,12 +10679,12 @@ static auto runOnMainWindowThread(Func &&func, std::invoke_result_t<Func, MainWi
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app.data(),
 	                                                         [&]
 	                                                         {
-		                                                       MainWindow *frame = resolveMainWindow();
-		                                                       if (!frame)
-			                                                       return;
-		                                                       result    = func(frame);
-		                                                       completed = true;
-	                                                         });
+                                                               MainWindow *frame = resolveMainWindow();
+                                                               if (!frame)
+                                                                   return;
+                                                               result    = func(frame);
+                                                               completed = true;
+                                                           });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] runOnMainWindowThread failed: %1")
@@ -10778,12 +10777,12 @@ template <typename Func> static MainWindowMutationDispatchResult dispatchMainWin
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app.data(),
 	                                                         [&]
 	                                                         {
-		                                                       MainWindow *frame = resolveMainWindow();
-		                                                       if (!frame)
-			                                                       return;
-		                                                       result    = (*mutation)(frame);
-		                                                       completed = true;
-	                                                         });
+                                                               MainWindow *frame = resolveMainWindow();
+                                                               if (!frame)
+                                                                   return;
+                                                               result    = (*mutation)(frame);
+                                                               completed = true;
+                                                           });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] dispatchMainWindowMutation failed: %1")
@@ -10832,9 +10831,9 @@ static auto runOnGuiThread(Func &&func, std::invoke_result_t<Func> fallbackValue
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app.data(),
 	                                                         [&]
 	                                                         {
-		                                                       result    = func();
-		                                                       completed = true;
-	                                                         });
+                                                               result    = func();
+                                                               completed = true;
+                                                           });
 	if (!bridged)
 	{
 		qWarning().noquote()
@@ -10928,9 +10927,9 @@ static bool dispatchAppControllerMutation(AppController *app, Func &&func,
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(app,
 	                                                         [&]
 	                                                         {
-		                                                       (*mutation)(*app);
-		                                                       completed = true;
-	                                                         });
+                                                               (*mutation)(*app);
+                                                               completed = true;
+                                                           });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] dispatchAppControllerMutation failed: %1")
@@ -11273,7 +11272,7 @@ LuaBatchDispatchResult LuaCallbackEngine::resumeSuspendedModalString(const quint
 	const QVector<QString> previousCallingPluginIdStack = m_callingPluginIdStack;
 	m_callingPluginIdStack                              = suspended->callingPluginIdStack;
 	const auto restoreCallingPluginIdStack              = qScopeGuard(
-	    [this, previousCallingPluginIdStack] { m_callingPluginIdStack = previousCallingPluginIdStack; });
+        [this, previousCallingPluginIdStack] { m_callingPluginIdStack = previousCallingPluginIdStack; });
 	Q_UNUSED(restoreCallingPluginIdStack);
 
 	pushActiveCallbackContext(this, std::move(suspended->context));
@@ -11320,8 +11319,8 @@ LuaBatchDispatchResult LuaCallbackEngine::resumeSuspendedModalString(const quint
 	}
 
 	LuaCallbackExecutionContext completedContext = takeActiveCallbackContext(this);
-	const auto unrefThread = qScopeGuard([this, registryRef = suspended->registryRef]
-	                                     { luaL_unref(m_state, LUA_REGISTRYINDEX, registryRef); });
+	const auto                  unrefThread      = qScopeGuard([this, registryRef = suspended->registryRef]
+                                         { luaL_unref(m_state, LUA_REGISTRYINDEX, registryRef); });
 	Q_UNUSED(unrefThread);
 	if (status != LUA_OK)
 	{
@@ -11490,28 +11489,28 @@ static int luaActivateNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, title, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        bool activated = false;
-				        if (const MainWindow *mw = resolveMainWindow())
-					        activated = mw->activateNotepad(title, targetRuntimeOnMain);
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ActivateNotepad"), activated, 0);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("ActivateNotepad"), false, 0);
-			    }
-		    });
+            engine, runtime,
+            [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, title, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        bool activated = false;
+                        if (const MainWindow *mw = resolveMainWindow())
+                            activated = mw->activateNotepad(title, targetRuntimeOnMain);
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("ActivateNotepad"), activated, 0);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("ActivateNotepad"), false, 0);
+                }
+            });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -12993,13 +12992,13 @@ static int luaCloseNotepad(lua_State *L)
 		{
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-			    engine, runtime,
-			    [title, querySave, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-			    {
-				    const bool closed = targetRuntime.closeNotepad(title, querySave);
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("CloseNotepad"), closed, 0);
-			    });
+                engine, runtime,
+                [title, querySave, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+                {
+                    const bool closed = targetRuntime.closeNotepad(title, querySave);
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                              QStringLiteral("CloseNotepad"), closed, 0);
+                });
 			if (accepted)
 				invalidateCallbackNotepadDocumentCache(engine, runtime, title, worldId);
 			lua_pushnumber(L, accepted ? 1 : 0);
@@ -13487,11 +13486,11 @@ static int luaDiscardQueue(lua_State *L)
 	return 1;
 }
 
-static int addTimerInternal(const LuaCallbackEngine *engine, const QString &rawName, int hour, int minute,
-                            double second, const QString &responseText, int flags, const QString &scriptName);
-static QString                       makeAutoName(const QString &prefix);
-static void                          applyTimerDefaults(WorldRuntime::Timer &timer);
-static void                          resetTimerFields(WorldRuntime::Timer &timer);
+static int     addTimerInternal(const LuaCallbackEngine *engine, const QString &rawName, int hour, int minute,
+                                double second, const QString &responseText, int flags, const QString &scriptName);
+static QString makeAutoName(const QString &prefix);
+static void    applyTimerDefaults(WorldRuntime::Timer &timer);
+static void    resetTimerFields(WorldRuntime::Timer &timer);
 static QList<WorldRuntime::Trigger> &mutableTriggerList(WorldRuntime *runtime, WorldRuntime::Plugin *plugin);
 static QList<WorldRuntime::Alias>   &mutableAliasList(WorldRuntime *runtime, WorldRuntime::Plugin *plugin);
 static QList<WorldRuntime::Timer>   &mutableTimerList(WorldRuntime *runtime, WorldRuntime::Plugin *plugin);
@@ -13551,12 +13550,12 @@ static auto runOnRuntimeThread(WorldRuntime *runtime, Func &&func, std::invoke_r
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(runtimeGuard.data(),
 	                                                         [&]
 	                                                         {
-		                                                       if (runtimeGuard)
-		                                                       {
-			                                                       result    = func();
-			                                                       completed = true;
-		                                                       }
-	                                                         });
+                                                               if (runtimeGuard)
+                                                               {
+                                                                   result    = func();
+                                                                   completed = true;
+                                                               }
+                                                           });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral("[QMud][LuaBridge] runOnRuntimeThread failed: %1")
@@ -13593,12 +13592,12 @@ static auto runOnRuntimeThreadNoDeferredFlush(WorldRuntime *runtime, Func &&func
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(runtimeGuard.data(),
 	                                                         [&]
 	                                                         {
-		                                                       if (runtimeGuard)
-		                                                       {
-			                                                       result    = func();
-			                                                       completed = true;
-		                                                       }
-	                                                         });
+                                                               if (runtimeGuard)
+                                                               {
+                                                                   result    = func();
+                                                                   completed = true;
+                                                               }
+                                                           });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral(
@@ -13638,12 +13637,12 @@ static auto runOnRuntimeThreadAllowNestedEvents(WorldRuntime *runtime, Func &&fu
 	const bool bridged   = qmudLuaBridgeInvokeOnObjectThread(runtimeGuard.data(),
 	                                                         [&]
 	                                                         {
-		                                                       if (runtimeGuard)
-		                                                       {
-			                                                       result    = func();
-			                                                       completed = true;
-		                                                       }
-	                                                         });
+                                                               if (runtimeGuard)
+                                                               {
+                                                                   result    = func();
+                                                                   completed = true;
+                                                               }
+                                                           });
 	if (!bridged)
 	{
 		qWarning().noquote() << QStringLiteral(
@@ -13764,14 +13763,14 @@ static bool enqueueRuntimeThreadDeferredMutationNoResult(const LuaCallbackEngine
 		const QPointer<WorldRuntime> runtimeGuard(runtime);
 		auto                         invokeShared = std::make_shared<decltype(invoke)>(std::move(invoke));
 		const bool                   queued       = QMetaObject::invokeMethod(
-		    runtime,
-		    [runtimeGuard, invokeShared]() mutable
-		    {
-			    if (!runtimeGuard || !invokeShared)
-				    return;
-			    (*invokeShared)(*runtimeGuard);
-		    },
-		    Qt::QueuedConnection);
+            runtime,
+            [runtimeGuard, invokeShared]() mutable
+            {
+                if (!runtimeGuard || !invokeShared)
+                    return;
+                (*invokeShared)(*runtimeGuard);
+            },
+            Qt::QueuedConnection);
 		if (!queued && runtimeGuard)
 		{
 			if (callbackScopeSyncBridgeForbidden())
@@ -13838,14 +13837,14 @@ static int enqueueRuntimeThreadAsyncStatusResult(lua_State *L, const LuaCallback
 	auto          funcCopy         = DecayedFunc(std::forward<Func>(func));
 	auto          okCopy           = DecayedOkFunc(std::forward<OkFunc>(okFunc));
 	const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-	    engine, runtime,
-	    [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy),
-	     okCopy = std::move(okCopy)](WorldRuntime &targetRuntime) mutable
-	    {
-		    const int status = funcCopy(targetRuntime);
-		    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
-		                          QString());
-	    });
+        engine, runtime,
+        [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy),
+         okCopy = std::move(okCopy)](WorldRuntime &targetRuntime) mutable
+        {
+            const int status = funcCopy(targetRuntime);
+            emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
+		                                     QString());
+        });
 
 	lua_pushnumber(L, accepted ? acceptedCode : enqueueFailureCode);
 	if (accepted && requestId != 0)
@@ -14101,7 +14100,7 @@ static bool mapTriggerCallbackBufferIndexToAbsoluteLineNumber(const LuaCallbackE
 
 	const qint64 offset = static_cast<qint64>(lineNumber) -
 	                      static_cast<qint64>(context->triggerMatchedLineBufferIndexAtDispatch);
-	absoluteLineNumber  = context->triggerMatchedLineAbsoluteNumberAtDispatch + offset;
+	absoluteLineNumber = context->triggerMatchedLineAbsoluteNumberAtDispatch + offset;
 	return absoluteLineNumber > 0;
 }
 
@@ -15528,39 +15527,39 @@ static bool resolveNotepadListForApi(const LuaCallbackEngine *engine, WorldRunti
 		return false;
 	const auto ownerToken = reinterpret_cast<quintptr>(runtime);
 	const bool resolved   = runOnMainWindowThread(
-	    [&](const MainWindow *frame) -> bool
-	    {
-		    auto *mdi = frame->findChild<QMdiArea *>();
-		    if (!mdi)
-			    return true;
+        [&](const MainWindow *frame) -> bool
+        {
+            auto *mdi = frame->findChild<QMdiArea *>();
+            if (!mdi)
+                return true;
 
-		    for (const QList<QMdiSubWindow *> windows = mdi->subWindowList(QMdiArea::CreationOrder);
-		         QMdiSubWindow *sub : windows)
-		    {
-			    auto *text = qobject_cast<TextChildWindow *>(sub);
-			    if (!text)
-				    continue;
-			    if (!all)
-			    {
-				    if (const auto relatedToken = text->property("worldRuntimeToken").toULongLong();
-				        relatedToken == ownerToken)
-				    {
-					    // Matched this runtime instance.
-				    }
-				    else
-				    {
-					    if (relatedToken != 0)
-						    continue;
-					    if (const QString related = text->property("worldId").toString();
-					        related.isEmpty() || related.compare(worldId, Qt::CaseInsensitive) != 0)
-						    continue;
-				    }
-			    }
-			    titles.push_back(text->windowTitle());
-		    }
-		    return true;
-	    },
-	    false);
+            for (const QList<QMdiSubWindow *> windows = mdi->subWindowList(QMdiArea::CreationOrder);
+                 QMdiSubWindow *sub : windows)
+            {
+                auto *text = qobject_cast<TextChildWindow *>(sub);
+                if (!text)
+                    continue;
+                if (!all)
+                {
+                    if (const auto relatedToken = text->property("worldRuntimeToken").toULongLong();
+                        relatedToken == ownerToken)
+                    {
+                        // Matched this runtime instance.
+                    }
+                    else
+                    {
+                        if (relatedToken != 0)
+                            continue;
+                        if (const QString related = text->property("worldId").toString();
+                            related.isEmpty() || related.compare(worldId, Qt::CaseInsensitive) != 0)
+                            continue;
+                    }
+                }
+                titles.push_back(text->windowTitle());
+            }
+            return true;
+        },
+        false);
 	if (!resolved)
 		return false;
 	cacheCallbackNotepadList(engine, key, !titles.isEmpty(), titles);
@@ -16423,35 +16422,35 @@ static int luaDoCommand(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [cmdName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, cmdName, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        int deferredResult = eNoSuchCommand;
-				        if (const MainWindow *mw = resolveMainWindow())
-				        {
-					        if (QAction *action = mw->actionForCommand(cmdName))
-					        {
-						        action->trigger();
-						        deferredResult = eOK;
-					        }
-				        }
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("DoCommand"), deferredResult == eOK,
-				                              deferredResult);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("DoCommand"), false, eNoSuchCommand);
-			    }
-		    });
+            engine, runtime,
+            [cmdName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, cmdName, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        int deferredResult = eNoSuchCommand;
+                        if (const MainWindow *mw = resolveMainWindow())
+                        {
+                            if (QAction *action = mw->actionForCommand(cmdName))
+                            {
+                                action->trigger();
+                                deferredResult = eOK;
+                            }
+                        }
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("DoCommand"), deferredResult == eOK,
+				                                                           deferredResult);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("DoCommand"), false, eNoSuchCommand);
+                }
+            });
 		lua_pushnumber(L, accepted ? eOK : eNoSuchCommand);
 		if (accepted && requestId != 0)
 		{
@@ -16690,13 +16689,13 @@ static int luaExecute(lua_State *L)
 	{
 		const bool triggerPriority = context->directTriggerScriptActionPriority;
 		const int  results         = enqueueRuntimeThreadAsyncStatusResult(
-		    L, engine, runtime, QStringLiteral("Execute"), eOK, eWorldClosed,
-		    [input, triggerPriority](const WorldRuntime &targetRuntime) -> int
-		    {
-			    return triggerPriority ? targetRuntime.executeCommandWithTriggerPriority(input)
-			                           : targetRuntime.executeCommand(input);
-		    },
-		    [](const int status) { return status == eOK; });
+            L, engine, runtime, QStringLiteral("Execute"), eOK, eWorldClosed,
+            [input, triggerPriority](const WorldRuntime &targetRuntime) -> int
+            {
+                return triggerPriority ? targetRuntime.executeCommandWithTriggerPriority(input)
+			                                    : targetRuntime.executeCommand(input);
+            },
+            [](const int status) { return status == eOK; });
 		return results;
 	}
 	const int result = runOnRuntimeThreadDeferredMutation(
@@ -18096,7 +18095,7 @@ static int luaGetScriptTime(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const double                          scriptSeconds =
-	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.scriptTimeSeconds : 0.0;
+        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.scriptTimeSeconds : 0.0;
 	lua_pushnumber(L, scriptSeconds);
 	return 1;
 }
@@ -19257,32 +19256,32 @@ static int luaImportXML(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [xml, callbackPluginId, requestId, encodeImportPayload](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, xml, callbackPluginId, requestId, encodeImportPayload]
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        AppController::ImportResult result;
-				        if (AppController *targetApp = AppController::instance())
-					        result = targetApp->importXmlFromText(xml, mask);
-				        else
-					        result.errorMessage = QStringLiteral("App controller is not available");
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ImportXML"), result.ok, result.ok ? eOK : -1,
-				                              encodeImportPayload(result));
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("ImportXML"), false, -1,
-				                          QStringLiteral("error=Failed%20to%20queue%20ImportXML"));
-			    }
-		    });
+            engine, runtime,
+            [xml, callbackPluginId, requestId, encodeImportPayload](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, xml, callbackPluginId, requestId, encodeImportPayload]
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        AppController::ImportResult result;
+                        if (AppController *targetApp = AppController::instance())
+                            result = targetApp->importXmlFromText(xml, mask);
+                        else
+                            result.errorMessage = QStringLiteral("App controller is not available");
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("ImportXML"), result.ok, result.ok ? eOK : -1,
+				                                                           encodeImportPayload(result));
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("ImportXML"), false, -1,
+				                                     QStringLiteral("error=Failed%20to%20queue%20ImportXML"));
+                }
+            });
 		lua_pushnumber(L, accepted ? 0 : -1);
 		if (accepted && requestId != 0)
 		{
@@ -19414,35 +19413,35 @@ static int luaLogSend(lua_State *L)
 		    resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("display_my_input")));
 		const QPointer<WorldRuntime> runtimeGuard(runtime);
 		const int                    results = enqueueRuntimeThreadAsyncOkStatusResult(
-		    L, engine, runtime, QStringLiteral("LogSend"), eWorldClosed,
-		    [runtimeGuard, text, echo](WorldRuntime &) -> int
-		    {
-			    if (!runtimeGuard)
-				    return eWorldClosed;
-			    const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
-			    if (sendResult == eOK)
-				    runtimeGuard->logInputCommand(text);
-			    return sendResult;
-		    });
+            L, engine, runtime, QStringLiteral("LogSend"), eWorldClosed,
+            [runtimeGuard, text, echo](WorldRuntime &) -> int
+            {
+                if (!runtimeGuard)
+                    return eWorldClosed;
+                const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
+                if (sendResult == eOK)
+                    runtimeGuard->logInputCommand(text);
+                return sendResult;
+            });
 		if (lua_tointeger(L, -results) == eOK)
 			updateCallbackSendCommandSnapshots(engine, runtime, text, echo, false, false, false);
 		return results;
 	}
 	const QPointer<WorldRuntime> runtimeGuard(runtime);
 	const int                    result = runOnRuntimeThreadDeferredMutation(
-	    engine, runtime,
-	    [runtimeGuard, text]() -> int
-	    {
-		    if (!runtimeGuard)
-			    return eWorldClosed;
-		    const bool echo =
-		        isEnabledValue(runtimeGuard->worldAttributeValue(QStringLiteral("display_my_input")));
-		    const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
-		    if (sendResult == eOK)
-			    runtimeGuard->logInputCommand(text);
-		    return sendResult;
-	    },
-	    eWorldClosed);
+        engine, runtime,
+        [runtimeGuard, text]() -> int
+        {
+            if (!runtimeGuard)
+                return eWorldClosed;
+            const bool echo =
+                isEnabledValue(runtimeGuard->worldAttributeValue(QStringLiteral("display_my_input")));
+            const int sendResult = runtimeGuard->sendCommand(text, echo, false, false, false, false);
+            if (sendResult == eOK)
+                runtimeGuard->logInputCommand(text);
+            return sendResult;
+        },
+        eWorldClosed);
 	lua_pushnumber(L, result);
 	return 1;
 }
@@ -19956,7 +19955,7 @@ static int luaGetNoteColourBack(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const long                            noteColour =
-	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourBack : 0;
+        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourBack : 0;
 	lua_pushnumber(L, static_cast<lua_Number>(noteColour));
 	return 1;
 }
@@ -19985,7 +19984,7 @@ static int luaGetNoteColourFore(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const long                            noteColour =
-	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourFore : 0;
+        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.noteColourFore : 0;
 	lua_pushnumber(L, static_cast<lua_Number>(noteColour));
 	return 1;
 }
@@ -20313,27 +20312,27 @@ static int luaOpen(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [path, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, path, callbackPluginId, requestId]
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        const bool opened =
-				            AppController::instance() && AppController::instance()->openDocumentFile(path);
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("Open"), opened, opened ? eOK : -1, path);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, QStringLiteral("Open"),
-				                          false, -1, path);
-			    }
-		    });
+            engine, runtime,
+            [path, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, path, callbackPluginId, requestId]
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        const bool opened =
+                            AppController::instance() && AppController::instance()->openDocumentFile(path);
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("Open"), opened, opened ? eOK : -1, path);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, QStringLiteral("Open"),
+				                                     false, -1, path);
+                }
+            });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -20373,18 +20372,18 @@ static int luaOpenBrowser(lua_State *L)
 		QPointer<QCoreApplication> app = QCoreApplication::instance();
 		QPointer<WorldRuntime>     runtimeGuard(runtime);
 		const bool                 queued = app && QMetaObject::invokeMethod(
-		                                               app.data(),
-		                                               [runtimeGuard, urlText, callbackPluginId, requestId]
-		                                               {
-			                               WorldRuntime *targetRuntime = runtimeGuard.data();
-			                               if (!targetRuntime)
-				                               return;
-			                               const bool ok = QDesktopServices::openUrl(QUrl(urlText));
-			                               emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
-			                                                     QStringLiteral("OpenBrowser"), ok,
-			                                                     ok ? eOK : eCouldNotOpenFile);
-		                                               },
-		                                               Qt::QueuedConnection);
+                                       app.data(),
+                                       [runtimeGuard, urlText, callbackPluginId, requestId]
+                                       {
+                                           WorldRuntime *targetRuntime = runtimeGuard.data();
+                                           if (!targetRuntime)
+                                               return;
+                                           const bool ok = QDesktopServices::openUrl(QUrl(urlText));
+                                           emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
+			                                                                     QStringLiteral("OpenBrowser"), ok,
+                                                                 ok ? eOK : eCouldNotOpenFile);
+                                       },
+                                       Qt::QueuedConnection);
 		lua_pushnumber(L, queued ? eOK : eCouldNotOpenFile);
 		if (queued && requestId != 0)
 		{
@@ -20423,9 +20422,9 @@ static int luaPasteCommand(lua_State *L)
 		                                   : static_cast<int>(expectedInput.size());
 		const int     selectionStart = std::clamp(snapshot.inputSelectionStartColumn - 1, 0, inputLength);
 		const int     selectionEnd =
-		    snapshot.inputSelectionEndColumn <= selectionStart
-		        ? selectionStart
-		        : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
+            snapshot.inputSelectionEndColumn <= selectionStart
+		            ? selectionStart
+		            : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
 		const QString replaced = selectionEnd > selectionStart
 		                             ? expectedInput.mid(selectionStart, selectionEnd - selectionStart)
 		                             : QString();
@@ -20929,9 +20928,9 @@ static int luaAudioIsPlaying(lua_State *L)
 	const int     buffer  = normalizeLuaAudioBuffer(L, 1, 0);
 	QMudNativePluginRegistry::LuaAudioRuntimeBufferState bufferState;
 	const int                                            status =
-	    (buffer > 0 && QMudNativePluginRegistry::luaAudioRuntimeBufferState(runtime, buffer, bufferState))
-	        ? luaAudioSoundStatus(engine, runtime, buffer)
-	        : -3;
+        (buffer > 0 && QMudNativePluginRegistry::luaAudioRuntimeBufferState(runtime, buffer, bufferState))
+	                                                   ? luaAudioSoundStatus(engine, runtime, buffer)
+	                                                   : -3;
 	lua_pushboolean(L, status == 1 || status == 2);
 	return 1;
 }
@@ -22072,19 +22071,19 @@ static int luaTransparency(lua_State *L)
 		QPointer<QCoreApplication> app = QCoreApplication::instance();
 		QPointer<WorldRuntime>     runtimeGuard(runtime);
 		const bool                 queued = app && QMetaObject::invokeMethod(
-		                                               app.data(),
-		                                               [runtimeGuard, callbackPluginId, requestId, applyTransparency]
-		                                               {
-			                               WorldRuntime *targetRuntime = runtimeGuard.data();
-			                               if (!targetRuntime)
-				                               return;
-			                               MainWindow *window = resolveMainWindow();
-			                               const bool  ok     = window && applyTransparency(window);
-			                               emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
-			                                                     QStringLiteral("Transparency"), ok,
-			                                                     ok ? eOK : eBadParameter);
-		                                               },
-		                                               Qt::QueuedConnection);
+                                       app.data(),
+                                       [runtimeGuard, callbackPluginId, requestId, applyTransparency]
+                                       {
+                                           WorldRuntime *targetRuntime = runtimeGuard.data();
+                                           if (!targetRuntime)
+                                               return;
+                                           MainWindow *window = resolveMainWindow();
+                                           const bool  ok = window && applyTransparency(window);
+                                           emitPluginAsyncResult(*targetRuntime, callbackPluginId, requestId,
+			                                                                     QStringLiteral("Transparency"), ok,
+                                                                 ok ? eOK : eBadParameter);
+                                       },
+                                       Qt::QueuedConnection);
 		lua_pushboolean(L, queued);
 		if (queued && requestId != 0)
 		{
@@ -22420,9 +22419,9 @@ static int luaSetToolBarPosition(lua_State *L)
 					                  const ToolBarDockState &sa = s_toolbarStates.value(a);
 					                  const ToolBarDockState &sb = s_toolbarStates.value(b);
 					                  const int               primaryA =
-					                      area == Qt::LeftToolBarArea || area == Qt::RightToolBarArea
-					                          ? sa.pos.y()
-					                          : sa.pos.x();
+                                          area == Qt::LeftToolBarArea || area == Qt::RightToolBarArea
+					                                        ? sa.pos.y()
+					                                        : sa.pos.x();
 					                  const int primaryB =
 					                      area == Qt::LeftToolBarArea || area == Qt::RightToolBarArea
 					                          ? sb.pos.y()
@@ -23138,9 +23137,9 @@ static int luaSpellCheckCommand(lua_State *L)
 		                                   ? std::numeric_limits<int>::max()
 		                                   : static_cast<int>(expectedInput.size());
 		int           selectionStart = std::clamp(snapshot.inputSelectionStartColumn - 1, 0, inputLength);
-		int selectionEnd = snapshot.inputSelectionEndColumn <= selectionStart
-		                       ? selectionStart
-		                       : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
+		int           selectionEnd   = snapshot.inputSelectionEndColumn <= selectionStart
+		                                   ? selectionStart
+		                                   : std::clamp(snapshot.inputSelectionEndColumn, selectionStart, inputLength);
 		if (endCol > startCol && startCol >= 0 && endCol >= 0)
 		{
 			selectionStart = std::clamp(startCol, 0, inputLength);
@@ -23172,16 +23171,16 @@ static int luaSpellCheckCommand(lua_State *L)
 
 		const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [expectedInput, selectionStart, selectionEnd, all, replacement, callbackPluginId, requestId,
-		     applySpellCheckReplacement](WorldRuntime &targetRuntime)
-		    {
-			    const bool applied = applySpellCheckReplacement(targetRuntime, expectedInput, selectionStart,
-			                                                    selectionEnd, all, replacement);
-			    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-			                          QStringLiteral("SpellCheckCommand"), applied, applied ? 0 : -1,
-			                          applied ? QStringLiteral("1") : QString());
-		    });
+            engine, runtime,
+            [expectedInput, selectionStart, selectionEnd, all, replacement, callbackPluginId, requestId,
+             applySpellCheckReplacement](WorldRuntime &targetRuntime)
+            {
+                const bool applied = applySpellCheckReplacement(targetRuntime, expectedInput, selectionStart,
+			                                                        selectionEnd, all, replacement);
+                emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+			                              QStringLiteral("SpellCheckCommand"), applied, applied ? 0 : -1,
+                                      applied ? QStringLiteral("1") : QString());
+            });
 		if (!accepted)
 		{
 			lua_pushnumber(L, -1);
@@ -23547,28 +23546,28 @@ static int luaAppendToNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, title, contents, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        bool ok = false;
-				        if (MainWindow *mw = resolveMainWindow())
-					        ok = mw->appendToNotepad(title, contents, false, targetRuntimeOnMain);
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("AppendToNotepad"), ok, 0);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("AppendToNotepad"), false, 0);
-			    }
-		    });
+            engine, runtime,
+            [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, title, contents, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        bool ok = false;
+                        if (MainWindow *mw = resolveMainWindow())
+                            ok = mw->appendToNotepad(title, contents, false, targetRuntimeOnMain);
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("AppendToNotepad"), ok, 0);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("AppendToNotepad"), false, 0);
+                }
+            });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, false);
 		lua_pushboolean(L, accepted);
@@ -23602,28 +23601,28 @@ static int luaReplaceNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, title, contents, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        bool ok = false;
-				        if (MainWindow *mw = resolveMainWindow())
-					        ok = mw->appendToNotepad(title, contents, true, targetRuntimeOnMain);
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ReplaceNotepad"), ok, 0);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("ReplaceNotepad"), false, 0);
-			    }
-		    });
+            engine, runtime,
+            [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, title, contents, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        bool ok = false;
+                        if (MainWindow *mw = resolveMainWindow())
+                            ok = mw->appendToNotepad(title, contents, true, targetRuntimeOnMain);
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("ReplaceNotepad"), ok, 0);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("ReplaceNotepad"), false, 0);
+                }
+            });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, true);
 		lua_pushboolean(L, accepted);
@@ -23657,28 +23656,28 @@ static int luaSendToNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, title, contents, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        bool ok = false;
-				        if (MainWindow *mw = resolveMainWindow())
-					        ok = mw->sendToNotepad(title, contents, targetRuntimeOnMain);
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("SendToNotepad"), ok, 0);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("SendToNotepad"), false, 0);
-			    }
-		    });
+            engine, runtime,
+            [title, contents, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, title, contents, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        bool ok = false;
+                        if (MainWindow *mw = resolveMainWindow())
+                            ok = mw->sendToNotepad(title, contents, targetRuntimeOnMain);
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("SendToNotepad"), ok, 0);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("SendToNotepad"), false, 0);
+                }
+            });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, true);
 		lua_pushboolean(L, accepted);
@@ -25624,9 +25623,9 @@ static int luaGetInfo(lua_State *L)
 			if (runtime && !callbackNoFlushRuntimeReadBridgeForbidden(engine, inCallback))
 			{
 				const auto resolveBackground = [&]() -> long { return runtime->backgroundColour(); };
-				backgroundValue = inCallback
-				                      ? runOnRuntimeThreadNoDeferredFlush(runtime, resolveBackground, 0L)
-				                      : runOnRuntimeThread(runtime, resolveBackground, 0L);
+				backgroundValue              = inCallback
+				                                   ? runOnRuntimeThreadNoDeferredFlush(runtime, resolveBackground, 0L)
+				                                   : runOnRuntimeThread(runtime, resolveBackground, 0L);
 				cacheCallbackBackgroundColour(engine, backgroundValue);
 			}
 			else
@@ -25999,7 +25998,7 @@ static int luaUtilsFontPicker(lua_State *L)
 	{
 		FontPickerResult pickerResult;
 		bool             ok = false;
-		pickerResult.font   = QFontDialog::getFont(&ok, initialFont, frame, QStringLiteral("Select Font"));
+		pickerResult.font   = qmudGetFont(&ok, initialFont, frame, QStringLiteral("Select Font"));
 		if (!ok)
 			return pickerResult;
 		pickerResult.accepted = true;
@@ -26600,37 +26599,37 @@ static int luaUtilsSendToFront(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [titlePrefix, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, titlePrefix, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        bool found = false;
-				        for (QWidget *widget : QApplication::topLevelWidgets())
-				        {
-					        if (!widget)
-						        continue;
-					        if (const QString title = widget->windowTitle(); !title.startsWith(titlePrefix))
-						        continue;
-					        widget->raise();
-					        widget->activateWindow();
-					        found = true;
-					        break;
-				        }
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("SendToFront"), found, found ? eOK : -1);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("SendToFront"), false, -1);
-			    }
-		    });
+            engine, runtime,
+            [titlePrefix, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, titlePrefix, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        bool found = false;
+                        for (QWidget *widget : QApplication::topLevelWidgets())
+                        {
+                            if (!widget)
+                                continue;
+                            if (const QString title = widget->windowTitle(); !title.startsWith(titlePrefix))
+                                continue;
+                            widget->raise();
+                            widget->activateWindow();
+                            found = true;
+                            break;
+                        }
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("SendToFront"), found, found ? eOK : -1);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("SendToFront"), false, -1);
+                }
+            });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -26862,29 +26861,29 @@ static int luaUtilsShellExecute(lua_State *L)
 			const QString callbackPluginId = engine->pluginId();
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-			    engine, runtime,
-			    [url, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-			    {
-				    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-				    const bool                   queued = enqueueOnMainThread(
-				        [runtimeGuard, url, callbackPluginId, requestId]()
-				        {
-					        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-					        if (!targetRuntimeOnMain)
-						        return;
-					        const bool opened = QDesktopServices::openUrl(url);
-					        emitPluginAsyncResult(
-					            *targetRuntimeOnMain, callbackPluginId, requestId,
-					            QStringLiteral("ShellExecute"), opened, opened ? eOK : eCouldNotOpenFile,
-					            opened ? QString() : QStringLiteral("Failed to open target."));
-				        });
-				    if (!queued)
-				    {
-					    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-					                          QStringLiteral("ShellExecute"), false, eCouldNotOpenFile,
-					                          QStringLiteral("Failed to open target."));
-				    }
-			    });
+                engine, runtime,
+                [url, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+                {
+                    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                    const bool                   queued = enqueueOnMainThread(
+                        [runtimeGuard, url, callbackPluginId, requestId]()
+                        {
+                            WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                            if (!targetRuntimeOnMain)
+                                return;
+                            const bool opened = QDesktopServices::openUrl(url);
+                            emitPluginAsyncResult(
+                                *targetRuntimeOnMain, callbackPluginId, requestId,
+                                QStringLiteral("ShellExecute"), opened, opened ? eOK : eCouldNotOpenFile,
+                                opened ? QString() : QStringLiteral("Failed to open target."));
+                        });
+                    if (!queued)
+                    {
+                        emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+					                              QStringLiteral("ShellExecute"), false, eCouldNotOpenFile,
+					                              QStringLiteral("Failed to open target."));
+                    }
+                });
 			lua_pushboolean(L, accepted ? 1 : 0);
 			if (accepted && requestId != 0)
 			{
@@ -28002,29 +28001,29 @@ static int luaUtilsActivateNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, title, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        bool activated = false;
-				        if (const MainWindow *mw = resolveMainWindow())
-					        activated = mw->activateNotepad(title, targetRuntimeOnMain);
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ActivateNotepad"), activated,
-				                              activated ? eOK : -1);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("ActivateNotepad"), false, -1);
-			    }
-		    });
+            engine, runtime,
+            [title, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, title, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        bool activated = false;
+                        if (const MainWindow *mw = resolveMainWindow())
+                            activated = mw->activateNotepad(title, targetRuntimeOnMain);
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("ActivateNotepad"), activated,
+                                              activated ? eOK : -1);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("ActivateNotepad"), false, -1);
+                }
+            });
 		lua_pushboolean(L, accepted);
 		if (accepted && requestId != 0)
 		{
@@ -28052,28 +28051,28 @@ static int luaUtilsAppendToNotepad(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [title, contents, replace, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, title, contents, replace, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        bool ok = false;
-				        if (MainWindow *mw = resolveMainWindow())
-					        ok = mw->appendToNotepad(title, contents, replace, targetRuntimeOnMain);
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("AppendToNotepad"), ok, ok ? eOK : -1);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("AppendToNotepad"), false, -1);
-			    }
-		    });
+            engine, runtime,
+            [title, contents, replace, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, title, contents, replace, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        bool ok = false;
+                        if (MainWindow *mw = resolveMainWindow())
+                            ok = mw->appendToNotepad(title, contents, replace, targetRuntimeOnMain);
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("AppendToNotepad"), ok, ok ? eOK : -1);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("AppendToNotepad"), false, -1);
+                }
+            });
 		if (accepted)
 			cacheCallbackNotepadDocumentTextAfterWrite(engine, runtime, title, worldId, contents, replace);
 		lua_pushboolean(L, accepted);
@@ -29633,26 +29632,26 @@ static int luaProgressGc(lua_State *L)
 			const QString callbackPluginId = engine->pluginId();
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-			    engine, runtime,
-			    [closeDialog, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-			    {
-				    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-				    const bool                   queued = enqueueOnMainThread(
-				        [runtimeGuard, closeDialog, callbackPluginId, requestId]()
-				        {
-					        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-					        if (!targetRuntimeOnMain)
-						        return;
-					        const bool closed = closeDialog(nullptr);
-					        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-					                              QStringLiteral("ProgressClose"), closed, closed ? eOK : -1);
-				        });
-				    if (!queued)
-				    {
-					    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-					                          QStringLiteral("ProgressClose"), false, -1);
-				    }
-			    });
+                engine, runtime,
+                [closeDialog, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+                {
+                    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                    const bool                   queued = enqueueOnMainThread(
+                        [runtimeGuard, closeDialog, callbackPluginId, requestId]()
+                        {
+                            WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                            if (!targetRuntimeOnMain)
+                                return;
+                            const bool closed = closeDialog(nullptr);
+                            emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+					                                                    QStringLiteral("ProgressClose"), closed, closed ? eOK : -1);
+                        });
+                    if (!queued)
+                    {
+                        emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+					                              QStringLiteral("ProgressClose"), false, -1);
+                    }
+                });
 			if (!accepted)
 				static_cast<void>(runOnMainWindowThread(closeDialog, false, true));
 		}
@@ -29697,57 +29696,57 @@ static int luaProgressNew(lua_State *L)
 		    {
 			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
 			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, title, handle, callbackPluginId, asyncRequestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
+                    [runtimeGuard, title, handle, callbackPluginId, asyncRequestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
 
-				        QProgressDialog *dialog = nullptr;
-				        if (MainWindow *frame = resolveMainWindow())
-				        {
-					        auto *newDialog = new QProgressDialog(frame);
-					        newDialog->setWindowTitle(title);
-					        newDialog->setLabelText(QString());
-					        newDialog->setCancelButtonText(QStringLiteral("Cancel"));
-					        newDialog->setRange(0, 100);
-					        newDialog->setValue(0);
-					        newDialog->setAutoClose(false);
-					        newDialog->setAutoReset(false);
-					        QObject::connect(newDialog, &QProgressDialog::canceled, newDialog,
-					                         [handle]()
-					                         {
-						                         const std::lock_guard<std::mutex> lock(handle->mutex);
-						                         handle->lastKnownCanceled    = true;
-						                         handle->hasLastKnownCanceled = true;
-					                         });
-					        newDialog->show();
-					        dialog = newDialog;
-				        }
+                        QProgressDialog *dialog = nullptr;
+                        if (MainWindow *frame = resolveMainWindow())
+                        {
+                            auto *newDialog = new QProgressDialog(frame);
+                            newDialog->setWindowTitle(title);
+                            newDialog->setLabelText(QString());
+                            newDialog->setCancelButtonText(QStringLiteral("Cancel"));
+                            newDialog->setRange(0, 100);
+                            newDialog->setValue(0);
+                            newDialog->setAutoClose(false);
+                            newDialog->setAutoReset(false);
+                            QObject::connect(newDialog, &QProgressDialog::canceled, newDialog,
+					                                           [handle]()
+					                                           {
+                                                 const std::lock_guard<std::mutex> lock(handle->mutex);
+                                                 handle->lastKnownCanceled    = true;
+                                                 handle->hasLastKnownCanceled = true;
+                                             });
+                            newDialog->show();
+                            dialog = newDialog;
+                        }
 
-				        QString pendingStatus;
-				        bool    hasPendingStatus = false;
-				        {
-					        const std::lock_guard<std::mutex> lock(handle->mutex);
-					        handle->dialog               = dialog;
-					        handle->createPending        = false;
-					        handle->lastKnownCanceled    = false;
-					        handle->hasLastKnownCanceled = dialog != nullptr;
-					        if (dialog && handle->hasPendingStatus)
-					        {
-						        pendingStatus            = handle->pendingStatus;
-						        hasPendingStatus         = true;
-						        handle->pendingStatus    = {};
-						        handle->hasPendingStatus = false;
-					        }
-				        }
-				        if (dialog && hasPendingStatus)
-					        dialog->setLabelText(pendingStatus);
+                        QString pendingStatus;
+                        bool    hasPendingStatus = false;
+                        {
+                            const std::lock_guard<std::mutex> lock(handle->mutex);
+                            handle->dialog               = dialog;
+                            handle->createPending        = false;
+                            handle->lastKnownCanceled    = false;
+                            handle->hasLastKnownCanceled = dialog != nullptr;
+                            if (dialog && handle->hasPendingStatus)
+                            {
+                                pendingStatus            = handle->pendingStatus;
+                                hasPendingStatus         = true;
+                                handle->pendingStatus    = {};
+                                handle->hasPendingStatus = false;
+                            }
+                        }
+                        if (dialog && hasPendingStatus)
+                            dialog->setLabelText(pendingStatus);
 
-				        const bool ok = dialog != nullptr;
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, asyncRequestId,
-				                              QStringLiteral("ProgressNew"), ok, ok ? eOK : -1);
-			        });
+                        const bool ok = dialog != nullptr;
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, asyncRequestId,
+				                                                QStringLiteral("ProgressNew"), ok, ok ? eOK : -1);
+                    });
 			    if (!queued)
 			    {
 				    {
@@ -29833,35 +29832,35 @@ static int luaProgressSetStatus(lua_State *L)
 		    {
 			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
 			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, handle, status, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        QPointer<QProgressDialog> dialog;
-				        bool                      pendingCreate = false;
-				        {
-					        const std::lock_guard<std::mutex> lock(handle->mutex);
-					        dialog        = handle->dialog;
-					        pendingCreate = handle->createPending;
-					        if (!dialog)
-					        {
-						        handle->pendingStatus    = status;
-						        handle->hasPendingStatus = true;
-					        }
-					        else
-					        {
-						        handle->pendingStatus    = {};
-						        handle->hasPendingStatus = false;
-					        }
-				        }
-				        const bool applied = dialog != nullptr;
-				        if (dialog)
-					        dialog->setLabelText(status);
-				        const bool ok = applied || pendingCreate;
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ProgressSetStatus"), ok, ok ? eOK : -1);
-			        });
+                    [runtimeGuard, handle, status, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        QPointer<QProgressDialog> dialog;
+                        bool                      pendingCreate = false;
+                        {
+                            const std::lock_guard<std::mutex> lock(handle->mutex);
+                            dialog        = handle->dialog;
+                            pendingCreate = handle->createPending;
+                            if (!dialog)
+                            {
+                                handle->pendingStatus    = status;
+                                handle->hasPendingStatus = true;
+                            }
+                            else
+                            {
+                                handle->pendingStatus    = {};
+                                handle->hasPendingStatus = false;
+                            }
+                        }
+                        const bool applied = dialog != nullptr;
+                        if (dialog)
+                            dialog->setLabelText(status);
+                        const bool ok = applied || pendingCreate;
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                QStringLiteral("ProgressSetStatus"), ok, ok ? eOK : -1);
+                    });
 			    if (!queued)
 			    {
 				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
@@ -29916,36 +29915,36 @@ static int luaProgressSetRange(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [handle, start, end, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, handle, start, end, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        QPointer<QProgressDialog> dialog;
-				        bool                      pendingCreate = false;
-				        {
-					        const std::lock_guard<std::mutex> lock(handle->mutex);
-					        dialog        = handle->dialog;
-					        pendingCreate = handle->createPending;
-				        }
-				        const bool applied = dialog != nullptr;
-				        if (dialog)
-					        dialog->setRange(start, end);
-				        const bool ok = applied || pendingCreate;
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ProgressSetRange"), ok, ok ? eOK : -1);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("ProgressSetRange"), false, -1);
-			    }
-		    });
+            engine, runtime,
+            [handle, start, end, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, handle, start, end, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        QPointer<QProgressDialog> dialog;
+                        bool                      pendingCreate = false;
+                        {
+                            const std::lock_guard<std::mutex> lock(handle->mutex);
+                            dialog        = handle->dialog;
+                            pendingCreate = handle->createPending;
+                        }
+                        const bool applied = dialog != nullptr;
+                        if (dialog)
+                            dialog->setRange(start, end);
+                        const bool ok = applied || pendingCreate;
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("ProgressSetRange"), ok, ok ? eOK : -1);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("ProgressSetRange"), false, -1);
+                }
+            });
 		if (!accepted)
 		{
 			// No callback-local progress state is modified here.
@@ -29985,36 +29984,36 @@ static int luaProgressSetPosition(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [handle, pos, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, handle, pos, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        QPointer<QProgressDialog> dialog;
-				        bool                      pendingCreate = false;
-				        {
-					        const std::lock_guard<std::mutex> lock(handle->mutex);
-					        dialog        = handle->dialog;
-					        pendingCreate = handle->createPending;
-				        }
-				        const bool applied = dialog != nullptr;
-				        if (dialog)
-					        dialog->setValue(pos);
-				        const bool ok = applied || pendingCreate;
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ProgressSetPosition"), ok, ok ? eOK : -1);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("ProgressSetPosition"), false, -1);
-			    }
-		    });
+            engine, runtime,
+            [handle, pos, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, handle, pos, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        QPointer<QProgressDialog> dialog;
+                        bool                      pendingCreate = false;
+                        {
+                            const std::lock_guard<std::mutex> lock(handle->mutex);
+                            dialog        = handle->dialog;
+                            pendingCreate = handle->createPending;
+                        }
+                        const bool applied = dialog != nullptr;
+                        if (dialog)
+                            dialog->setValue(pos);
+                        const bool ok = applied || pendingCreate;
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("ProgressSetPosition"), ok, ok ? eOK : -1);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("ProgressSetPosition"), false, -1);
+                }
+            });
 		if (!accepted)
 		{
 			// No callback-local progress state is modified here.
@@ -30071,36 +30070,36 @@ static int luaProgressStep(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [handle, step, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
-			    const bool                   queued = enqueueOnMainThread(
-			        [runtimeGuard, handle, step, callbackPluginId, requestId]()
-			        {
-				        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
-				        if (!targetRuntimeOnMain)
-					        return;
-				        QPointer<QProgressDialog> dialog;
-				        bool                      pendingCreate = false;
-				        {
-					        const std::lock_guard<std::mutex> lock(handle->mutex);
-					        dialog        = handle->dialog;
-					        pendingCreate = handle->createPending;
-				        }
-				        const bool applied = dialog != nullptr;
-				        if (dialog)
-					        dialog->setValue(dialog->value() + step);
-				        const bool ok = applied || pendingCreate;
-				        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
-				                              QStringLiteral("ProgressStep"), ok, ok ? eOK : -1);
-			        });
-			    if (!queued)
-			    {
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("ProgressStep"), false, -1);
-			    }
-		    });
+            engine, runtime,
+            [handle, step, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                const QPointer<WorldRuntime> runtimeGuard(&targetRuntime);
+                const bool                   queued = enqueueOnMainThread(
+                    [runtimeGuard, handle, step, callbackPluginId, requestId]()
+                    {
+                        WorldRuntime *targetRuntimeOnMain = runtimeGuard.data();
+                        if (!targetRuntimeOnMain)
+                            return;
+                        QPointer<QProgressDialog> dialog;
+                        bool                      pendingCreate = false;
+                        {
+                            const std::lock_guard<std::mutex> lock(handle->mutex);
+                            dialog        = handle->dialog;
+                            pendingCreate = handle->createPending;
+                        }
+                        const bool applied = dialog != nullptr;
+                        if (dialog)
+                            dialog->setValue(dialog->value() + step);
+                        const bool ok = applied || pendingCreate;
+                        emitPluginAsyncResult(*targetRuntimeOnMain, callbackPluginId, requestId,
+				                                                           QStringLiteral("ProgressStep"), ok, ok ? eOK : -1);
+                    });
+                if (!queued)
+                {
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                                     QStringLiteral("ProgressStep"), false, -1);
+                }
+            });
 		if (!accepted)
 		{
 			// No callback-local progress state is modified here.
@@ -30706,30 +30705,30 @@ static int pushDispatchSendCommandResult(lua_State *L, const LuaCallbackEngine *
 		    context && context->directTriggerScriptActionPriority && !queue && !immediate;
 		const QPointer<WorldRuntime> runtimeGuard(runtime);
 		const int                    results = enqueueRuntimeThreadAsyncOkStatusResult(
-		    L, engine, runtime, apiName, eWorldClosed,
-		    [runtimeGuard, text, echo, queue, log, history, immediate, actionSourceOverride,
-		     directTriggerPrioritySend](WorldRuntime &) -> int
-		    {
-			    if (!runtimeGuard)
-				    return eWorldClosed;
-			    if (actionSourceOverride.active)
-			    {
-				    const unsigned short previousActionSource = runtimeGuard->currentActionSource();
-				    runtimeGuard->setCurrentActionSource(actionSourceOverride.source);
-				    [[maybe_unused]] const auto restoreActionSource = qScopeGuard(
-				        [runtimeGuard, previousActionSource]
-				        {
-					        if (runtimeGuard)
-						        runtimeGuard->setCurrentActionSource(previousActionSource);
-				        });
-				    return directTriggerPrioritySend
-				               ? runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history)
-				               : runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
-			    }
-			    if (directTriggerPrioritySend)
-				    return runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history);
-			    return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
-		    });
+            L, engine, runtime, apiName, eWorldClosed,
+            [runtimeGuard, text, echo, queue, log, history, immediate, actionSourceOverride,
+             directTriggerPrioritySend](WorldRuntime &) -> int
+            {
+                if (!runtimeGuard)
+                    return eWorldClosed;
+                if (actionSourceOverride.active)
+                {
+                    const unsigned short previousActionSource = runtimeGuard->currentActionSource();
+                    runtimeGuard->setCurrentActionSource(actionSourceOverride.source);
+                    [[maybe_unused]] const auto restoreActionSource = qScopeGuard(
+                        [runtimeGuard, previousActionSource]
+                        {
+                            if (runtimeGuard)
+                                runtimeGuard->setCurrentActionSource(previousActionSource);
+                        });
+                    return directTriggerPrioritySend
+				                                  ? runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history)
+				                                  : runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
+                }
+                if (directTriggerPrioritySend)
+                    return runtimeGuard->sendCommandWithTriggerPriority(text, echo, queue, log, history);
+                return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
+            });
 		if (lua_tointeger(L, -results) == eOK)
 			updateCallbackSendCommandSnapshots(engine, runtime, text, echo, queue, log, immediate);
 		return results;
@@ -30737,14 +30736,14 @@ static int pushDispatchSendCommandResult(lua_State *L, const LuaCallbackEngine *
 
 	const QPointer<WorldRuntime> runtimeGuard(runtime);
 	const int                    result = runOnRuntimeThreadDeferredMutation(
-	    engine, runtime,
-	    [runtimeGuard, text, echo, queue, log, history, immediate]() -> int
-	    {
-		    if (!runtimeGuard)
-			    return eWorldClosed;
-		    return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
-	    },
-	    eWorldClosed);
+        engine, runtime,
+        [runtimeGuard, text, echo, queue, log, history, immediate]() -> int
+        {
+            if (!runtimeGuard)
+                return eWorldClosed;
+            return runtimeGuard->sendCommand(text, echo, queue, log, history, immediate);
+        },
+        eWorldClosed);
 	lua_pushnumber(L, result);
 	return 1;
 }
@@ -30885,7 +30884,7 @@ static int luaConnect(lua_State *L)
 		}
 		const QString host = resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("site"));
 		const auto    port = static_cast<quint16>(
-		    resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("port")).toUInt());
+            resolveWorldAttributeValueForApi(engine, runtime, QStringLiteral("port")).toUInt());
 		enqueueRuntimeThreadDeferredMutationNoResult(engine, runtime,
 		                                             [host, port](WorldRuntime &targetRuntime)
 		                                             { targetRuntime.connectToWorld(host, port); });
@@ -31235,12 +31234,12 @@ static int pushAcceleratorRegistrationResult(lua_State *L, const LuaCallbackEngi
 
 		const QString pluginId = engine ? engine->pluginId() : QString();
 		const int     results  = enqueueRuntimeThreadAsyncOkStatusResult(
-		    L, engine, runtime, apiName, eWorldClosed,
-		    [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
-		    {
-			    return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo,
-			                                              pluginId);
-		    });
+            L, engine, runtime, apiName, eWorldClosed,
+            [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
+            {
+                return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo,
+			                                                   pluginId);
+            });
 		if (lua_tointeger(L, -results) == eOK)
 		{
 			if (remove)
@@ -31253,12 +31252,12 @@ static int pushAcceleratorRegistrationResult(lua_State *L, const LuaCallbackEngi
 
 	const QString pluginId = engine ? engine->pluginId() : QString();
 	const int     result   = runOnRuntimeThreadDeferredMutation(
-	    engine, runtime,
-	    [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
-	    {
-		    return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo, pluginId);
-	    },
-	    eWorldClosed);
+        engine, runtime,
+        [mapKey, sendTextValue, sendTo, pluginId](WorldRuntime &targetRuntime) -> int
+        {
+            return applyAcceleratorRegistrationForApi(targetRuntime, mapKey, sendTextValue, sendTo, pluginId);
+        },
+        eWorldClosed);
 	lua_pushnumber(L, result);
 	return 1;
 }
@@ -31354,7 +31353,7 @@ static int luaAcceleratorList(lua_State *L)
 		const auto    keyCode   = static_cast<quint16>(row.key & 0xFFFF);
 		const auto    virt      = static_cast<quint32>(row.key >> 16 & 0xFFFFFFFF);
 		const QString keyString = AcceleratorUtils::acceleratorToString(virt, keyCode);
-		const QString line = QStringLiteral("%1 = %2%3")
+		const QString line      = QStringLiteral("%1 = %2%3")
 		                         .arg(keyString.isEmpty() ? QStringLiteral("<unknown>") : keyString, row.text,
 		                              acceleratorSendTag(row.sendTo));
 		const QByteArray bytes = line.toUtf8();
@@ -31477,26 +31476,26 @@ static int luaGetLinesInBufferCount(lua_State *L)
 	WorldRuntime::LineEntry currentEntry;
 	bool                    hasLineEntry = false;
 	const bool              resolved =
-	    inCallback ? runOnRuntimeThreadNoDeferredFlush(
-	                     runtime,
-	                     [&]() -> bool
-	                     {
-		                     lineCount = runtime->luaContextLinesInBufferCount();
-		                     if (lineCount > 0)
-			                     hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
-		                     return true;
-	                     },
-	                     false)
-	               : runOnRuntimeThread(
-	                     runtime,
-	                     [&]() -> bool
-	                     {
-		                     lineCount = runtime->luaContextLinesInBufferCount();
-		                     if (lineCount > 0)
-			                     hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
-		                     return true;
-	                     },
-	                     false);
+        inCallback ? runOnRuntimeThreadNoDeferredFlush(
+                         runtime,
+                         [&]() -> bool
+                         {
+                             lineCount = runtime->luaContextLinesInBufferCount();
+                             if (lineCount > 0)
+                                 hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
+                             return true;
+                         },
+                         false)
+	                            : runOnRuntimeThread(
+                         runtime,
+                         [&]() -> bool
+                         {
+                             lineCount = runtime->luaContextLinesInBufferCount();
+                             if (lineCount > 0)
+                                 hasLineEntry = runtime->luaContextLineEntry(lineCount, currentEntry);
+                             return true;
+                         },
+                         false);
 	if (resolved)
 	{
 		cacheCallbackLineCount(engine, lineCount);
@@ -31754,7 +31753,7 @@ static int luaGetTrace(lua_State *L)
 	}
 	WorldRuntime::RuntimeCountersSnapshot snapshot;
 	const bool                            enabled =
-	    resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.traceEnabled : false;
+        resolveRuntimeCountersSnapshotForApi(engine, runtime, snapshot) ? snapshot.traceEnabled : false;
 	lua_pushboolean(L, enabled);
 	return 1;
 }
@@ -31947,9 +31946,9 @@ static WorldRuntime *findWorldRuntimeByAttribute(const LuaCallbackEngine *engine
 	                             {
 		                             auto         *mutableRuntime = const_cast<WorldRuntime *>(runtime);
 		                             const QString attr           = runOnRuntimeThread(
-		                                 mutableRuntime, [mutableRuntime, &attributeName]() -> QString
-		                                 { return mutableRuntime->worldAttributeValue(attributeName); },
-		                                 QString());
+                                         mutableRuntime, [mutableRuntime, &attributeName]() -> QString
+                                         { return mutableRuntime->worldAttributeValue(attributeName); },
+                                         QString());
 		                             return attr.compare(value, Qt::CaseInsensitive) == 0;
 	                             });
 }
@@ -33220,7 +33219,7 @@ static QVariant resolvePluginInfoValueForApi(const LuaCallbackEngine *engine, Wo
 	}
 	const QString selfPluginId      = engine->pluginId().trimmed();
 	const bool    targetsSelfPlugin = !selfPluginId.isEmpty() && effectivePluginId.trimmed().compare(
-	                                                                 selfPluginId, Qt::CaseInsensitive) == 0;
+                                                                  selfPluginId, Qt::CaseInsensitive) == 0;
 	if (targetsSelfPlugin)
 	{
 		if (infoType == 1)
@@ -36301,12 +36300,12 @@ static int luaSetTriggerOption(lua_State *L)
 	{
 		const QString textValue = luaOptionValue(L, 3);
 		const int     result    = applyTriggerMutation(
-		    [textValue](WorldRuntime::Trigger &trigger) -> int
-		    {
-			    trigger.children.insert(QStringLiteral("send"), textValue);
-			    applyTriggerDefaults(trigger);
-			    return eOK;
-		    });
+            [textValue](WorldRuntime::Trigger &trigger) -> int
+            {
+                trigger.children.insert(QStringLiteral("send"), textValue);
+                applyTriggerDefaults(trigger);
+                return eOK;
+            });
 		lua_pushnumber(L, result);
 		return 1;
 	}
@@ -36639,12 +36638,12 @@ static int luaSetAliasOption(lua_State *L)
 	{
 		const QString textValue = luaOptionValue(L, 3);
 		const int     result    = applyAliasMutation(
-		    [textValue](WorldRuntime::Alias &alias) -> int
-		    {
-			    alias.children.insert(QStringLiteral("send"), textValue);
-			    applyAliasDefaults(alias);
-			    return eOK;
-		    });
+            [textValue](WorldRuntime::Alias &alias) -> int
+            {
+                alias.children.insert(QStringLiteral("send"), textValue);
+                applyAliasDefaults(alias);
+                return eOK;
+            });
 		lua_pushnumber(L, result);
 		return 1;
 	}
@@ -36879,12 +36878,12 @@ static int luaSetTimerOption(lua_State *L)
 	{
 		const QString textValue = luaOptionValue(L, 3);
 		const int     result    = applyTimerMutation(
-		    [textValue](WorldRuntime::Timer &timer) -> int
-		    {
-			    timer.children.insert(QStringLiteral("send"), textValue);
-			    applyTimerDefaults(timer);
-			    return eOK;
-		    });
+            [textValue](WorldRuntime::Timer &timer) -> int
+            {
+                timer.children.insert(QStringLiteral("send"), textValue);
+                applyTimerDefaults(timer);
+                return eOK;
+            });
 		lua_pushnumber(L, result);
 		return 1;
 	}
@@ -38461,22 +38460,22 @@ static int luaArrayExport(lua_State *L)
 	QStringList keys;
 	QStringList values;
 	const int   status = runOnRuntimeThread(
-	    runtime,
-	    [&]() -> int
-	    {
-		    if (!runtime->arrayExists(name))
-			    return eArrayDoesNotExist;
-		    keys = runtime->arrayListKeys(name);
-		    values.reserve(keys.size());
-		    for (const QString &key : keys)
-		    {
-			    QString value;
-			    runtime->arrayGet(name, key, value);
-			    values.push_back(value);
-		    }
-		    return eOK;
-	    },
-	    eBadParameter);
+        runtime,
+        [&]() -> int
+        {
+            if (!runtime->arrayExists(name))
+                return eArrayDoesNotExist;
+            keys = runtime->arrayListKeys(name);
+            values.reserve(keys.size());
+            for (const QString &key : keys)
+            {
+                QString value;
+                runtime->arrayGet(name, key, value);
+                values.push_back(value);
+            }
+            return eOK;
+        },
+        eBadParameter);
 	if (status != eOK)
 	{
 		lua_pushnumber(L, status);
@@ -38570,15 +38569,15 @@ static int luaArrayExportKeys(lua_State *L)
 	}
 	QStringList keys;
 	const int   status = runOnRuntimeThread(
-	    runtime,
-	    [&]() -> int
-	    {
-		    if (!runtime->arrayExists(name))
-			    return eArrayDoesNotExist;
-		    keys = runtime->arrayListKeys(name);
-		    return eOK;
-	    },
-	    eBadParameter);
+        runtime,
+        [&]() -> int
+        {
+            if (!runtime->arrayExists(name))
+                return eArrayDoesNotExist;
+            keys = runtime->arrayListKeys(name);
+            return eOK;
+        },
+        eBadParameter);
 	if (status != eOK)
 	{
 		lua_pushnumber(L, status);
@@ -38922,22 +38921,22 @@ static int luaArrayList(lua_State *L)
 	QStringList      keys;
 	QVector<QString> values;
 	const bool       exists = runOnRuntimeThread(
-	    runtime,
-	    [&]() -> bool
-	    {
-		    if (!runtime->arrayExists(name))
-			    return false;
-		    keys = runtime->arrayListKeys(name);
-		    values.reserve(keys.size());
-		    for (const QString &key : keys)
-		    {
-			    QString value;
-			    runtime->arrayGet(name, key, value);
-			    values.push_back(value);
-		    }
-		    return true;
-	    },
-	    false);
+        runtime,
+        [&]() -> bool
+        {
+            if (!runtime->arrayExists(name))
+                return false;
+            keys = runtime->arrayListKeys(name);
+            values.reserve(keys.size());
+            for (const QString &key : keys)
+            {
+                QString value;
+                runtime->arrayGet(name, key, value);
+                values.push_back(value);
+            }
+            return true;
+        },
+        false);
 	if (!exists)
 		return 0;
 	lua_newtable(L);
@@ -38974,14 +38973,14 @@ static int enqueueDatabaseAsyncStatusResult(lua_State *L, const LuaCallbackEngin
 	auto          okCopy           = DecayedOkFunc(std::forward<OkFunc>(okFunc));
 	auto          payloadCopy      = DecayedPayloadFunc(std::forward<PayloadFunc>(payloadFunc));
 	const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-	    engine, runtime,
-	    [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy), okCopy = std::move(okCopy),
-	     payloadCopy = std::move(payloadCopy)](WorldRuntime &targetRuntime) mutable
-	    {
-		    const int status = funcCopy(targetRuntime);
-		    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
-		                          payloadCopy(status));
-	    });
+        engine, runtime,
+        [apiName, callbackPluginId, requestId, funcCopy = std::move(funcCopy), okCopy = std::move(okCopy),
+         payloadCopy = std::move(payloadCopy)](WorldRuntime &targetRuntime) mutable
+        {
+            const int status = funcCopy(targetRuntime);
+            emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId, apiName, okCopy(status), status,
+		                                     payloadCopy(status));
+        });
 	lua_pushnumber(L, accepted ? acceptedCode : enqueueFailureCode);
 	if (accepted && requestId != 0)
 	{
@@ -39184,21 +39183,21 @@ static bool resolveDatabaseColumnsForApi(const LuaCallbackEngine *engine, WorldR
 		return false;
 	int        resolvedColumns = eBadParameter;
 	const bool resolved        = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-	                                              runtime,
-	                                              [&]() -> bool
-	                                              {
-		                                       resolvedColumns = runtime->databaseColumns(name);
-		                                       return true;
-	                                              },
-	                                              false)
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedColumns = runtime->databaseColumns(name);
+                                               return true;
+                                           },
+                                           false)
 	                                        : runOnRuntimeThread(
-	                                              runtime,
-	                                              [&]() -> bool
-	                                              {
-		                                       resolvedColumns = runtime->databaseColumns(name);
-		                                       return true;
-	                                              },
-	                                              false);
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedColumns = runtime->databaseColumns(name);
+                                               return true;
+                                           },
+                                           false);
 	if (!resolved)
 		return false;
 	columns = resolvedColumns;
@@ -39271,9 +39270,9 @@ static bool resolveDatabaseColumnNameForApi(const LuaCallbackEngine *engine, Wor
 		bool snapshotAvailable = false;
 		if (const auto *database = callbackDatabaseSnapshotForApi(engine, name, snapshotAvailable))
 		{
-			const bool    found    = database->stmtPrepared && column >= 1 &&
-			                         column <= database->columnNames.size() &&
-			                         !database->columnNames.at(column - 1).isEmpty();
+			const bool found = database->stmtPrepared && column >= 1 &&
+			                   column <= database->columnNames.size() &&
+			                   !database->columnNames.at(column - 1).isEmpty();
 			const QString resolved = found ? database->columnNames.at(column - 1) : QString();
 			cacheCallbackDatabaseColumnName(engine, name, column, found, resolved);
 			if (!found)
@@ -39353,21 +39352,21 @@ static bool resolveDatabaseColumnTextForApi(const LuaCallbackEngine *engine, Wor
 	QString    resolvedColumnText = {};
 	const bool resolved           = inCallback
 	                                    ? runOnRuntimeThreadNoDeferredFlush(
-	                                          runtime,
-	                                          [&]() -> bool
-	                                          {
-		                                resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
-		                                return true;
-	                                          },
-	                                          false)
+                                    runtime,
+                                    [&]() -> bool
+                                    {
+                                        resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
+                                        return true;
+                                    },
+                                    false)
 	                                    : runOnRuntimeThread(
-	                                          runtime,
-	                                          [&]() -> bool
-	                                          {
-		                                resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
-		                                return true;
-	                                          },
-	                                          false);
+                                    runtime,
+                                    [&]() -> bool
+                                    {
+                                        resolvedColumnText = runtime->databaseColumnText(name, column, &ok);
+                                        return true;
+                                    },
+                                    false);
 	if (!resolved)
 		return false;
 	cacheCallbackDatabaseColumnText(engine, name, column, ok, resolvedColumnText);
@@ -39462,21 +39461,21 @@ static bool resolveDatabaseColumnTypeForApi(const LuaCallbackEngine *engine, Wor
 		return false;
 	int        resolvedType = eBadParameter;
 	const bool resolved     = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-	                                           runtime,
-	                                           [&]() -> bool
-	                                           {
-		                                       resolvedType = runtime->databaseColumnType(name, column);
-		                                       return true;
-	                                           },
-	                                           false)
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedType = runtime->databaseColumnType(name, column);
+                                               return true;
+                                           },
+                                           false)
 	                                     : runOnRuntimeThread(
-	                                           runtime,
-	                                           [&]() -> bool
-	                                           {
-		                                       resolvedType = runtime->databaseColumnType(name, column);
-		                                       return true;
-	                                           },
-	                                           false);
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedType = runtime->databaseColumnType(name, column);
+                                               return true;
+                                           },
+                                           false);
 	if (!resolved)
 		return false;
 	columnType = resolvedType;
@@ -39509,21 +39508,21 @@ static bool resolveDatabaseTotalChangesForApi(const LuaCallbackEngine *engine, W
 		return false;
 	int        resolvedChanges = eBadParameter;
 	const bool resolved        = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-	                                              runtime,
-	                                              [&]() -> bool
-	                                              {
-		                                       resolvedChanges = runtime->databaseTotalChanges(name);
-		                                       return true;
-	                                              },
-	                                              false)
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedChanges = runtime->databaseTotalChanges(name);
+                                               return true;
+                                           },
+                                           false)
 	                                        : runOnRuntimeThread(
-	                                              runtime,
-	                                              [&]() -> bool
-	                                              {
-		                                       resolvedChanges = runtime->databaseTotalChanges(name);
-		                                       return true;
-	                                              },
-	                                              false);
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedChanges = runtime->databaseTotalChanges(name);
+                                               return true;
+                                           },
+                                           false);
 	if (!resolved)
 		return false;
 	changes = resolvedChanges;
@@ -39556,21 +39555,21 @@ static bool resolveDatabaseChangesForApi(const LuaCallbackEngine *engine, WorldR
 		return false;
 	int        resolvedChanges = eBadParameter;
 	const bool resolved        = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-	                                              runtime,
-	                                              [&]() -> bool
-	                                              {
-		                                       resolvedChanges = runtime->databaseChanges(name);
-		                                       return true;
-	                                              },
-	                                              false)
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedChanges = runtime->databaseChanges(name);
+                                               return true;
+                                           },
+                                           false)
 	                                        : runOnRuntimeThread(
-	                                              runtime,
-	                                              [&]() -> bool
-	                                              {
-		                                       resolvedChanges = runtime->databaseChanges(name);
-		                                       return true;
-	                                              },
-	                                              false);
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedChanges = runtime->databaseChanges(name);
+                                               return true;
+                                           },
+                                           false);
 	if (!resolved)
 		return false;
 	changes = resolvedChanges;
@@ -39649,21 +39648,21 @@ static bool resolveDatabaseListForApi(const LuaCallbackEngine *engine, WorldRunt
 		return false;
 	QStringList resolvedDatabaseNames;
 	const bool  resolved = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-	                                        runtime,
-	                                        [&]() -> bool
-	                                        {
-		                                       resolvedDatabaseNames = runtime->databaseList();
-		                                       return true;
-	                                        },
-	                                        false)
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedDatabaseNames = runtime->databaseList();
+                                               return true;
+                                           },
+                                           false)
 	                                  : runOnRuntimeThread(
-	                                        runtime,
-	                                        [&]() -> bool
-	                                        {
-		                                       resolvedDatabaseNames = runtime->databaseList();
-		                                       return true;
-	                                        },
-	                                        false);
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedDatabaseNames = runtime->databaseList();
+                                               return true;
+                                           },
+                                           false);
 	if (!resolved)
 		return false;
 	databaseNames = resolvedDatabaseNames;
@@ -39787,21 +39786,21 @@ static bool resolveDatabaseColumnNamesForApi(const LuaCallbackEngine *engine, Wo
 		return false;
 	QStringList resolvedNames;
 	const bool  resolved = inCallback ? runOnRuntimeThreadNoDeferredFlush(
-	                                        runtime,
-	                                        [&]() -> bool
-	                                        {
-		                                       resolvedNames = runtime->databaseColumnNames(name);
-		                                       return true;
-	                                        },
-	                                        false)
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedNames = runtime->databaseColumnNames(name);
+                                               return true;
+                                           },
+                                           false)
 	                                  : runOnRuntimeThread(
-	                                        runtime,
-	                                        [&]() -> bool
-	                                        {
-		                                       resolvedNames = runtime->databaseColumnNames(name);
-		                                       return true;
-	                                        },
-	                                        false);
+                                           runtime,
+                                           [&]() -> bool
+                                           {
+                                               resolvedNames = runtime->databaseColumnNames(name);
+                                               return true;
+                                           },
+                                           false);
 	if (!resolved)
 		return false;
 	const bool found = !resolvedNames.isEmpty();
@@ -39866,11 +39865,11 @@ static bool resolveDatabaseColumnValuesForApi(const LuaCallbackEngine *engine, W
 	QVector<QVariant> resolvedValues;
 	const bool        found     = inCallback
 	                                  ? runOnRuntimeThreadNoDeferredFlush(
-	                                        runtime, [&]() -> bool
-	                                        { return runtime->databaseColumnValues(name, resolvedValues); }, false)
+                                 runtime, [&]() -> bool
+                                 { return runtime->databaseColumnValues(name, resolvedValues); }, false)
 	                                  : runOnRuntimeThread(
-	                                        runtime, [&]() -> bool
-	                                        { return runtime->databaseColumnValues(name, resolvedValues); }, false);
+                                 runtime, [&]() -> bool
+                                 { return runtime->databaseColumnValues(name, resolvedValues); }, false);
 	const bool        hasValues = found && !resolvedValues.isEmpty();
 	cacheCallbackDatabaseColumnValues(engine, name, hasValues, resolvedValues);
 	if (!hasValues)
@@ -40295,43 +40294,43 @@ static int luaDatabaseGetField(lua_State *L)
 		const QString callbackPluginId = engine->pluginId();
 		const quint64 requestId        = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 		const bool    accepted         = enqueueRuntimeThreadDeferredMutationNoResult(
-		    engine, runtime,
-		    [name, sql, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-		    {
-			    QVariant value;
-			    QString  payload = QStringLiteral("null:");
-			    int      status  = targetRuntime.databasePrepare(name, sql);
-			    bool     ok      = status == SQLITE_OK;
-			    if (ok)
-			    {
-				    const auto finalize =
-				        qScopeGuard([&]() { static_cast<void>(targetRuntime.databaseFinalize(name)); });
-				    status = targetRuntime.databaseStep(name);
-				    if (status == SQLITE_ROW)
-				    {
-					    if (targetRuntime.databaseColumnValue(name, 1, value))
-					    {
-						    status  = eOK;
-						    payload = encodeDatabaseFieldAsyncPayload(value);
-					    }
-					    else
-					    {
-						    status = kDbErrorColumnOutOfRange;
-						    ok     = false;
-					    }
-				    }
-				    else if (status == SQLITE_DONE)
-				    {
-					    status = eOK;
-				    }
-				    else
-				    {
-					    ok = false;
-				    }
-			    }
-			    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-			                          QStringLiteral("DatabaseGetField"), ok, status, payload);
-		    });
+            engine, runtime,
+            [name, sql, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+            {
+                QVariant value;
+                QString  payload = QStringLiteral("null:");
+                int      status  = targetRuntime.databasePrepare(name, sql);
+                bool     ok      = status == SQLITE_OK;
+                if (ok)
+                {
+                    const auto finalize =
+                        qScopeGuard([&]() { static_cast<void>(targetRuntime.databaseFinalize(name)); });
+                    status = targetRuntime.databaseStep(name);
+                    if (status == SQLITE_ROW)
+                    {
+                        if (targetRuntime.databaseColumnValue(name, 1, value))
+                        {
+                            status  = eOK;
+                            payload = encodeDatabaseFieldAsyncPayload(value);
+                        }
+                        else
+                        {
+                            status = kDbErrorColumnOutOfRange;
+                            ok     = false;
+                        }
+                    }
+                    else if (status == SQLITE_DONE)
+                    {
+                        status = eOK;
+                    }
+                    else
+                    {
+                        ok = false;
+                    }
+                }
+                emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+			                                     QStringLiteral("DatabaseGetField"), ok, status, payload);
+            });
 		lua_pushnil(L);
 		if (accepted && requestId != 0)
 		{
@@ -40949,15 +40948,15 @@ static int luaCallPlugin(lua_State *L)
 
 		const int                    callerTopBefore = lua_gettop(L);
 		const LuaBatchDispatchResult dispatchResult  = runtime->dispatchLuaCallPluginMarshalling(
-		    QSharedPointer<LuaCallbackEngine>(targetEngine, [](LuaCallbackEngine  */*unused*/) {}), routine,
-		    L, 1, engine->pluginId(), callPluginMiniWindowSnapshot);
+            QSharedPointer<LuaCallbackEngine>(targetEngine, [](LuaCallbackEngine  */*unused*/) {}), routine,
+            L, 1, engine->pluginId(), callPluginMiniWindowSnapshot);
 		const bool marshallingExecuted = dispatchResult.boolResultValid ? dispatchResult.boolResult : false;
 		const bool sameState           = dispatchResult.marshallingSameState;
 		CallPluginLuaMarshallingResult marshalling;
-		marshalling.error = dispatchResult.marshallingErrorValid
-		                        ? static_cast<CallPluginLuaMarshallingError>(dispatchResult.marshallingError)
-		                        : CallPluginLuaMarshallingError::NoSuchRoutine;
-		marshalling.index = dispatchResult.marshallingIndex;
+		marshalling.error        = dispatchResult.marshallingErrorValid
+		                               ? static_cast<CallPluginLuaMarshallingError>(dispatchResult.marshallingError)
+		                               : CallPluginLuaMarshallingError::NoSuchRoutine;
+		marshalling.index        = dispatchResult.marshallingIndex;
 		marshalling.typeName     = dispatchResult.marshallingTypeName;
 		marshalling.runtimeError = dispatchResult.marshallingRuntimeError;
 		marshalling.returnCount  = dispatchResult.marshallingReturnCount;
@@ -40978,8 +40977,8 @@ static int luaCallPlugin(lua_State *L)
 			lua_pushnumber(L, eBadParameter);
 			const int     displayIndex = marshalling.index - 1 + 3; // plugin ID + routine removed
 			const QString error        = QStringLiteral("Cannot pass argument #%1 (%2 type) to CallPlugin")
-			                                 .arg(displayIndex)
-			                                 .arg(QString::fromLatin1(marshalling.typeName));
+			                          .arg(displayIndex)
+			                          .arg(QString::fromLatin1(marshalling.typeName));
 			pushLuaUtf8String(L, error);
 			return 2;
 		}
@@ -42634,8 +42633,8 @@ static int luaWindowOutputText(lua_State *L)
 				    {
 					    WorldRuntime::WindowOutputMetrics deferredMetrics;
 					    const int                         deferredResult = targetRuntime.windowOutputText(
-					        name, fontId, text, left, top, right, bottom, colour, mouseUp, hotspotPrefix,
-					        pluginId, &deferredMetrics);
+                            name, fontId, text, left, top, right, bottom, colour, mouseUp, hotspotPrefix,
+                            pluginId, &deferredMetrics);
 					    emitPluginAsyncResult(
 					        targetRuntime, pluginId, asyncRequestId, QStringLiteral("WindowOutputText"),
 					        deferredResult == eOK, deferredResult,
@@ -43409,8 +43408,8 @@ static int luaWindowBlendImage(lua_State *L)
 		}
 		const quint32 randomSeed     = QRandomGenerator::global()->generate();
 		const int     callbackResult = MiniWindowUtils::blendImage(
-		    *shadow, imageId, left, top, right, bottom, mode, opacity, srcLeft, srcTop, srcRight, srcBottom,
-		    callbackMiniWindowSeededRandomUnit(randomSeed));
+            *shadow, imageId, left, top, right, bottom, mode, opacity, srcLeft, srcTop, srcRight, srcBottom,
+            callbackMiniWindowSeededRandomUnit(randomSeed));
 		if (callbackResult != eOK)
 		{
 			lua_pushnumber(L, callbackResult);
@@ -43606,13 +43605,13 @@ static int luaWindowWrite(lua_State *L)
 			const QString callbackPluginId = engine->pluginId();
 			const quint64 requestId = callbackPluginId.isEmpty() ? 0 : nextPluginAsyncResultRequestId();
 			const bool    accepted  = enqueueRuntimeThreadDeferredMutationNoResult(
-			    engine, runtime,
-			    [name, trimmedFileName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
-			    {
-				    const int status = targetRuntime.windowWrite(name, trimmedFileName);
-				    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
-				                          QStringLiteral("WindowWrite"), status == eOK, status, QString());
-			    });
+                engine, runtime,
+                [name, trimmedFileName, callbackPluginId, requestId](WorldRuntime &targetRuntime)
+                {
+                    const int status = targetRuntime.windowWrite(name, trimmedFileName);
+                    emitPluginAsyncResult(targetRuntime, callbackPluginId, requestId,
+				                              QStringLiteral("WindowWrite"), status == eOK, status, QString());
+                });
 			lua_pushnumber(L, accepted ? eOK : eBadParameter);
 			if (accepted && requestId != 0)
 			{

--- a/src/LuaCallbackEngine.cpp
+++ b/src/LuaCallbackEngine.cpp
@@ -20506,7 +20506,7 @@ static int luaPlaySound(lua_State *L)
 	const double  pan      = luaL_optnumber(L, 5, 0.0);
 	if (activeCallbackContextConst(engine))
 	{
-#ifdef QMUD_ENABLE_QSOUND
+#if QMUD_ENABLE_SOUND
 		if (buffer < 0 || buffer > WorldRuntime::kMaxSoundBuffers)
 		{
 			lua_pushnumber(L, eBadParameter);
@@ -20567,7 +20567,7 @@ static int luaPlaySoundMemory(lua_State *L)
 	const QByteArray payload(data, static_cast<int>(length));
 	if (activeCallbackContextConst(engine))
 	{
-#ifdef QMUD_ENABLE_QSOUND
+#if QMUD_ENABLE_SOUND
 		if (buffer < 0 || buffer > WorldRuntime::kMaxSoundBuffers || payload.isEmpty())
 		{
 			lua_pushnumber(L, eBadParameter);
@@ -20615,7 +20615,7 @@ static int luaStopSound(lua_State *L)
 	const int buffer = static_cast<int>(luaL_optnumber(L, 1, 0));
 	if (activeCallbackContextConst(engine))
 	{
-#ifdef QMUD_ENABLE_QSOUND
+#if QMUD_ENABLE_SOUND
 		if (buffer < 0 || buffer > WorldRuntime::kMaxSoundBuffers)
 		{
 			lua_pushnumber(L, eBadParameter);
@@ -20771,7 +20771,7 @@ static int playLuaAudioBuffer(const LuaCallbackEngine *engine, WorldRuntime *run
 	int result = eCannotPlaySound;
 	if (activeCallbackContextConst(engine))
 	{
-#ifdef QMUD_ENABLE_QSOUND
+#if QMUD_ENABLE_SOUND
 		if (callbackScopeSyncBridgeForbidden())
 		{
 			enqueueRuntimeThreadDeferredMutationNoResult(engine, runtime, [play](WorldRuntime &targetRuntime)
@@ -22895,7 +22895,7 @@ static int luaSound(lua_State *L)
 	}
 	if (activeCallbackContextConst(engine))
 	{
-#ifdef QMUD_ENABLE_QSOUND
+#if QMUD_ENABLE_SOUND
 		if (callbackScopeSyncBridgeForbidden())
 		{
 			return enqueueRuntimeThreadAsyncStatusResult(

--- a/src/NativePluginRegistry.cpp
+++ b/src/NativePluginRegistry.cpp
@@ -418,6 +418,8 @@ namespace
 
 	struct MushReaderState
 	{
+			bool                                        mushReaderPluginEnabled{false};
+			bool                                        mushReaderSpeechEnabled{true};
 			bool                                        passiveSpeechEnabled{false};
 			bool                                        substitutionsEnabled{true};
 			bool                                        substitutionsLoaded{false};
@@ -569,6 +571,11 @@ namespace
 		return stopped;
 	}
 
+	bool effectiveMushReaderSpeechEnabled(const MushReaderState &state)
+	{
+		return state.mushReaderPluginEnabled ? state.mushReaderSpeechEnabled : state.passiveSpeechEnabled;
+	}
+
 	void installMushReaderAccelerator(WorldRuntime *runtime, MushReaderState &state)
 	{
 		if (state.runtimeSetupComplete)
@@ -662,8 +669,8 @@ namespace
 		}
 		if (lower.startsWith(QStringLiteral("add ")))
 		{
-			const QString payload = trimmed.mid(4);
-			const int     sep     = payload.indexOf(QStringLiteral("=="));
+			const QString   payload = trimmed.mid(4);
+			const qsizetype sep     = payload.indexOf(QStringLiteral("=="));
 			if (sep < 0)
 			{
 				outputLine(*runtime, QStringLiteral("Substitution add requires <text>==<replacement>."));
@@ -724,7 +731,7 @@ namespace
 		constexpr qsizetype kIndex = 1;
 		if (kIndex >= arguments.size() || !arguments.at(kIndex).isValid())
 			return false;
-		const QVariant value = arguments.at(kIndex);
+		const QVariant &value = arguments.at(kIndex);
 		if (value.typeId() == QMetaType::Bool)
 			return value.toBool();
 		bool         ok     = false;
@@ -1067,14 +1074,14 @@ namespace
 		if (!runtime)
 			return false;
 		const QString audioId = QMudNativePluginRegistry::luaAudioPluginId();
-		for (const WorldRuntime::Plugin &plugin : runtime->plugins())
-		{
-			if (!plugin.enabled || plugin.installPending || plugin.sequence < 0)
-				continue;
-			if (normalizedId(plugin.attributes.value(QStringLiteral("id"))) == audioId)
-				return true;
-		}
-		return false;
+		return std::ranges::any_of(runtime->plugins(),
+		                           [&audioId](const WorldRuntime::Plugin &plugin)
+		                           {
+			                           return plugin.enabled && !plugin.installPending &&
+			                                  plugin.sequence >= 0 &&
+			                                  normalizedId(plugin.attributes.value(QStringLiteral("id"))) ==
+			                                      audioId;
+		                           });
 	}
 
 	void handleLuaAudioVolumeCommand(WorldRuntime *runtime, const int delta)
@@ -1330,7 +1337,7 @@ namespace QMudNativePluginRegistry
 
 	QString normalizeNativeSource(const QString &source)
 	{
-		const QString normalizedSource = normalizeNativeSourceSyntax(source);
+		QString normalizedSource = normalizeNativeSourceSyntax(source);
 		if (normalizedSource.isEmpty())
 			return {};
 		const QString nativeName = normalizedSource.mid(QStringLiteral("qmud:native/").size()).trimmed();
@@ -1697,7 +1704,7 @@ namespace QMudNativePluginRegistry
 
 	QString resolveShimIdOrName(const QString &pluginIdOrName)
 	{
-		const QString key = normalizedId(pluginIdOrName);
+		QString key = normalizedId(pluginIdOrName);
 		if (key.isEmpty())
 			return {};
 		if (isShimId(key))
@@ -1858,13 +1865,21 @@ namespace QMudNativePluginRegistry
 		}
 		if (lower == QStringLiteral("tts"))
 		{
-			MushReaderState &state     = stateFor(runtime);
-			state.passiveSpeechEnabled = !state.passiveSpeechEnabled;
+			MushReaderState &state = stateFor(runtime);
+			bool             enabled;
+			if (state.mushReaderPluginEnabled)
+			{
+				state.mushReaderSpeechEnabled = !state.mushReaderSpeechEnabled;
+				enabled                       = state.mushReaderSpeechEnabled;
+			}
+			else
+			{
+				state.passiveSpeechEnabled = !state.passiveSpeechEnabled;
+				enabled                    = state.passiveSpeechEnabled;
+			}
 			runtime->notifyNativePluginStateChanged();
 			stopSpeech(runtime);
-			speak(runtime,
-			      state.passiveSpeechEnabled ? QStringLiteral("speech on") : QStringLiteral("speech off"),
-			      true);
+			speak(runtime, enabled ? QStringLiteral("speech on") : QStringLiteral("speech off"), true);
 			return true;
 		}
 		if (lower == QStringLiteral("mushreader help") || lower == QStringLiteral("mushreader:help"))
@@ -1951,7 +1966,7 @@ namespace QMudNativePluginRegistry
 			return true;
 		}
 
-		const int separator = trimmed.indexOf(QLatin1Char('='));
+		const qsizetype separator = trimmed.indexOf(QLatin1Char('='));
 		if (separator > 0)
 		{
 			const QString key   = trimmed.left(separator).trimmed().toLower();
@@ -2017,7 +2032,7 @@ namespace QMudNativePluginRegistry
 		if (!runtime || (type != 0 && type != 1) || text.trimmed().isEmpty())
 			return;
 		MushReaderState &state = stateFor(runtime);
-		if (!state.passiveSpeechEnabled)
+		if (!effectiveMushReaderSpeechEnabled(state))
 			return;
 		bool    skip = false;
 		QString line = substitutionAppliedText(runtime, text, skip);
@@ -2030,8 +2045,28 @@ namespace QMudNativePluginRegistry
 		if (!runtime || text.trimmed().isEmpty())
 			return;
 		MushReaderState &state = stateFor(runtime);
-		if (state.passiveSpeechEnabled)
+		if (effectiveMushReaderSpeechEnabled(state))
 			speak(runtime, text, false);
+	}
+
+	void setMushReaderPluginEnabled(const WorldRuntime *runtime, const bool enable)
+	{
+		if (!runtime)
+			return;
+		MushReaderState &state        = stateFor(runtime);
+		state.mushReaderPluginEnabled = enable;
+		state.mushReaderSpeechEnabled = enable;
+		if (!enable)
+			stopSpeech(runtime);
+	}
+
+	bool isMushReaderPluginEnabled(const WorldRuntime *runtime)
+	{
+		if (!runtime)
+			return false;
+		QMutexLocker locker(&stateMutex());
+		const auto   it = states().find(runtime);
+		return it != states().end() && it->second && it->second->mushReaderPluginEnabled;
 	}
 
 	void setMushReaderPassiveSpeechEnabled(const WorldRuntime *runtime, const bool enable)

--- a/src/NativePluginRegistry.h
+++ b/src/NativePluginRegistry.h
@@ -367,13 +367,25 @@ namespace QMudNativePluginRegistry
 	 */
 	void handleMushReaderTabComplete(const WorldRuntime *runtime, const QString &text);
 	/**
-	 * @brief Enables or disables passive native MushReader screen/tab speech.
+	 * @brief Marks whether the native MushReader shim plugin is enabled.
+	 * @param runtime Owning runtime.
+	 * @param enable Enable the native MushReader shim when `true`.
+	 */
+	void setMushReaderPluginEnabled(const WorldRuntime *runtime, bool enable);
+	/**
+	 * @brief Returns whether the native MushReader shim plugin is enabled.
+	 * @param runtime Owning runtime.
+	 * @return `true` when the native MushReader shim plugin is enabled for the runtime.
+	 */
+	[[nodiscard]] bool isMushReaderPluginEnabled(const WorldRuntime *runtime);
+	/**
+	 * @brief Enables or disables passive screen/tab speech used when MushReader is not enabled.
 	 * @param runtime Owning runtime.
 	 * @param enable Enable passive screen/tab speech when `true`.
 	 */
-	void setMushReaderPassiveSpeechEnabled(const WorldRuntime *runtime, bool enable);
+	void               setMushReaderPassiveSpeechEnabled(const WorldRuntime *runtime, bool enable);
 	/**
-	 * @brief Returns whether passive native MushReader screen/tab speech is active.
+	 * @brief Returns whether passive screen/tab speech is enabled outside the MushReader shim.
 	 * @param runtime Owning runtime.
 	 * @return `true` when passive speech is enabled for the runtime.
 	 */

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -10238,7 +10238,8 @@ QSharedPointer<const LuaCallbackMiniWindowSnapshot> WorldRuntime::captureLuaCall
 		const int  shadowIndex = findPluginIndex(m_plugins, shimId);
 		const bool enabled =
 		    shimId.compare(QMudNativePluginRegistry::mushReaderPluginId(), Qt::CaseInsensitive) == 0
-		        ? QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(this) ||
+		        ? QMudNativePluginRegistry::isMushReaderPluginEnabled(this) ||
+		              QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(this) ||
 		              (shadowIndex >= 0 && m_plugins.at(shadowIndex).enabled)
 		        : true;
 		if (!snapshot->pluginIdsSnapshot.contains(shimId, Qt::CaseInsensitive))
@@ -17535,6 +17536,7 @@ void WorldRuntime::applyFromDocument(const WorldDocument &doc)
 	m_pluginCallbackRecipientIndices.clear();
 	m_pluginCallbackPresencePluginCount = -1;
 	invalidatePluginCallbackPresenceCache();
+	QMudNativePluginRegistry::setMushReaderPluginEnabled(this, false);
 	QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, false);
 	QVector<LuaEngineObservedInitializationRequest> pluginLuaInitRequests;
 	pluginLuaInitRequests.reserve(safeQSizeToInt(doc.plugins().size()));
@@ -17572,7 +17574,7 @@ void WorldRuntime::applyFromDocument(const WorldDocument &doc)
 			if (findPluginIndex(m_plugins, metadata.id) < 0)
 				m_plugins.push_back(shadow);
 			if (pluginId == QMudNativePluginRegistry::mushReaderPluginId())
-				QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, requestedEnabled);
+				QMudNativePluginRegistry::setMushReaderPluginEnabled(this, requestedEnabled);
 			continue;
 		}
 		for (const auto &t : p.triggers)
@@ -19337,13 +19339,13 @@ bool WorldRuntime::loadPluginFile(const QString &fileName, QString *error, bool 
 			m_plugins[existingShimIndex].attributes.insert(
 			    QStringLiteral("enabled"), wasEnabled ? QStringLiteral("1") : QStringLiteral("0"));
 			if (pluginId == QMudNativePluginRegistry::mushReaderPluginId())
-				QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, wasEnabled);
+				QMudNativePluginRegistry::setMushReaderPluginEnabled(this, wasEnabled);
 		}
 		else
 		{
 			m_plugins.push_back(makeNativeShimShadowPlugin(metadata, markGlobal));
 			if (pluginId == QMudNativePluginRegistry::mushReaderPluginId())
-				QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, true);
+				QMudNativePluginRegistry::setMushReaderPluginEnabled(this, true);
 		}
 		sortPluginsBySequence();
 		m_pluginCount = safeQSizeToInt(m_plugins.size());
@@ -19546,7 +19548,7 @@ bool WorldRuntime::unloadPlugin(const QString &pluginId, QString *error)
 
 	Plugin &plugin = m_plugins[index];
 	if (plugin.nativeShim && resolvedPluginId == QMudNativePluginRegistry::mushReaderPluginId())
-		QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, false);
+		QMudNativePluginRegistry::setMushReaderPluginEnabled(this, false);
 	if (plugin.nativeShim && resolvedPluginId == QMudNativePluginRegistry::luaAudioPluginId())
 		QMudNativePluginRegistry::luaAudioStopRuntime(this);
 	if (plugin.lua)
@@ -19591,10 +19593,6 @@ bool WorldRuntime::enablePlugin(const QString &pluginId, bool enable)
 	if (index < 0)
 		return QMudNativePluginRegistry::isShimId(resolvedPluginId);
 	Plugin &plugin = m_plugins[index];
-	if (plugin.nativeShim && resolvedPluginId == QMudNativePluginRegistry::mushReaderPluginId())
-		QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, enable);
-	if (plugin.nativeShim && resolvedPluginId == QMudNativePluginRegistry::luaAudioPluginId() && !enable)
-		QMudNativePluginRegistry::luaAudioStopRuntime(this);
 	if (plugin.enabled == enable)
 	{
 		if (enable && plugin.disableAfterInstall)
@@ -19612,6 +19610,10 @@ bool WorldRuntime::enablePlugin(const QString &pluginId, bool enable)
 	if (!enable)
 		plugin.disableAfterInstall = false;
 	plugin.attributes.insert(QStringLiteral("enabled"), enable ? QStringLiteral("1") : QStringLiteral("0"));
+	if (plugin.nativeShim && resolvedPluginId == QMudNativePluginRegistry::mushReaderPluginId())
+		QMudNativePluginRegistry::setMushReaderPluginEnabled(this, enable);
+	if (plugin.nativeShim && resolvedPluginId == QMudNativePluginRegistry::luaAudioPluginId() && !enable)
+		QMudNativePluginRegistry::luaAudioStopRuntime(this);
 	invalidateLuaCallbackDispatchSnapshot();
 	if (enable)
 	{
@@ -21667,7 +21669,8 @@ QVariant WorldRuntime::pluginInfo(const QString &pluginId, int infoType) const
 		const int         shadowIndex  = findPluginIndex(m_plugins, shimId);
 		const bool        enabled =
 		    shimId.compare(QMudNativePluginRegistry::mushReaderPluginId(), Qt::CaseInsensitive) == 0
-		        ? QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(this) ||
+		        ? QMudNativePluginRegistry::isMushReaderPluginEnabled(this) ||
+		              QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(this) ||
 		              (shadowIndex >= 0 && m_plugins.at(shadowIndex).enabled)
 		        : true;
 		for (int i = 0; i < ids.size(); ++i)

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -12611,9 +12611,8 @@ void WorldView::repeatLastCommand()
 {
 	if (!m_input || m_lastCommand.isEmpty())
 		return;
-	if (!confirmReplaceTyping(m_lastCommand))
-		return;
-	setInputText(m_lastCommand, true);
+	emit sendText(m_lastCommand);
+	resetHistoryRecall();
 }
 
 void WorldView::recallLastWord()

--- a/src/dialogs/GlobalPreferencesDialog.cpp
+++ b/src/dialogs/GlobalPreferencesDialog.cpp
@@ -521,7 +521,7 @@ QWidget *GlobalPreferencesDialog::buildWorldsPage()
 			                 app->changeToFileBrowsingDirectory();
 		                 const QString startDir = m_worldDefaultDir ? m_worldDefaultDir->text() : QString();
 		                 const QString dir      = QFileDialog::getExistingDirectory(
-                             this, QStringLiteral("Select Default World Files Directory"), startDir);
+		                     this, QStringLiteral("Select Default World Files Directory"), startDir);
 		                 if (app)
 			                 app->changeToStartupDirectory();
 		                 if (!dir.isEmpty())
@@ -1060,7 +1060,7 @@ QWidget *GlobalPreferencesDialog::buildDefaultsPage()
 	auto *layout = new QVBoxLayout(page);
 
 	auto  connectBrowse = [this](const QPushButton *button, QLineEdit *target, const QString &title,
-                                const QString &filter, const QString &suggestedName)
+	                             const QString &filter, const QString &suggestedName)
 	{
 		QObject::connect(button, &QPushButton::clicked, this,
 		                 [this, target, title, filter, suggestedName]()

--- a/src/dialogs/GlobalPreferencesDialog.cpp
+++ b/src/dialogs/GlobalPreferencesDialog.cpp
@@ -9,6 +9,7 @@
 #include "dialogs/GlobalPreferencesDialog.h"
 
 #include "AppController.h"
+#include "FontUtils.h"
 #include "LogCompressionUtils.h"
 #include "MainFrame.h"
 #include "WorldChildWindow.h"
@@ -24,7 +25,6 @@
 #include <QDirIterator>
 #include <QFileDialog>
 #include <QFileInfo>
-#include <QFontDialog>
 #include <QFormLayout>
 #include <QGridLayout>
 #include <QGroupBox>
@@ -521,7 +521,7 @@ QWidget *GlobalPreferencesDialog::buildWorldsPage()
 			                 app->changeToFileBrowsingDirectory();
 		                 const QString startDir = m_worldDefaultDir ? m_worldDefaultDir->text() : QString();
 		                 const QString dir      = QFileDialog::getExistingDirectory(
-		                     this, QStringLiteral("Select Default World Files Directory"), startDir);
+                             this, QStringLiteral("Select Default World Files Directory"), startDir);
 		                 if (app)
 			                 app->changeToStartupDirectory();
 		                 if (!dir.isEmpty())
@@ -798,7 +798,7 @@ QWidget *GlobalPreferencesDialog::buildPrintingPage()
 			                 current.setWeight(static_cast<QFont::Weight>(m_printerFontWeight));
 		                 current.setItalic(m_printerFontItalic != 0);
 		                 QFont chosen =
-		                     QFontDialog::getFont(&ok, current, this, QStringLiteral("Select Printer Font"));
+		                     qmudGetFont(&ok, current, this, QStringLiteral("Select Printer Font"));
 		                 if (!ok)
 			                 return;
 		                 m_printerFontLabel->setText(chosen.family());
@@ -1060,7 +1060,7 @@ QWidget *GlobalPreferencesDialog::buildDefaultsPage()
 	auto *layout = new QVBoxLayout(page);
 
 	auto  connectBrowse = [this](const QPushButton *button, QLineEdit *target, const QString &title,
-	                             const QString &filter, const QString &suggestedName)
+                                const QString &filter, const QString &suggestedName)
 	{
 		QObject::connect(button, &QPushButton::clicked, this,
 		                 [this, target, title, filter, suggestedName]()
@@ -1163,24 +1163,24 @@ QWidget *GlobalPreferencesDialog::buildDefaultsPage()
 	layout->addLayout(fontGrid);
 	layout->addStretch();
 
-	QObject::connect(
-	    m_outputFontButton, &QPushButton::clicked, page,
-	    [this]()
-	    {
-		    bool  ok = false;
-		    QFont current(m_outputFontName->text());
-		    if (m_outputFontHeight > 0)
-			    current.setPointSize(m_outputFontHeight);
-		    current.setWeight(QFont::Normal);
-		    current.setItalic(false);
-		    QFont chosen = QFontDialog::getFont(&ok, current, this, QStringLiteral("Select Output Font"));
-		    if (!ok)
-			    return;
-		    m_outputFontName->setText(chosen.family());
-		    m_outputFontHeight = chosen.pointSize();
-		    if (m_outputFontStyle)
-			    m_outputFontStyle->setText(fontStyleSummary(m_outputFontHeight, QFont::Normal, false));
-	    });
+	QObject::connect(m_outputFontButton, &QPushButton::clicked, page,
+	                 [this]()
+	                 {
+		                 bool  ok = false;
+		                 QFont current(m_outputFontName->text());
+		                 if (m_outputFontHeight > 0)
+			                 current.setPointSize(m_outputFontHeight);
+		                 current.setWeight(QFont::Normal);
+		                 current.setItalic(false);
+		                 QFont chosen = qmudGetFont(&ok, current, this, QStringLiteral("Select Output Font"));
+		                 if (!ok)
+			                 return;
+		                 m_outputFontName->setText(chosen.family());
+		                 m_outputFontHeight = chosen.pointSize();
+		                 if (m_outputFontStyle)
+			                 m_outputFontStyle->setText(
+			                     fontStyleSummary(m_outputFontHeight, QFont::Normal, false));
+	                 });
 	QObject::connect(m_inputFontButton, &QPushButton::clicked, page,
 	                 [this]()
 	                 {
@@ -1191,8 +1191,7 @@ QWidget *GlobalPreferencesDialog::buildDefaultsPage()
 		                 if (m_inputFontWeight > 0)
 			                 current.setWeight(static_cast<QFont::Weight>(m_inputFontWeight));
 		                 current.setItalic(m_inputFontItalic != 0);
-		                 QFont chosen =
-		                     QFontDialog::getFont(&ok, current, this, QStringLiteral("Select Input Font"));
+		                 QFont chosen = qmudGetFont(&ok, current, this, QStringLiteral("Select Input Font"));
 		                 if (!ok)
 			                 return;
 		                 m_inputFontName->setText(chosen.family());

--- a/src/dialogs/PluginsDialog.cpp
+++ b/src/dialogs/PluginsDialog.cpp
@@ -121,6 +121,7 @@ PluginsDialog::PluginsDialog(WorldRuntime *runtime, MainWindow *main, QWidget *p
 	m_table->setColumnCount(kColumnCount);
 	m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	m_table->setTabKeyNavigation(false);
 	m_table->setSortingEnabled(true);
 	m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
 	m_table->horizontalHeader()->setStretchLastSection(false);
@@ -228,7 +229,7 @@ PluginsDialog::PluginsDialog(WorldRuntime *runtime, MainWindow *main, QWidget *p
 		clampColumnsToViewport(m_table);
 		const int  sortColumn = settings.value(QStringLiteral("SortColumn"), kColumnName).toInt();
 		const auto sortOrder  = static_cast<Qt::SortOrder>(
-		    settings.value(QStringLiteral("SortOrder"), Qt::AscendingOrder).toInt());
+            settings.value(QStringLiteral("SortOrder"), Qt::AscendingOrder).toInt());
 		if (sortColumn >= 0)
 			m_table->sortByColumn(sortColumn, sortOrder);
 		settings.endGroup();
@@ -263,10 +264,10 @@ void PluginsDialog::reloadList() const
 			continue;
 		visiblePluginRows.push_back(pluginIndex);
 	}
-	constexpr qsizetype maxPluginRows = static_cast<qsizetype>(std::numeric_limits<int>::max());
-	const int           pluginCount   = visiblePluginRows.size() > maxPluginRows
-	                                        ? std::numeric_limits<int>::max()
-	                                        : static_cast<int>(visiblePluginRows.size());
+	constexpr auto maxPluginRows = static_cast<qsizetype>(std::numeric_limits<int>::max());
+	const int      pluginCount   = visiblePluginRows.size() > maxPluginRows
+	                                   ? std::numeric_limits<int>::max()
+	                                   : static_cast<int>(visiblePluginRows.size());
 	m_table->setRowCount(pluginCount);
 
 	for (int row = 0; row < pluginCount; ++row)
@@ -275,7 +276,7 @@ void PluginsDialog::reloadList() const
 		const QString               pluginId = plugin.attributes.value(QStringLiteral("id"));
 		const QString               name     = plugin.attributes.value(QStringLiteral("name"));
 		const QString               purpose =
-		    plugin.nativeShim ? plugin.nativeShimMarker : plugin.attributes.value(QStringLiteral("purpose"));
+            plugin.nativeShim ? plugin.nativeShimMarker : plugin.attributes.value(QStringLiteral("purpose"));
 		const QString author  = plugin.attributes.value(QStringLiteral("author"));
 		const QString file    = plugin.source;
 		const QString enabled = plugin.enabled ? QStringLiteral("Yes") : QStringLiteral("No");

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -9,6 +9,7 @@
 #include "dialogs/WorldPreferencesDialog.h"
 #include "AppController.h"
 #include "FileExtensions.h"
+#include "FontUtils.h"
 #include "StringUtils.h"
 #include "Version.h"
 #include "WorldDocument.h"
@@ -34,7 +35,6 @@
 #include <QEvent>
 #include <QFileDialog>
 #include <QFileInfo>
-#include <QFontDialog>
 #include <QFontMetrics>
 #include <QFormLayout>
 #include <QFrame>
@@ -717,8 +717,8 @@ static void browseSoundFile(WorldRuntime *runtime, QWidget *parent, QLineEdit *t
 	const QString startDir    = runtime ? runtime->fileBrowsingDirectory() : QString();
 	const QString initialPath = start.isEmpty() ? startDir : start;
 	const QString fileName    = QFileDialog::getOpenFileName(
-	    parent, QStringLiteral("Select sound to play"), initialPath,
-	    QStringLiteral("Waveaudio files (*.wav);;MIDI files (*.mid);;Sequencer files (*.rmi)"));
+        parent, QStringLiteral("Select sound to play"), initialPath,
+        QStringLiteral("Waveaudio files (*.wav);;MIDI files (*.mid);;Sequencer files (*.rmi)"));
 	if (!fileName.isEmpty())
 	{
 		if (runtime)
@@ -5163,7 +5163,7 @@ void WorldPreferencesDialog::buildUi()
 		        if (m_outputFontWeight > 0)
 			        current.setWeight(WorldView::mapFontWeight(m_outputFontWeight));
 		        bool        ok   = false;
-		        const QFont font = QFontDialog::getFont(&ok, current, this, QStringLiteral("Output font"));
+		        const QFont font = qmudGetFont(&ok, current, this, QStringLiteral("Output font"));
 		        if (!ok)
 			        return;
 		        if (m_outputFontName)
@@ -5757,7 +5757,7 @@ void WorldPreferencesDialog::buildUi()
 			        current.setWeight(WorldView::mapFontWeight(m_inputFontWeight));
 		        current.setItalic(m_inputFontItalic);
 		        bool        ok   = false;
-		        const QFont font = QFontDialog::getFont(&ok, current, this, QStringLiteral("Input font"));
+		        const QFont font = qmudGetFont(&ok, current, this, QStringLiteral("Input font"));
 		        if (!ok)
 			        return;
 		        if (m_inputFontName)
@@ -6273,7 +6273,7 @@ void WorldPreferencesDialog::buildUi()
 			        AppController *app              = AppController::instance();
 			        const QString  resolvedFileName = app ? app->makeAbsolutePath(fileName) : fileName;
 			        const QString  editorWindowName =
-			            m_editorWindowName ? m_editorWindowName->text().trimmed() : QString();
+                        m_editorWindowName ? m_editorWindowName->text().trimmed() : QString();
 			        const auto tryRaiseConfiguredEditorWindow = [&]
 			        {
 				        if (editorWindowName.isEmpty())
@@ -7185,8 +7185,8 @@ void WorldPreferencesDialog::buildUi()
 	// Printing
 	auto *printingLayout     = new QVBoxLayout(printingPage);
 	auto  buildPrintingGroup = [](const QString &title, QVector<QCheckBox *> &boldChecks,
-	                              QVector<QCheckBox *> &italicChecks, QVector<QCheckBox *> &underlineChecks,
-	                              QWidget *parent) -> QGroupBox *
+                                 QVector<QCheckBox *> &italicChecks, QVector<QCheckBox *> &underlineChecks,
+                                 QWidget *parent) -> QGroupBox *
 	{
 		static const QStringList colours = {QStringLiteral("Black"), QStringLiteral("Red"),
 		                                    QStringLiteral("Green"), QStringLiteral("Yellow"),
@@ -7437,7 +7437,7 @@ void WorldPreferencesDialog::buildUi()
 	        {
 		        const QString startDir = m_runtime ? m_runtime->fileBrowsingDirectory() : QString();
 		        const QString dirName  = QFileDialog::getExistingDirectory(
-		            this, QStringLiteral("Save chat files folder"), startDir);
+                    this, QStringLiteral("Save chat files folder"), startDir);
 		        if (!dirName.isEmpty())
 		        {
 			        if (m_runtime)
@@ -8932,8 +8932,8 @@ void WorldPreferencesDialog::buildUi()
 	const int      treeHeight = rowHeight * treeItems + (m_pageTree->frameWidth() * 2) + 12;
 	const QMargins margins    = layout->contentsMargins();
 	const int      minHeight  = treeHeight + buttons->sizeHint().height() + margins.top() + margins.bottom() +
-	                            (layout->spacing() * 2);
-	const int      minHeightWithPadding = minHeight + ((minHeight * 2) / 10);
+	                      (layout->spacing() * 2);
+	const int minHeightWithPadding = minHeight + ((minHeight * 2) / 10);
 	setMinimumHeight(qMax(minHeightWithPadding, minimumHeight()));
 	int baseWidth = qMax(minimumWidth(), sizeHint().width());
 	baseWidth += (baseWidth * 1) / 20;

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -717,8 +717,8 @@ static void browseSoundFile(WorldRuntime *runtime, QWidget *parent, QLineEdit *t
 	const QString startDir    = runtime ? runtime->fileBrowsingDirectory() : QString();
 	const QString initialPath = start.isEmpty() ? startDir : start;
 	const QString fileName    = QFileDialog::getOpenFileName(
-        parent, QStringLiteral("Select sound to play"), initialPath,
-        QStringLiteral("Waveaudio files (*.wav);;MIDI files (*.mid);;Sequencer files (*.rmi)"));
+	    parent, QStringLiteral("Select sound to play"), initialPath,
+	    QStringLiteral("Waveaudio files (*.wav);;MIDI files (*.mid);;Sequencer files (*.rmi)"));
 	if (!fileName.isEmpty())
 	{
 		if (runtime)
@@ -6273,7 +6273,7 @@ void WorldPreferencesDialog::buildUi()
 			        AppController *app              = AppController::instance();
 			        const QString  resolvedFileName = app ? app->makeAbsolutePath(fileName) : fileName;
 			        const QString  editorWindowName =
-                        m_editorWindowName ? m_editorWindowName->text().trimmed() : QString();
+			            m_editorWindowName ? m_editorWindowName->text().trimmed() : QString();
 			        const auto tryRaiseConfiguredEditorWindow = [&]
 			        {
 				        if (editorWindowName.isEmpty())
@@ -7185,8 +7185,8 @@ void WorldPreferencesDialog::buildUi()
 	// Printing
 	auto *printingLayout     = new QVBoxLayout(printingPage);
 	auto  buildPrintingGroup = [](const QString &title, QVector<QCheckBox *> &boldChecks,
-                                 QVector<QCheckBox *> &italicChecks, QVector<QCheckBox *> &underlineChecks,
-                                 QWidget *parent) -> QGroupBox *
+	                              QVector<QCheckBox *> &italicChecks, QVector<QCheckBox *> &underlineChecks,
+	                              QWidget *parent) -> QGroupBox *
 	{
 		static const QStringList colours = {QStringLiteral("Black"), QStringLiteral("Red"),
 		                                    QStringLiteral("Green"), QStringLiteral("Yellow"),
@@ -7437,7 +7437,7 @@ void WorldPreferencesDialog::buildUi()
 	        {
 		        const QString startDir = m_runtime ? m_runtime->fileBrowsingDirectory() : QString();
 		        const QString dirName  = QFileDialog::getExistingDirectory(
-                    this, QStringLiteral("Save chat files folder"), startDir);
+		            this, QStringLiteral("Save chat files folder"), startDir);
 		        if (!dirName.isEmpty())
 		        {
 			        if (m_runtime)
@@ -8932,8 +8932,8 @@ void WorldPreferencesDialog::buildUi()
 	const int      treeHeight = rowHeight * treeItems + (m_pageTree->frameWidth() * 2) + 12;
 	const QMargins margins    = layout->contentsMargins();
 	const int      minHeight  = treeHeight + buttons->sizeHint().height() + margins.top() + margins.bottom() +
-	                      (layout->spacing() * 2);
-	const int minHeightWithPadding = minHeight + ((minHeight * 2) / 10);
+	                            (layout->spacing() * 2);
+	const int      minHeightWithPadding = minHeight + ((minHeight * 2) / 10);
 	setMinimumHeight(qMax(minHeightWithPadding, minimumHeight()));
 	int baseWidth = qMax(minimumWidth(), sizeHint().width());
 	baseWidth += (baseWidth * 1) / 20;

--- a/src/helpers/FontUtils.cpp
+++ b/src/helpers/FontUtils.cpp
@@ -10,6 +10,7 @@
 #include "FontUtils.h"
 
 #include <QFont>
+#include <QFontDialog>
 #include <QStringList>
 
 namespace
@@ -24,6 +25,15 @@ namespace
 		         << QStringLiteral("Menlo") << QStringLiteral("Monaco") << QStringLiteral("Courier New");
 		families.removeDuplicates();
 		return families;
+	}
+
+	QFontDialog::FontDialogOptions fontDialogOptions()
+	{
+#ifdef Q_OS_MACOS
+		return QFontDialog::DontUseNativeDialog;
+#else
+		return {};
+#endif
 	}
 } // namespace
 
@@ -42,6 +52,20 @@ QFont qmudPreferredMonospaceFont(const QString &preferredFamily, const int point
 	if (pointSize > 0)
 		font.setPointSize(pointSize);
 	return font;
+}
+
+bool qmudFontDialogUsesQtDialog()
+{
+#ifdef Q_OS_MACOS
+	return true;
+#else
+	return false;
+#endif
+}
+
+QFont qmudGetFont(bool *ok, const QFont &initial, QWidget *parent, const QString &title)
+{
+	return QFontDialog::getFont(ok, initial, parent, title, fontDialogOptions());
 }
 
 bool qmudMapWindowsCharsetToWritingSystem(const int charset, QFontDatabase::WritingSystem *outWritingSystem)

--- a/src/helpers/FontUtils.h
+++ b/src/helpers/FontUtils.h
@@ -13,6 +13,7 @@
 #include <QString>
 
 class QFont;
+class QWidget;
 
 /**
  * @brief Applies fallback monospace family to font when needed.
@@ -27,6 +28,20 @@ void    qmudApplyMonospaceFallback(QFont &font, const QString &preferredFamily =
  * @return Selected monospace font.
  */
 QFont   qmudPreferredMonospaceFont(const QString &preferredFamily = QString(), int pointSize = 0);
+/**
+ * @brief Returns whether QMud uses the Qt font dialog instead of the native platform dialog.
+ * @return `true` when QMud intentionally uses the Qt font dialog.
+ */
+bool    qmudFontDialogUsesQtDialog();
+/**
+ * @brief Opens QMud's standard font picker with platform-correct dialog options.
+ * @param ok Receives whether the user accepted the dialog.
+ * @param initial Initial font selection.
+ * @param parent Parent widget for the dialog.
+ * @param title Dialog title.
+ * @return Chosen font when accepted, otherwise an undefined dialog result.
+ */
+QFont   qmudGetFont(bool *ok, const QFont &initial, QWidget *parent, const QString &title);
 /**
  * @brief Maps Windows charset id to Qt writing system.
  * @param charset Windows charset id.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,7 +131,7 @@ qmud_add_qtest(tst_MiniWindowUtils
         "${CMAKE_SOURCE_DIR}/src/helpers/MiniWindowUtils.cpp"
         "${CMAKE_SOURCE_DIR}/src/helpers/FontUtils.cpp"
         LIBRARIES
-        Qt6::Gui
+        Qt6::Widgets
         LABELS
         unit)
 
@@ -231,6 +231,7 @@ if (QMUD_ENABLE_LUA_SCRIPTING)
             "${CMAKE_SOURCE_DIR}/src/Sqlite3Lua.cpp"
             "${CMAKE_SOURCE_DIR}/src/Environment.cpp"
             "${CMAKE_SOURCE_DIR}/src/helpers/AcceleratorUtils.cpp"
+            "${CMAKE_SOURCE_DIR}/src/helpers/FontUtils.cpp"
             "${CMAKE_SOURCE_DIR}/src/helpers/LuaExecutionUtils.cpp"
             "${CMAKE_SOURCE_DIR}/src/helpers/PluginPathUtils.cpp"
             LIBRARIES
@@ -809,6 +810,7 @@ if (QMUD_ENABLE_GUI_TESTS)
             SOURCES
             gui/tst_Dialog_GlobalPreferencesUpdates.cpp
             "${CMAKE_SOURCE_DIR}/src/dialogs/GlobalPreferencesDialog.cpp"
+            "${CMAKE_SOURCE_DIR}/src/helpers/FontUtils.cpp"
             "${CMAKE_SOURCE_DIR}/src/AppController.h"
             LIBRARIES
             Qt6::Sql

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,46 +218,13 @@ if (QMUD_ENABLE_LUA_SCRIPTING)
     target_compile_definitions(tst_LuaExecution PRIVATE QMUD_ENABLE_LUA_SCRIPTING)
 
     qmud_add_qtest(tst_LuaCallbackEngine
+            GUI
             SOURCES
             unit/tst_LuaCallbackEngine.cpp
-            "${CMAKE_SOURCE_DIR}/src/WorldRuntime.h"
-            "${CMAKE_SOURCE_DIR}/src/LuaCallbackEngine.cpp"
-            "${CMAKE_SOURCE_DIR}/src/LuaExecutor.cpp"
-            "${CMAKE_SOURCE_DIR}/src/LuaExecutorWorker.cpp"
-            "${CMAKE_SOURCE_DIR}/src/LuaSupport.cpp"
-            "${CMAKE_SOURCE_DIR}/src/LuaLuacomShim.cpp"
-            "${CMAKE_SOURCE_DIR}/src/NativePluginRegistry.cpp"
-            "${CMAKE_SOURCE_DIR}/src/TtsEngine.cpp"
-            "${CMAKE_SOURCE_DIR}/src/Sqlite3Lua.cpp"
-            "${CMAKE_SOURCE_DIR}/src/Environment.cpp"
-            "${CMAKE_SOURCE_DIR}/src/helpers/AcceleratorUtils.cpp"
-            "${CMAKE_SOURCE_DIR}/src/helpers/FontUtils.cpp"
-            "${CMAKE_SOURCE_DIR}/src/helpers/LuaExecutionUtils.cpp"
-            "${CMAKE_SOURCE_DIR}/src/helpers/PluginPathUtils.cpp"
             LIBRARIES
-            ${LUA_LIBRARIES}
-            Qt6::Gui
-            Qt6::Widgets
-            Qt6::Network
-            Qt6::Sql
-            ${QMUD_QT_TEXTTOSPEECH_TARGET}
+            qmud_app_core
             LABELS
             unit)
-    if (TARGET Lua::Lua)
-        target_link_libraries(tst_LuaCallbackEngine PRIVATE Lua::Lua)
-    endif ()
-    if (DEFINED LUA_INCLUDE_DIR)
-        target_include_directories(tst_LuaCallbackEngine SYSTEM BEFORE PRIVATE ${LUA_INCLUDE_DIR})
-    elseif (DEFINED LUA_INCLUDE_DIRS)
-        target_include_directories(tst_LuaCallbackEngine SYSTEM BEFORE PRIVATE ${LUA_INCLUDE_DIRS})
-    endif ()
-    target_compile_definitions(tst_LuaCallbackEngine
-            PRIVATE
-            QMUD_ENABLE_LUA_SCRIPTING
-            QMUD_LUACALLBACKENGINE_TEST_MINIMAL_BINDINGS
-            QMUD_ENABLE_TEXT_TO_SPEECH=${QMUD_ENABLE_TEXT_TO_SPEECH_VALUE})
-    target_compile_options(tst_LuaCallbackEngine PRIVATE -ffunction-sections -fdata-sections)
-    target_link_options(tst_LuaCallbackEngine PRIVATE -Wl,--gc-sections)
 
     qmud_add_qtest(tst_LuaLuacomShim
             SOURCES

--- a/tests/gui/tst_Dialog_Plugins.cpp
+++ b/tests/gui/tst_Dialog_Plugins.cpp
@@ -16,6 +16,8 @@
 #include "dialogs/PluginsDialog.h"
 #include "scripting/ScriptingErrors.h"
 
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QApplication>
 #include <QPushButton>
 #include <QTableWidget>
 #include <QtTest/QSignalSpy>
@@ -269,6 +271,27 @@ class tst_Dialog_Plugins : public QObject
 			QVERIFY(table->item(0, 0));
 			QCOMPARE(table->item(0, 0)->text(), QStringLiteral("Visible"));
 			QCOMPARE(table->item(0, 0)->data(Qt::UserRole).toString(), QStringLiteral("visible"));
+		}
+
+		void tabLeavesPluginTableForActionButtons()
+		{
+			WorldRuntime runtime;
+			runtime.pluginsMutable().push_back(makePlugin(QStringLiteral("plug"), QStringLiteral("Plugin")));
+
+			PluginsDialog dialog(&runtime, nullptr);
+			dialog.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&dialog));
+
+			auto *table = dialog.findChild<QTableWidget *>();
+			QVERIFY(table);
+			QPushButton *addButton = findButtonByText(dialog, QStringLiteral("Add..."));
+			QVERIFY(addButton);
+
+			table->setFocus();
+			QTRY_COMPARE(QApplication::focusWidget(), table);
+
+			QTest::keyClick(table, Qt::Key_Tab);
+			QTRY_COMPARE(QApplication::focusWidget(), addButton);
 		}
 
 		void enableDisableAndReloadActOnSelectedPlugin()

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -7000,6 +7000,33 @@ class tst_WorldView_Basic : public QObject
 			resetTestState();
 		}
 
+		void repeatLastCommandSendsHistoryTailAndPreservesInput()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("history_lines"), QStringLiteral("50"));
+
+			WorldView view;
+			view.resize(760, 460);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			view.addToHistoryForced(QStringLiteral("qcmd-older-a14"));
+			view.addToHistoryForced(QStringLiteral("qcmd-repeat-b92"));
+			view.setInputText(QStringLiteral("qcmd-partial-c37"), true);
+			QCoreApplication::processEvents();
+
+			QSignalSpy sendSpy(&view, &WorldView::sendText);
+			view.repeatLastCommand();
+
+			QCOMPARE(sendSpy.size(), 1);
+			QCOMPARE(sendSpy.constFirst().constFirst().toString(), QStringLiteral("qcmd-repeat-b92"));
+			QCOMPARE(view.inputText(), QStringLiteral("qcmd-partial-c37"));
+			QCOMPARE(view.commandHistoryList(),
+			         (QStringList{QStringLiteral("qcmd-older-a14"), QStringLiteral("qcmd-repeat-b92")}));
+
+			resetTestState();
+		}
+
 		void lineInformationTooltipShowsUnknownTimeWhenRuntimeLineHasNoTimestamp()
 		{
 			resetTestState();

--- a/tests/unit/tst_FontUtils.cpp
+++ b/tests/unit/tst_FontUtils.cpp
@@ -19,7 +19,7 @@ class tst_FontUtils : public QObject
 {
 		Q_OBJECT
 
-	// NOLINTBEGIN(readability-convert-member-functions-to-static)
+		// NOLINTBEGIN(readability-convert-member-functions-to-static)
 	private slots:
 		void applyMonospaceFallback()
 		{
@@ -34,6 +34,15 @@ class tst_FontUtils : public QObject
 			const QFont font = qmudPreferredMonospaceFont(QStringLiteral("DejaVu Sans Mono"), 13);
 			QVERIFY(font.fixedPitch());
 			QCOMPARE(font.pointSize(), 13);
+		}
+
+		void fontDialogUsesQtDialogOnMacOS()
+		{
+#ifdef Q_OS_MACOS
+			QVERIFY(qmudFontDialogUsesQtDialog());
+#else
+			QVERIFY(!qmudFontDialogUsesQtDialog());
+#endif
 		}
 
 		void mapCharsetKnownAndUnknown()
@@ -52,12 +61,10 @@ class tst_FontUtils : public QObject
 			QCOMPARE(qmudFamilyForCharset(QStringLiteral("MyPreferredFamily"), 999),
 			         QStringLiteral("MyPreferredFamily"));
 		}
-	// NOLINTEND(readability-convert-member-functions-to-static)
+		// NOLINTEND(readability-convert-member-functions-to-static)
 };
 
 QTEST_GUILESS_MAIN(tst_FontUtils)
-
-
 
 #if __has_include("tst_FontUtils.moc")
 #include "tst_FontUtils.moc"

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -921,18 +921,18 @@ void tst_LuaCallbackEngine::worldLuaFileApisUseRuntimeHomeAcrossThreadAffinity()
 	WorldRuntime runtime;
 	QThread     *mainThread = QThread::currentThread();
 	const auto   cleanup    = qScopeGuard(
-        [&]()
-        {
-            if (runtime.thread() == &worker)
-            {
-                const bool moved = QMetaObject::invokeMethod(
-                    &runtime, [&runtime, mainThread]() { runtime.moveToThread(mainThread); },
-                    Qt::BlockingQueuedConnection);
-                QVERIFY(moved);
-            }
-            worker.quit();
-            worker.wait();
-        });
+	    [&]()
+	    {
+		    if (runtime.thread() == &worker)
+		    {
+			    const bool moved = QMetaObject::invokeMethod(
+			        &runtime, [&runtime, mainThread]() { runtime.moveToThread(mainThread); },
+			        Qt::BlockingQueuedConnection);
+			    QVERIFY(moved);
+		    }
+		    worker.quit();
+		    worker.wait();
+	    });
 	worker.start();
 	QVERIFY(worker.isRunning());
 	runtime.setStartupDirectory(root.absolutePath());

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -6,15 +6,12 @@
  * Role: Unit coverage for Lua callback-engine dispatch, catalog, and callback-context semantics.
  */
 
-#include "AppController.h"
 #include "LuaCallbackEngine.h"
 #include "LuaExecutor.h"
 #include "LuaExecutorWorker.h"
 #include "LuaSupport.h"
 #include "NativePluginRegistry.h"
-#include "TelnetProcessor.h"
 #include "WorldRuntime.h"
-#include "WorldView.h"
 #include "helpers/LuaExecutionUtils.h"
 #include "helpers/PluginPathUtils.h"
 #include "scripting/ScriptingErrors.h"
@@ -22,6 +19,9 @@
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QDir>
 #include <QFile>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QMetaObject>
 #include <QScopeGuard>
 // ReSharper disable once CppUnusedIncludeDirective
@@ -39,765 +39,6 @@ extern "C"
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>
-}
-
-AppController *AppController::instance()
-{
-	return nullptr;
-}
-
-// NOLINTBEGIN(readability-convert-member-functions-to-static,readability-make-member-function-const,readability-non-const-parameter)
-QVariant AppController::getGlobalOption(const QString &name) const
-{
-	Q_UNUSED(name);
-	return {};
-}
-
-QString AppController::iniFilePath() const
-{
-	return QDir::current().filePath(QStringLiteral("qmud.ini"));
-}
-
-bool AppController::isTranslatorLuaAvailable() const
-{
-	return false;
-}
-
-QVariantMap qmudCollectGuiSystemValues()
-{
-	return {};
-}
-
-TelnetProcessor::TelnetProcessor() = default;
-
-namespace
-{
-	struct RuntimeStubState
-	{
-			int                                           outputBatchDepth     = 0;
-			int                                           miniWindowBatchDepth = 0;
-			int                                           savePluginStateCalls = 0;
-			unsigned short                                noteStyle            = 0;
-			int                                           noteTextColour       = 0;
-			long                                          noteColourFore       = 0xFFFFFF;
-			long                                          noteColourBack       = 0;
-			bool                                          notesInRgb           = false;
-			QStringList                                   outputLines;
-			QList<bool>                                   outputNewLines;
-			QStringList                                   windowNames;
-			QHash<QString, QHash<int, QVariant>>          windowInfo;
-			QHash<QString, QStringList>                   hotspotIds;
-			QHash<int, int>                               soundStatusByBuffer;
-			QVector<WorldRuntime::LineEntry>              lineEntries;
-			QString                                       startupDirectory;
-			QMap<QString, QString>                        worldAttributes;
-			QString                                       logFileName;
-			QString                                       worldFilePath;
-			QString                                       defaultWorldDirectory;
-			QString                                       defaultLogDirectory;
-			QString                                       pluginsDirectory;
-			QString                                       translatorFile;
-			QString                                       firstSpecialFontPath;
-			QString                                       preferencesDatabaseName;
-			QString                                       fileBrowsingDirectory;
-			QString                                       stateFilesDirectory;
-			QList<WorldRuntime::Plugin>                   plugins;
-			QList<WorldRuntime::Variable>                 variables;
-			QSharedPointer<LuaCallbackMiniWindowSnapshot> variableDispatchSnapshotCache;
-			int                nextAcceleratorCommand = WorldRuntime::kAcceleratorFirstCommand;
-			QHash<qint64, int> acceleratorKeyToCommand;
-			QHash<int, WorldRuntime::AcceleratorEntry> acceleratorEntries;
-	};
-
-	QHash<const WorldRuntime *, RuntimeStubState> &runtimeStubStates()
-	{
-		static QHash<const WorldRuntime *, RuntimeStubState> states;
-		return states;
-	}
-
-	RuntimeStubState &runtimeStubState(const WorldRuntime *runtime)
-	{
-		return runtimeStubStates()[runtime];
-	}
-
-	WorldRuntime::LineEntry makeStubLineEntry(const RuntimeStubState &state, const QString &text,
-	                                          const int flags, const QVector<WorldRuntime::StyleSpan> &spans,
-	                                          const bool hardReturn)
-	{
-		qint64 nextLineNumber = 1;
-		for (const WorldRuntime::LineEntry &entry : state.lineEntries)
-			nextLineNumber = qMax(nextLineNumber, entry.lineNumber + 1);
-
-		WorldRuntime::LineEntry entry;
-		entry.text       = text;
-		entry.flags      = flags;
-		entry.spans      = spans;
-		entry.hardReturn = hardReturn;
-		entry.time       = QDateTime::currentDateTime();
-		entry.lineNumber = nextLineNumber;
-		return entry;
-	}
-
-	QStringList logicalOutputLinesFromEntries(const QVector<WorldRuntime::LineEntry> &entries)
-	{
-		QStringList lines;
-		QString     currentLine;
-		for (const WorldRuntime::LineEntry &entry : entries)
-		{
-			if ((entry.flags & WorldRuntime::LineHidden) != 0)
-				continue;
-			currentLine += entry.text;
-			if (entry.hardReturn)
-			{
-				lines.push_back(currentLine);
-				currentLine.clear();
-			}
-		}
-		if (!currentLine.isEmpty())
-			lines.push_back(currentLine);
-		return lines;
-	}
-
-	int safeQSizeToInt(const qsizetype size)
-	{
-		if (size <= 0)
-			return 0;
-		constexpr qsizetype kMaxInt = std::numeric_limits<int>::max();
-		return size > kMaxInt ? std::numeric_limits<int>::max() : static_cast<int>(size);
-	}
-
-	QSharedPointer<const LuaCallbackMiniWindowSnapshot>
-	captureVariableDispatchSnapshotForTest(const WorldRuntime &runtime)
-	{
-		RuntimeStubState &state = runtimeStubState(&runtime);
-		if (state.variableDispatchSnapshotCache)
-			return state.variableDispatchSnapshotCache;
-		auto snapshot                       = QSharedPointer<LuaCallbackMiniWindowSnapshot>::create();
-		snapshot->worldVariablesSnapshot    = runtime.variableSnapshot();
-		snapshot->hasWorldVariablesSnapshot = true;
-		state.variableDispatchSnapshotCache = snapshot;
-		return snapshot;
-	}
-} // namespace
-
-WorldRuntime::WorldRuntime(QObject *parent) : QObject(parent)
-{
-	runtimeStubStates().insert(this, RuntimeStubState{});
-}
-
-WorldRuntime::~WorldRuntime()
-{
-	QMudNativePluginRegistry::discardRuntimeState(this);
-	runtimeStubStates().remove(this);
-}
-
-void WorldRuntime::notifyNativePluginStateChanged()
-{
-}
-
-void WorldRuntime::addScriptTime(qint64 nanos)
-{
-	Q_UNUSED(nanos);
-}
-
-WorldRuntime::RuntimeCountersSnapshot WorldRuntime::runtimeCountersSnapshot(bool includeStrings) const
-{
-	Q_UNUSED(includeStrings);
-	RuntimeCountersSnapshot snapshot;
-	const RuntimeStubState &state = runtimeStubState(this);
-	snapshot.notesInRgb           = state.notesInRgb;
-	snapshot.noteStyle            = state.noteStyle;
-	snapshot.noteTextColour       = state.noteTextColour;
-	snapshot.noteColourFore       = state.noteColourFore;
-	snapshot.noteColourBack       = state.noteColourBack;
-	snapshot.outputLineCount      = safeQSizeToInt(state.outputLines.size());
-	if (includeStrings)
-	{
-		snapshot.logFileName             = state.logFileName;
-		snapshot.worldFilePath           = state.worldFilePath;
-		snapshot.defaultWorldDirectory   = state.defaultWorldDirectory;
-		snapshot.defaultLogDirectory     = state.defaultLogDirectory;
-		snapshot.pluginsDirectory        = state.pluginsDirectory;
-		snapshot.startupDirectory        = state.startupDirectory;
-		snapshot.translatorFile          = state.translatorFile;
-		snapshot.firstSpecialFontPath    = state.firstSpecialFontPath;
-		snapshot.preferencesDatabaseName = state.preferencesDatabaseName;
-		snapshot.fileBrowsingDirectory   = state.fileBrowsingDirectory;
-		snapshot.stateFilesDirectory     = state.stateFilesDirectory;
-	}
-	return snapshot;
-}
-
-void WorldRuntime::beginOutputViewMutationBatch()
-{
-	++runtimeStubState(this).outputBatchDepth;
-}
-
-void WorldRuntime::endOutputViewMutationBatch()
-{
-	--runtimeStubState(this).outputBatchDepth;
-}
-
-bool WorldRuntime::luaContextLineEntry(int lineNumber, LineEntry &entry) const
-{
-	Q_UNUSED(lineNumber);
-	Q_UNUSED(entry);
-	return false;
-}
-
-int WorldRuntime::luaContextLinesInBufferCount() const
-{
-	return 0;
-}
-
-void WorldRuntime::beginMiniWindowMutationBatch()
-{
-	++runtimeStubState(this).miniWindowBatchDepth;
-}
-
-void WorldRuntime::endMiniWindowMutationBatch()
-{
-	--runtimeStubState(this).miniWindowBatchDepth;
-}
-
-QString WorldRuntime::startupDirectory() const
-{
-	return runtimeStubState(this).startupDirectory;
-}
-
-QString WorldRuntime::defaultLogDirectory() const
-{
-	return {};
-}
-
-QString WorldRuntime::worldAttributeValue(const QString &key) const
-{
-	return runtimeStubState(this).worldAttributes.value(key);
-}
-
-QString WorldRuntime::worldMultilineAttributeValue(const QString &key) const
-{
-	return worldAttributeValue(key);
-}
-
-long WorldRuntime::backgroundColour() const
-{
-	return 0;
-}
-
-WorldRuntime::CommandUiSnapshot WorldRuntime::commandUiSnapshot(bool includeHistory, bool includeFrameData,
-                                                                bool allowSelectedWordHitTest) const
-{
-	Q_UNUSED(includeHistory);
-	Q_UNUSED(includeFrameData);
-	Q_UNUSED(allowSelectedWordHitTest);
-	return {};
-}
-
-unsigned short WorldRuntime::noteStyle() const
-{
-	return runtimeStubState(this).noteStyle;
-}
-
-bool WorldRuntime::notesInRgb() const
-{
-	return runtimeStubState(this).notesInRgb;
-}
-
-int WorldRuntime::noteTextColour() const
-{
-	return runtimeStubState(this).noteTextColour;
-}
-
-void WorldRuntime::setNoteTextColour(int value)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	state.noteTextColour    = value;
-	state.notesInRgb        = false;
-}
-
-long WorldRuntime::noteColourFore() const
-{
-	return runtimeStubState(this).noteColourFore;
-}
-
-void WorldRuntime::setNoteColourFore(long value)
-{
-	runtimeStubState(this).noteColourFore = value & 0x00FFFFFF;
-	runtimeStubState(this).notesInRgb     = true;
-}
-
-long WorldRuntime::noteColourBack() const
-{
-	return runtimeStubState(this).noteColourBack;
-}
-
-long WorldRuntime::normalColour(int index) const
-{
-	Q_UNUSED(index);
-	return 0xFFFFFF;
-}
-
-long WorldRuntime::customColourText(int index) const
-{
-	Q_UNUSED(index);
-	return 0xFFFFFF;
-}
-
-long WorldRuntime::customColourBackground(int index) const
-{
-	Q_UNUSED(index);
-	return 0;
-}
-
-const QList<WorldRuntime::Variable> &WorldRuntime::variables() const
-{
-	return runtimeStubState(this).variables;
-}
-
-bool WorldRuntime::findVariable(const QString &name, QString &value) const
-{
-	for (const Variable &variable : runtimeStubState(this).variables)
-	{
-		const QString variableName = variable.attributes.value(QStringLiteral("name"));
-		if (variableName.compare(name, Qt::CaseInsensitive) == 0)
-		{
-			value = variable.content;
-			return true;
-		}
-	}
-	return false;
-}
-
-QStringList WorldRuntime::variableList() const
-{
-	QStringList names;
-	for (const Variable &variable : runtimeStubState(this).variables)
-	{
-		const QString name = variable.attributes.value(QStringLiteral("name"));
-		if (!name.isEmpty())
-			names.push_back(name);
-	}
-	return names;
-}
-
-QMap<QString, QString> WorldRuntime::variableSnapshot() const
-{
-	QMap<QString, QString> snapshot;
-	for (const Variable &variable : runtimeStubState(this).variables)
-	{
-		const QString name = variable.attributes.value(QStringLiteral("name"));
-		if (!name.isEmpty())
-			snapshot.insert(name, variable.content);
-	}
-	return snapshot;
-}
-
-void WorldRuntime::invalidateLuaCallbackDispatchSnapshot() const
-{
-	runtimeStubState(this).variableDispatchSnapshotCache.clear();
-}
-
-void WorldRuntime::setVariable(const QString &name, const QString &value)
-{
-	if (name.isEmpty())
-		return;
-
-	RuntimeStubState &state = runtimeStubState(this);
-	for (Variable &variable : state.variables)
-	{
-		const QString variableName = variable.attributes.value(QStringLiteral("name"));
-		if (variableName.compare(name, Qt::CaseInsensitive) == 0)
-		{
-			variable.content = value;
-			invalidateLuaCallbackDispatchSnapshot();
-			return;
-		}
-	}
-
-	Variable variable;
-	variable.attributes.insert(QStringLiteral("name"), name);
-	variable.content = value;
-	state.variables.push_back(variable);
-	invalidateLuaCallbackDispatchSnapshot();
-}
-
-void WorldRuntime::setVariables(const QList<Variable> &variables)
-{
-	runtimeStubState(this).variables = variables;
-	invalidateLuaCallbackDispatchSnapshot();
-}
-
-int WorldRuntime::deleteVariable(const QString &name)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	for (int i = 0; i < state.variables.size(); ++i)
-	{
-		const QString variableName = state.variables.at(i).attributes.value(QStringLiteral("name"));
-		if (variableName.compare(name, Qt::CaseInsensitive) == 0)
-		{
-			state.variables.removeAt(i);
-			invalidateLuaCallbackDispatchSnapshot();
-			return eOK;
-		}
-	}
-	return eVariableNotFound;
-}
-
-void WorldRuntime::setNoteColourBack(long value)
-{
-	runtimeStubState(this).noteColourBack = value & 0x00FFFFFF;
-	runtimeStubState(this).notesInRgb     = true;
-}
-
-void WorldRuntime::outputText(const QString &text, bool note, bool newLine)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	state.outputLines.push_back(text);
-	state.outputNewLines.push_back(newLine);
-	state.lineEntries.push_back(makeStubLineEntry(state, text, note ? LineNote : LineOutput, {}, newLine));
-}
-
-void WorldRuntime::outputStyledText(const QString &text, const QVector<StyleSpan> &spans, bool note,
-                                    bool newLine)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	state.outputLines.push_back(text);
-	state.outputNewLines.push_back(newLine);
-	state.lineEntries.push_back(makeStubLineEntry(state, text, note ? LineNote : LineOutput, spans, newLine));
-}
-
-bool WorldRuntime::writeLuaCallbackOutputAtLineAnchor(qint64 anchorLineNumber, int anchorRelativeOffset,
-                                                      bool replaceAnchor, const QString &text, int flags,
-                                                      const QVector<StyleSpan> &spans, bool hardReturn)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	state.outputLines.push_back(text);
-	state.outputNewLines.push_back(hardReturn);
-
-	int anchorIndex = -1;
-	for (int index = 0; index < state.lineEntries.size(); ++index)
-	{
-		if (state.lineEntries.at(index).lineNumber == anchorLineNumber)
-		{
-			anchorIndex = index;
-			break;
-		}
-	}
-	if (anchorIndex < 0)
-		return false;
-
-	WorldRuntime::LineEntry entry = makeStubLineEntry(state, text, flags & ~LineHidden, spans, hardReturn);
-	if (replaceAnchor)
-	{
-		state.lineEntries[anchorIndex] = entry;
-		return true;
-	}
-
-	const qsizetype insertIndex = qBound<qsizetype>(
-	    0, static_cast<qsizetype>(anchorIndex) + anchorRelativeOffset, state.lineEntries.size());
-	state.lineEntries.insert(insertIndex, entry);
-	return true;
-}
-
-int WorldRuntime::savePluginState(const QString &pluginId, bool scripted, QString *error)
-{
-	Q_UNUSED(pluginId);
-	Q_UNUSED(scripted);
-	if (error)
-		error->clear();
-	++runtimeStubState(this).savePluginStateCalls;
-	return 0;
-}
-
-int WorldRuntime::windowCreate(const QString &name, int left, int top, int width, int height, int position,
-                               int flags, const QColor &background, const QString &pluginId)
-{
-	Q_UNUSED(background);
-	Q_UNUSED(pluginId);
-	RuntimeStubState &state = runtimeStubState(this);
-	if (!state.windowNames.contains(name))
-		state.windowNames.push_back(name);
-	state.windowInfo[name][1] = left;
-	state.windowInfo[name][2] = top;
-	state.windowInfo[name][3] = width;
-	state.windowInfo[name][4] = height;
-	state.windowInfo[name][7] = position;
-	state.windowInfo[name][8] = flags;
-	return 0;
-}
-
-QStringList WorldRuntime::windowList() const
-{
-	return runtimeStubState(this).windowNames;
-}
-
-QVariant WorldRuntime::windowInfo(const QString &name, int infoType) const
-{
-	return runtimeStubState(this).windowInfo.value(name).value(infoType);
-}
-
-int WorldRuntime::windowPosition(const QString &name, int left, int top, int position, int flags)
-{
-	RuntimeStubState &state   = runtimeStubState(this);
-	state.windowInfo[name][1] = left;
-	state.windowInfo[name][2] = top;
-	state.windowInfo[name][7] = position;
-	state.windowInfo[name][8] = flags;
-	return 0;
-}
-
-int WorldRuntime::windowResize(const QString &name, int width, int height, long colour)
-{
-	Q_UNUSED(colour);
-	RuntimeStubState &state   = runtimeStubState(this);
-	state.windowInfo[name][3] = width;
-	state.windowInfo[name][4] = height;
-	return 0;
-}
-
-int WorldRuntime::windowAddHotspot(const QString &name, const QString &hotspotId, int left, int top,
-                                   int right, int bottom, const QString &mouseOver,
-                                   const QString &cancelMouseOver, const QString &mouseDown,
-                                   const QString &cancelMouseDown, const QString &mouseUp,
-                                   const QString &tooltip, int cursor, int flags, const QString &pluginId)
-{
-	Q_UNUSED(left);
-	Q_UNUSED(top);
-	Q_UNUSED(right);
-	Q_UNUSED(bottom);
-	Q_UNUSED(mouseOver);
-	Q_UNUSED(cancelMouseOver);
-	Q_UNUSED(mouseDown);
-	Q_UNUSED(cancelMouseDown);
-	Q_UNUSED(mouseUp);
-	Q_UNUSED(tooltip);
-	Q_UNUSED(cursor);
-	Q_UNUSED(flags);
-	Q_UNUSED(pluginId);
-	RuntimeStubState &state = runtimeStubState(this);
-	if (!state.hotspotIds[name].contains(hotspotId))
-		state.hotspotIds[name].push_back(hotspotId);
-	return 0;
-}
-
-QStringList WorldRuntime::windowHotspotList(const QString &name) const
-{
-	return runtimeStubState(this).hotspotIds.value(name);
-}
-
-int WorldRuntime::playSound(const int buffer, const QString &fileName, const bool loop, double, double)
-{
-	return playSoundBypassingPluginCallbacks(buffer, fileName, loop, 0.0, 0.0);
-}
-
-int WorldRuntime::playSoundBypassingPluginCallbacks(const int buffer, const QString &fileName,
-                                                    const bool loop, double, double)
-{
-	if (fileName.isEmpty())
-	{
-		if (!runtimeStubState(this).soundStatusByBuffer.contains(buffer))
-			return eBadParameter;
-		runtimeStubState(this).soundStatusByBuffer.insert(buffer, loop ? 2 : 1);
-		return eOK;
-	}
-	const int targetBuffer = buffer > 0 ? buffer : 1;
-	runtimeStubState(this).soundStatusByBuffer.insert(targetBuffer, loop ? 2 : 1);
-	return eOK;
-}
-
-int WorldRuntime::stopSound(const int buffer)
-{
-	return stopSoundBypassingPluginCallbacks(buffer);
-}
-
-int WorldRuntime::stopSoundBypassingPluginCallbacks(const int buffer)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	if (buffer == 0)
-		state.soundStatusByBuffer.clear();
-	else
-		state.soundStatusByBuffer.remove(buffer);
-	return eOK;
-}
-
-int WorldRuntime::soundStatus(const int buffer) const
-{
-	if (buffer < 1 || buffer > WorldRuntime::kMaxSoundBuffers)
-		return -1;
-	return runtimeStubState(this).soundStatusByBuffer.value(buffer, -2);
-}
-
-const QList<WorldRuntime::Plugin> &WorldRuntime::plugins() const
-{
-	return runtimeStubState(this).plugins;
-}
-
-QList<WorldRuntime::Plugin> &WorldRuntime::pluginsMutable()
-{
-	return runtimeStubState(this).plugins;
-}
-
-bool WorldRuntime::isPluginInstalled(const QString &pluginId) const
-{
-	if (QMudNativePluginRegistry::isBlacklistedId(pluginId))
-		return false;
-	if (!QMudNativePluginRegistry::resolveShimIdOrName(pluginId).isEmpty())
-		return true;
-	for (const Plugin &plugin : runtimeStubState(this).plugins)
-	{
-		if (plugin.attributes.value(QStringLiteral("id")).compare(pluginId, Qt::CaseInsensitive) == 0)
-			return true;
-	}
-	return false;
-}
-
-QVariant WorldRuntime::pluginInfo(const QString &pluginId, const int infoType) const
-{
-	if (const QString shimId = QMudNativePluginRegistry::resolveShimIdOrName(pluginId); !shimId.isEmpty())
-	{
-		int               visibleIndex = 0;
-		const QStringList ids          = pluginIdList();
-		for (int i = 0; i < ids.size(); ++i)
-		{
-			if (ids.at(i).compare(shimId, Qt::CaseInsensitive) == 0)
-			{
-				visibleIndex = i + 1;
-				break;
-			}
-		}
-		const bool enabled =
-		    shimId.compare(QMudNativePluginRegistry::mushReaderPluginId(), Qt::CaseInsensitive) == 0
-		        ? QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(this)
-		        : true;
-		return QMudNativePluginRegistry::pluginInfo(shimId, infoType, visibleIndex, enabled);
-	}
-	for (const Plugin &plugin : runtimeStubState(this).plugins)
-	{
-		if (plugin.attributes.value(QStringLiteral("id")).compare(pluginId, Qt::CaseInsensitive) != 0)
-			continue;
-		switch (infoType)
-		{
-		case 1:
-			return plugin.attributes.value(QStringLiteral("name"));
-		case 2:
-			return plugin.attributes.value(QStringLiteral("author"));
-		case 3:
-			return plugin.description;
-		case 4:
-			return plugin.script;
-		case 5:
-			return plugin.attributes.value(QStringLiteral("language"));
-		case 6:
-			return plugin.source;
-		case 7:
-			return plugin.attributes.value(QStringLiteral("id"));
-		case 8:
-			return plugin.attributes.value(QStringLiteral("purpose"));
-		case 20:
-			return plugin.directory;
-		default:
-			return {};
-		}
-	}
-	return {};
-}
-
-bool WorldRuntime::findPluginVariable(const QString &pluginId, const QString &name, QString &value) const
-{
-	for (const Plugin &plugin : runtimeStubState(this).plugins)
-	{
-		if (plugin.attributes.value(QStringLiteral("id")).compare(pluginId, Qt::CaseInsensitive) != 0)
-			continue;
-		for (auto it = plugin.variables.constBegin(); it != plugin.variables.constEnd(); ++it)
-		{
-			if (it.key().compare(name, Qt::CaseInsensitive) == 0)
-			{
-				value = it.value();
-				return true;
-			}
-		}
-		return false;
-	}
-	return false;
-}
-
-bool WorldRuntime::pluginVariableSnapshot(const QString &pluginId, QMap<QString, QString> &values) const
-{
-	values.clear();
-	for (const Plugin &plugin : runtimeStubState(this).plugins)
-	{
-		if (plugin.attributes.value(QStringLiteral("id")).compare(pluginId, Qt::CaseInsensitive) != 0)
-			continue;
-		values = plugin.variables;
-		return true;
-	}
-	return false;
-}
-
-QStringList WorldRuntime::pluginIdList() const
-{
-	QStringList ids;
-	for (const Plugin &plugin : runtimeStubState(this).plugins)
-	{
-		const QString id = plugin.attributes.value(QStringLiteral("id"));
-		if (!id.isEmpty() && !QMudNativePluginRegistry::isBlacklistedId(id))
-			ids.push_back(id);
-	}
-	for (const QString &shimId :
-	     {QMudNativePluginRegistry::mushReaderPluginId(), QMudNativePluginRegistry::luaAudioPluginId()})
-	{
-		if (!ids.contains(shimId, Qt::CaseInsensitive))
-			ids.push_back(shimId);
-	}
-	return ids;
-}
-
-int WorldRuntime::allocateAcceleratorCommand()
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	return state.nextAcceleratorCommand++;
-}
-
-void WorldRuntime::registerAccelerator(const qint64 key, const int commandId, const AcceleratorEntry &entry)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	state.acceleratorKeyToCommand.insert(key, commandId);
-	state.acceleratorEntries.insert(commandId, entry);
-}
-
-void WorldRuntime::removeAccelerator(const qint64 key)
-{
-	RuntimeStubState &state = runtimeStubState(this);
-	const auto        it    = state.acceleratorKeyToCommand.constFind(key);
-	if (it == state.acceleratorKeyToCommand.constEnd())
-		return;
-	state.acceleratorEntries.remove(it.value());
-	state.acceleratorKeyToCommand.remove(key);
-}
-
-int WorldRuntime::acceleratorCommandForKey(const qint64 key) const
-{
-	return runtimeStubState(this).acceleratorKeyToCommand.value(key, -1);
-}
-
-QVariant WorldRuntime::windowHotspotInfo(const QString &name, const QString &hotspotId, int infoType) const
-{
-	Q_UNUSED(name);
-	Q_UNUSED(hotspotId);
-	Q_UNUSED(infoType);
-	return {};
-}
-
-bool WorldRuntime::suppressScriptErrorOutputToWorld() const
-{
-	return false;
-}
-// NOLINTEND(readability-convert-member-functions-to-static,readability-make-member-function-const,readability-non-const-parameter)
-
-QColor WorldView::parseColor(const QString &value)
-{
-	return {value};
 }
 
 namespace
@@ -871,6 +112,51 @@ namespace
 		const QString value = QString::fromUtf8(lua_tostring(state, -1));
 		lua_pop(state, 1);
 		return value;
+	}
+
+	int safeQSizeToInt(const qsizetype size)
+	{
+		if (size <= 0)
+			return 0;
+		constexpr qsizetype kMaxInt = std::numeric_limits<int>::max();
+		return size > kMaxInt ? std::numeric_limits<int>::max() : static_cast<int>(size);
+	}
+
+	QStringList logicalOutputLinesFromEntries(const QVector<WorldRuntime::LineEntry> &entries)
+	{
+		QStringList lines;
+		QString     currentLine;
+		for (const WorldRuntime::LineEntry &entry : entries)
+		{
+			if ((entry.flags & WorldRuntime::LineHidden) != 0)
+				continue;
+			currentLine += entry.text;
+			if (entry.hardReturn)
+			{
+				lines.push_back(currentLine);
+				currentLine.clear();
+			}
+		}
+		if (!currentLine.isEmpty())
+			lines.push_back(currentLine);
+		return lines;
+	}
+
+	QString acceptedModalStringResult(const QString &value)
+	{
+		QJsonObject object;
+		object.insert(QStringLiteral("accepted"), true);
+		object.insert(QStringLiteral("value"), value);
+		return QString::fromUtf8(QJsonDocument(object).toJson(QJsonDocument::Compact));
+	}
+
+	QSharedPointer<const LuaCallbackMiniWindowSnapshot>
+	captureVariableDispatchSnapshotForTest(const WorldRuntime &runtime)
+	{
+		auto snapshot                       = QSharedPointer<LuaCallbackMiniWindowSnapshot>::create();
+		snapshot->worldVariablesSnapshot    = runtime.variableSnapshot();
+		snapshot->hasWorldVariablesSnapshot = true;
+		return snapshot;
 	}
 
 	struct LuaStateDeleterForTest
@@ -1149,10 +435,10 @@ void tst_LuaCallbackEngine::modalYieldResumePreservesNumberAndStringCallback()
 	setEngineScript(*engine, QStringLiteral(R"lua(
 colour_seen = false
 function OnHotspot(flags, hotspot)
-  SaveState()
-  local colour = TestYieldModalNumber()
+  modal_number_phase = "before"
+  local colour = PickColour(-1)
   colour_seen = flags == 2 and hotspot == "tab" and colour == 255
-  SaveState()
+  modal_number_phase = "after"
   return colour_seen
 end
 )lua"));
@@ -1174,7 +460,7 @@ end
 	QVERIFY(initialResult.pendingModalStringRequest.guiCallable);
 	QVERIFY(initialResult.pendingModalStringRequest.resultCallback);
 	executeDeferredMutations(initialResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 1);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_number_phase"), QStringLiteral("before"));
 	QVERIFY(!luaGlobalBoolean(engine->luaState(), "colour_seen"));
 
 	LuaBatchDispatchRequest resumeRequest;
@@ -1190,7 +476,7 @@ end
 	QVERIFY(resumedResult.hasFunctionValid);
 	QVERIFY(resumedResult.hasFunction);
 	executeDeferredMutations(resumedResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 2);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_number_phase"), QStringLiteral("after"));
 	QVERIFY(luaGlobalBoolean(engine->luaState(), "colour_seen"));
 }
 
@@ -1202,7 +488,7 @@ void tst_LuaCallbackEngine::modalYieldResumePreservesStringInOutCallback()
 	setEngineScript(*engine, QStringLiteral(R"lua(
 string_seen = ""
 function Transform(value)
-  local choice = TestYieldModalString()
+  local choice = utils.inputbox("choose", "title", "")
   string_seen = value .. ":" .. choice
   return string_seen
 end
@@ -1227,7 +513,7 @@ end
 	resumeRequest.engines       = {engine};
 	resumeRequest.kind          = LuaBatchDispatchKind::ResumeSuspendedModalString;
 	resumeRequest.modalResumeId = initialResult.modalResumeId;
-	resumeRequest.stringArg     = QStringLiteral("after");
+	resumeRequest.stringArg     = acceptedModalStringResult(QStringLiteral("after"));
 
 	LuaBatchDispatchResult resumedResult = executor.dispatchBatch(resumeRequest);
 	QVERIFY(!resumedResult.suspended);
@@ -1247,10 +533,10 @@ void tst_LuaCallbackEngine::modalYieldResumePreservesNoArgsCallback()
 	setEngineScript(*engine, QStringLiteral(R"lua(
 noargs_seen = false
 function OnPluginEnable()
-  SaveState()
-  local choice = TestYieldModalString()
+  modal_noargs_phase = "before"
+  local choice = utils.inputbox("choose", "title", "")
   noargs_seen = choice == "accepted"
-  SaveState()
+  modal_noargs_phase = "after"
   return noargs_seen
 end
 )lua"));
@@ -1270,14 +556,14 @@ end
 	QVERIFY(!initialResult.boolResultValid);
 	QVERIFY(!initialResult.hasFunctionValid);
 	executeDeferredMutations(initialResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 1);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_noargs_phase"), QStringLiteral("before"));
 	QVERIFY(!luaGlobalBoolean(engine->luaState(), "noargs_seen"));
 
 	LuaBatchDispatchRequest resumeRequest;
 	resumeRequest.engines       = {engine};
 	resumeRequest.kind          = LuaBatchDispatchKind::ResumeSuspendedModalString;
 	resumeRequest.modalResumeId = initialResult.modalResumeId;
-	resumeRequest.stringArg     = QStringLiteral("accepted");
+	resumeRequest.stringArg     = acceptedModalStringResult(QStringLiteral("accepted"));
 
 	LuaBatchDispatchResult resumedResult = executor.dispatchBatch(resumeRequest);
 	QVERIFY(!resumedResult.suspended);
@@ -1286,7 +572,7 @@ end
 	QVERIFY(resumedResult.hasFunctionValid);
 	QVERIFY(resumedResult.hasFunction);
 	executeDeferredMutations(resumedResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 2);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_noargs_phase"), QStringLiteral("after"));
 	QVERIFY(luaGlobalBoolean(engine->luaState(), "noargs_seen"));
 }
 
@@ -1298,10 +584,10 @@ void tst_LuaCallbackEngine::modalYieldResumePreservesBytesInOutCallback()
 	setEngineScript(*engine, QStringLiteral(R"lua(
 bytes_seen = false
 function TransformBytes(value)
-  SaveState()
-  local suffix = TestYieldModalString()
+  modal_bytes_phase = "before"
+  local suffix = utils.inputbox("choose", "title", "")
   bytes_seen = value == "payload" and suffix == "done"
-  SaveState()
+  modal_bytes_phase = "after"
   return value .. ":" .. suffix
 end
 )lua"));
@@ -1320,14 +606,14 @@ end
 	QVERIFY(initialResult.hasPendingModalStringRequest);
 	QCOMPARE(initialResult.bytesResult, QByteArray("payload"));
 	executeDeferredMutations(initialResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 1);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_bytes_phase"), QStringLiteral("before"));
 	QVERIFY(!luaGlobalBoolean(engine->luaState(), "bytes_seen"));
 
 	LuaBatchDispatchRequest resumeRequest;
 	resumeRequest.engines       = {engine};
 	resumeRequest.kind          = LuaBatchDispatchKind::ResumeSuspendedModalString;
 	resumeRequest.modalResumeId = initialResult.modalResumeId;
-	resumeRequest.stringArg     = QStringLiteral("done");
+	resumeRequest.stringArg     = acceptedModalStringResult(QStringLiteral("done"));
 
 	LuaBatchDispatchResult resumedResult = executor.dispatchBatch(resumeRequest);
 	QVERIFY(!resumedResult.suspended);
@@ -1337,7 +623,7 @@ end
 	QVERIFY(resumedResult.hasFunction);
 	QCOMPARE(resumedResult.bytesResult, QByteArray("payload:done"));
 	executeDeferredMutations(resumedResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 2);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_bytes_phase"), QStringLiteral("after"));
 	QVERIFY(luaGlobalBoolean(engine->luaState(), "bytes_seen"));
 }
 
@@ -1349,11 +635,11 @@ void tst_LuaCallbackEngine::modalYieldResumeSupportsStackedModalCalls()
 	setEngineScript(*engine, QStringLiteral(R"lua(
 stacked_seen = false
 function OnHotspot(flags, hotspot)
-  SaveState()
-  local first = TestYieldModalNumber()
-  SaveState()
-  local second = TestYieldModalNumber()
-  SaveState()
+  modal_stacked_phase = "before_first"
+  local first = PickColour(-1)
+  modal_stacked_phase = "before_second"
+  local second = PickColour(-1)
+  modal_stacked_phase = "after_second"
   stacked_seen = flags == 4 and hotspot == "stacked" and first == 10 and second == 20
   return stacked_seen
 end
@@ -1373,7 +659,7 @@ end
 	QVERIFY(firstSuspend.modalResumeId != 0);
 	QVERIFY(firstSuspend.hasPendingModalStringRequest);
 	executeDeferredMutations(firstSuspend);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 1);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_stacked_phase"), QStringLiteral("before_first"));
 
 	LuaBatchDispatchRequest firstResume;
 	firstResume.engines       = {engine};
@@ -1388,7 +674,7 @@ end
 	QCOMPARE(secondSuspend.suspendedEngineIndex, 0);
 	QVERIFY(secondSuspend.hasPendingModalStringRequest);
 	executeDeferredMutations(secondSuspend);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 2);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_stacked_phase"), QStringLiteral("before_second"));
 	QVERIFY(!luaGlobalBoolean(engine->luaState(), "stacked_seen"));
 
 	LuaBatchDispatchRequest secondResume;
@@ -1402,7 +688,7 @@ end
 	QVERIFY(completed.boolResultValid);
 	QVERIFY(completed.boolResult);
 	executeDeferredMutations(completed);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 3);
+	QCOMPARE(luaGlobalString(engine->luaState(), "modal_stacked_phase"), QStringLiteral("after_second"));
 	QVERIFY(luaGlobalBoolean(engine->luaState(), "stacked_seen"));
 }
 
@@ -1414,10 +700,10 @@ void tst_LuaCallbackEngine::workerModalResumeDefersPostModalRuntimeMutations()
 	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 worker_resume_seen = false
 function OnPluginEnable()
-  SaveState()
-  local choice = TestYieldModalString()
+  worker_modal_phase = "before"
+  local choice = utils.inputbox("choose", "title", "")
   worker_resume_seen = choice == "accepted"
-  SaveState()
+  worker_modal_phase = "after"
   return worker_resume_seen
 end
 function worker_status(value)
@@ -1439,33 +725,30 @@ end
 	dispatchWorkerAndWait(executor, request, initialResult);
 	QVERIFY(initialResult.suspended);
 	QVERIFY(initialResult.modalResumeId != 0);
-	QVERIFY(!initialResult.deferredRuntimeMutationBatches.isEmpty());
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 0);
-	executeDeferredMutations(initialResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 1);
-
-	LuaBatchDispatchRequest resumeRequest;
-	resumeRequest.engines       = {engine};
-	resumeRequest.kind          = LuaBatchDispatchKind::ResumeSuspendedModalString;
-	resumeRequest.modalResumeId = initialResult.modalResumeId;
-	resumeRequest.stringArg     = QStringLiteral("accepted");
-
-	LuaBatchDispatchResult resumedResult;
-	dispatchWorkerAndWait(executor, resumeRequest, resumedResult);
-	QVERIFY(!resumedResult.suspended);
-	QVERIFY(resumedResult.boolResultValid);
-	QVERIFY(resumedResult.boolResult);
-	QVERIFY(!resumedResult.deferredRuntimeMutationBatches.isEmpty());
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 1);
-	executeDeferredMutations(resumedResult);
-	QCOMPARE(runtimeStubState(&runtime).savePluginStateCalls, 2);
-
 	LuaBatchDispatchRequest statusRequest;
 	statusRequest.engines      = {engine};
 	statusRequest.kind         = LuaBatchDispatchKind::StringInOut;
 	statusRequest.functionName = QStringLiteral("worker_status");
 	statusRequest.stringArg    = QStringLiteral("ignored");
 	LuaBatchDispatchResult statusResult;
+	dispatchWorkerAndWait(executor, statusRequest, statusResult);
+	QCOMPARE(statusResult.stringResult, QStringLiteral("no"));
+	executeDeferredMutations(initialResult);
+
+	LuaBatchDispatchRequest resumeRequest;
+	resumeRequest.engines       = {engine};
+	resumeRequest.kind          = LuaBatchDispatchKind::ResumeSuspendedModalString;
+	resumeRequest.modalResumeId = initialResult.modalResumeId;
+	resumeRequest.stringArg     = acceptedModalStringResult(QStringLiteral("accepted"));
+
+	LuaBatchDispatchResult resumedResult;
+	dispatchWorkerAndWait(executor, resumeRequest, resumedResult);
+	QVERIFY(!resumedResult.suspended);
+	QVERIFY(resumedResult.boolResultValid);
+	QVERIFY(resumedResult.boolResult);
+	QVERIFY(resumedResult.deferredRuntimeMutationBatches.isEmpty());
+	executeDeferredMutations(resumedResult);
+
 	dispatchWorkerAndWait(executor, statusRequest, statusResult);
 	QCOMPARE(statusResult.stringResult, QStringLiteral("yes"));
 
@@ -1480,7 +763,7 @@ void tst_LuaCallbackEngine::modalYieldCancelPreventsCallbackContinuation()
 	setEngineScript(*engine, QStringLiteral(R"lua(
 cancel_seen = false
 function OnHotspot(flags, hotspot)
-  local colour = TestYieldModalNumber()
+  local colour = PickColour(-1)
   cancel_seen = true
   return colour == 42
 end
@@ -1590,7 +873,7 @@ void tst_LuaCallbackEngine::worldLuaFileApisAcceptMixedSeparators()
 	input.close();
 
 	WorldRuntime runtime;
-	runtimeStubState(&runtime).startupDirectory = root.absolutePath();
+	runtime.setStartupDirectory(root.absolutePath());
 	LuaCallbackEngine engine;
 	engine.setWorldRuntime(&runtime);
 	setEngineScript(engine, QString());
@@ -1638,21 +921,21 @@ void tst_LuaCallbackEngine::worldLuaFileApisUseRuntimeHomeAcrossThreadAffinity()
 	WorldRuntime runtime;
 	QThread     *mainThread = QThread::currentThread();
 	const auto   cleanup    = qScopeGuard(
-	    [&]()
-	    {
-		    if (runtime.thread() == &worker)
-		    {
-			    const bool moved = QMetaObject::invokeMethod(
-			        &runtime, [&runtime, mainThread]() { runtime.moveToThread(mainThread); },
-			        Qt::BlockingQueuedConnection);
-			    QVERIFY(moved);
-		    }
-		    worker.quit();
-		    worker.wait();
-	    });
+        [&]()
+        {
+            if (runtime.thread() == &worker)
+            {
+                const bool moved = QMetaObject::invokeMethod(
+                    &runtime, [&runtime, mainThread]() { runtime.moveToThread(mainThread); },
+                    Qt::BlockingQueuedConnection);
+                QVERIFY(moved);
+            }
+            worker.quit();
+            worker.wait();
+        });
 	worker.start();
 	QVERIFY(worker.isRunning());
-	runtimeStubState(&runtime).startupDirectory = root.absolutePath();
+	runtime.setStartupDirectory(root.absolutePath());
 	runtime.moveToThread(&worker);
 
 	LuaCallbackEngine engine;
@@ -1705,9 +988,8 @@ void tst_LuaCallbackEngine::worldLuaFileApisIgnoreProcessQmudHome()
 			    qunsetenv("QMUD_HOME");
 	    });
 
-	WorldRuntime      runtime;
-	RuntimeStubState &state = runtimeStubState(&runtime);
-	state.startupDirectory  = runtimeRoot.absolutePath();
+	WorldRuntime runtime;
+	runtime.setStartupDirectory(runtimeRoot.absolutePath());
 
 	LuaCallbackEngine engine;
 	engine.setWorldRuntime(&runtime);
@@ -1720,7 +1002,7 @@ process_qmud_home_ignored = chunk() == "runtime"
 	QVERIFY(engine.executeScript(script, QStringLiteral("ignore process QMUD_HOME")));
 	QVERIFY(luaGlobalBoolean(engine.luaState(), "process_qmud_home_ignored"));
 
-	state.startupDirectory.clear();
+	runtime.setStartupDirectory(QString());
 	LuaCallbackEngine missingHomeEngine;
 	missingHomeEngine.setWorldRuntime(&runtime);
 	setEngineScript(missingHomeEngine, QString());
@@ -1757,37 +1039,75 @@ void tst_LuaCallbackEngine::luaVisiblePathApisReturnRelativePosix()
 	[[maybe_unused]] const auto restoreCurrentPath =
 	    qScopeGuard([previousCurrentPath] { QDir::setCurrent(previousCurrentPath); });
 
-	WorldRuntime      runtime;
-	RuntimeStubState &state = runtimeStubState(&runtime);
-	state.startupDirectory  = root.absolutePath();
-	state.worldAttributes.insert(QStringLiteral("new_activity_sound"),
-	                             QStringLiteral(R"(C:\MUSHclient\sounds\activity.wav)"));
-	state.worldAttributes.insert(QStringLiteral("script_editor"),
-	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\editor.lua)"));
-	state.worldAttributes.insert(QStringLiteral("script_filename"),
-	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\script.lua)"));
-	state.worldAttributes.insert(QStringLiteral("auto_log_file_name"),
-	                             QStringLiteral(R"(C:\MUSHclient\logs\auto.log)"));
-	state.worldAttributes.insert(QStringLiteral("beep_sound"),
-	                             QStringLiteral(R"(C:\MUSHclient\sounds\beep.wav)"));
-	state.worldAttributes.insert(QStringLiteral("foreground_image"),
-	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\foreground.png)"));
-	state.worldAttributes.insert(QStringLiteral("background_image"),
-	                             QStringLiteral(R"(C:\MUSHclient\worlds\foo\background.png)"));
-	state.logFileName             = root.filePath(QStringLiteral("logs/current.log"));
-	state.worldFilePath           = root.filePath(QStringLiteral("worlds/foo/test.mcl"));
-	state.defaultWorldDirectory   = QStringLiteral(R"(C:\MUSHclient\worlds\)");
-	state.defaultLogDirectory     = root.filePath(QStringLiteral("logs"));
-	state.pluginsDirectory        = QStringLiteral(R"(C:\MUSHclient\worlds\plugins\)");
-	state.translatorFile          = root.filePath(QStringLiteral("locale/EN.lua"));
-	state.firstSpecialFontPath    = root.filePath(QStringLiteral("fonts/special.ttf"));
-	state.preferencesDatabaseName = root.filePath(QStringLiteral("prefs/qmud.db"));
-	state.fileBrowsingDirectory   = root.filePath(QStringLiteral("worlds/browse"));
-	state.stateFilesDirectory     = QStringLiteral(R"(C:\MUSHclient\worlds\plugins\state\)");
+	WorldRuntime runtime;
+	runtime.setStartupDirectory(root.absolutePath());
+	runtime.setWorldAttribute(QStringLiteral("new_activity_sound"),
+	                          QStringLiteral(R"(C:\MUSHclient\sounds\activity.wav)"));
+	runtime.setWorldAttribute(QStringLiteral("script_editor"),
+	                          QStringLiteral(R"(C:\MUSHclient\worlds\foo\editor.lua)"));
+	runtime.setWorldAttribute(QStringLiteral("script_filename"),
+	                          QStringLiteral(R"(C:\MUSHclient\worlds\foo\script.lua)"));
+	runtime.setWorldAttribute(QStringLiteral("auto_log_file_name"),
+	                          QStringLiteral(R"(C:\MUSHclient\logs\auto.log)"));
+	runtime.setWorldAttribute(QStringLiteral("beep_sound"),
+	                          QStringLiteral(R"(C:\MUSHclient\sounds\beep.wav)"));
+	runtime.setWorldAttribute(QStringLiteral("foreground_image"),
+	                          QStringLiteral(R"(C:\MUSHclient\worlds\foo\foreground.png)"));
+	runtime.setWorldAttribute(QStringLiteral("background_image"),
+	                          QStringLiteral(R"(C:\MUSHclient\worlds\foo\background.png)"));
+	runtime.setWorldFilePath(root.filePath(QStringLiteral("worlds/foo/test.mcl")));
+	runtime.setDefaultWorldDirectory(QStringLiteral("C:/MUSHclient/worlds/"));
+	runtime.setDefaultLogDirectory(root.filePath(QStringLiteral("logs")));
+	runtime.setPluginsDirectory(QStringLiteral("C:/MUSHclient/worlds/plugins/"));
+	runtime.setTranslatorFile(root.filePath(QStringLiteral("locale/EN.lua")));
+	runtime.setPreferencesDatabaseName(root.filePath(QStringLiteral("prefs/qmud.db")));
+	runtime.setFileBrowsingDirectory(root.filePath(QStringLiteral("worlds/browse")));
+	runtime.setStateFilesDirectory(QStringLiteral("C:/MUSHclient/worlds/plugins/state/"));
+	QCOMPARE(runtime.openLog(root.filePath(QStringLiteral("logs/current.log")), false), eOK);
 
-	LuaCallbackEngine engine;
-	engine.setWorldRuntime(&runtime);
-	setEngineScript(engine, QStringLiteral(R"lua(
+	auto engine = QSharedPointer<LuaCallbackEngine>::create();
+	engine->setWorldRuntime(&runtime);
+	setEngineScript(*engine, QString());
+
+	auto snapshot                       = QSharedPointer<LuaCallbackMiniWindowSnapshot>::create();
+	snapshot->hasWorldAttributeSnapshot = true;
+	snapshot->worldAttributesSnapshot.insert(QStringLiteral("new_activity_sound"),
+	                                         QStringLiteral(R"(C:\MUSHclient\sounds\activity.wav)"));
+	snapshot->worldAttributesSnapshot.insert(QStringLiteral("script_editor"),
+	                                         QStringLiteral(R"(C:\MUSHclient\worlds\foo\editor.lua)"));
+	snapshot->worldAttributesSnapshot.insert(QStringLiteral("script_filename"),
+	                                         QStringLiteral(R"(C:\MUSHclient\worlds\foo\script.lua)"));
+	snapshot->worldAttributesSnapshot.insert(QStringLiteral("auto_log_file_name"),
+	                                         QStringLiteral(R"(C:\MUSHclient\logs\auto.log)"));
+	snapshot->worldAttributesSnapshot.insert(QStringLiteral("beep_sound"),
+	                                         QStringLiteral(R"(C:\MUSHclient\sounds\beep.wav)"));
+	snapshot->worldAttributesSnapshot.insert(QStringLiteral("foreground_image"),
+	                                         QStringLiteral(R"(C:\MUSHclient\worlds\foo\foreground.png)"));
+	snapshot->worldAttributesSnapshot.insert(QStringLiteral("background_image"),
+	                                         QStringLiteral(R"(C:\MUSHclient\worlds\foo\background.png)"));
+	snapshot->hasRuntimeCountersSnapshot = true;
+	snapshot->runtimeCounterValues.insert(QStringLiteral("logFileName"),
+	                                      root.filePath(QStringLiteral("logs/current.log")));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("worldFilePath"),
+	                                      root.filePath(QStringLiteral("worlds/foo/test.mcl")));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("defaultWorldDirectory"),
+	                                      QStringLiteral("C:/MUSHclient/worlds/"));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("defaultLogDirectory"),
+	                                      root.filePath(QStringLiteral("logs")));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("pluginsDirectory"),
+	                                      QStringLiteral("C:/MUSHclient/worlds/plugins/"));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("startupDirectory"), root.absolutePath());
+	snapshot->runtimeCounterValues.insert(QStringLiteral("translatorFile"),
+	                                      root.filePath(QStringLiteral("locale/EN.lua")));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("firstSpecialFontPath"), QString());
+	snapshot->runtimeCounterValues.insert(QStringLiteral("preferencesDatabaseName"),
+	                                      root.filePath(QStringLiteral("prefs/qmud.db")));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("fileBrowsingDirectory"),
+	                                      root.filePath(QStringLiteral("worlds/browse")));
+	snapshot->runtimeCounterValues.insert(QStringLiteral("stateFilesDirectory"),
+	                                      QStringLiteral("C:/MUSHclient/worlds/plugins/state/"));
+
+	const QString           script = QStringLiteral(R"lua(
 local values = {
   GetInfo(9),
   GetInfo(10),
@@ -1820,7 +1140,19 @@ getinfo_56_ok = #getinfo_56 > 0 and getinfo_56:sub(-1) == "/" and not getinfo_56
 local info = utils.info()
 utils_info_summary = tostring(info.app_directory) .. "|" .. tostring(info.current_directory)
 utils_info_ok = utils_info_summary == "./|./"
-)lua"));
+)lua");
+
+	LuaExecutorDirect       executor;
+	LuaBatchDispatchRequest request;
+	request.engines               = {engine};
+	request.kind                  = LuaBatchDispatchKind::ExecuteScript;
+	request.stringArg             = script;
+	request.stringArg2            = QStringLiteral("path visible api snapshot");
+	request.miniWindowSnapshotArg = snapshot;
+	LuaBatchDispatchResult result = executor.dispatchBatch(request);
+	QVERIFY(result.boolResultValid);
+	QVERIFY(result.boolResult);
+	executeDeferredMutations(result);
 
 	const QString expected =
 	    QStringList{
@@ -1841,7 +1173,7 @@ utils_info_ok = utils_info_summary == "./|./"
 	        QStringLiteral("./"),
 	        QStringLiteral("locale/EN.lua"),
 	        QStringLiteral("sounds/"),
-	        QStringLiteral("fonts/special.ttf"),
+	        QString(),
 	        QStringLiteral("worlds/foo/foreground.png"),
 	        QStringLiteral("worlds/foo/background.png"),
 	        QStringLiteral("prefs/qmud.db"),
@@ -1851,12 +1183,12 @@ utils_info_ok = utils_info_summary == "./|./"
 	        .join(QLatin1Char('|'));
 	const QString expectedGetInfo56 =
 	    QMudPluginPathUtils::normalizeSeparators(root.absolutePath()) + QLatin1Char('/');
-	QCOMPARE(luaGlobalString(engine.luaState(), "path_summary"), expected);
-	QVERIFY(luaGlobalBoolean(engine.luaState(), "path_no_backslashes"));
-	QCOMPARE(luaGlobalString(engine.luaState(), "getinfo_56"), expectedGetInfo56);
-	QVERIFY(luaGlobalBoolean(engine.luaState(), "getinfo_56_ok"));
-	QCOMPARE(luaGlobalString(engine.luaState(), "utils_info_summary"), QStringLiteral("./|./"));
-	QVERIFY(luaGlobalBoolean(engine.luaState(), "utils_info_ok"));
+	QCOMPARE(luaGlobalString(engine->luaState(), "path_summary"), expected);
+	QVERIFY(luaGlobalBoolean(engine->luaState(), "path_no_backslashes"));
+	QCOMPARE(luaGlobalString(engine->luaState(), "getinfo_56"), expectedGetInfo56);
+	QVERIFY(luaGlobalBoolean(engine->luaState(), "getinfo_56_ok"));
+	QCOMPARE(luaGlobalString(engine->luaState(), "utils_info_summary"), QStringLiteral("./|./"));
+	QVERIFY(luaGlobalBoolean(engine->luaState(), "utils_info_ok"));
 	QVERIFY(QDir::setCurrent(previousCurrentPath));
 	QVERIFY(root.removeRecursively());
 }
@@ -2081,7 +1413,22 @@ end
 
 void tst_LuaCallbackEngine::workerCallbackBatchCapturesOutputMiniWindowAndSaveStateMutations()
 {
-	WorldRuntime      runtime;
+	WorldRuntime runtime;
+	QStringList  outputTexts;
+	QList<bool>  outputNewLines;
+	QObject::connect(&runtime, &WorldRuntime::outputRequested, &runtime,
+	                 [&](const QString &text, const bool newLine, const bool)
+	                 {
+		                 outputTexts.push_back(text);
+		                 outputNewLines.push_back(newLine);
+	                 });
+	QObject::connect(
+	    &runtime, &WorldRuntime::outputStyledRequested, &runtime,
+	    [&](const QString &text, const QVector<WorldRuntime::StyleSpan> &, const bool newLine, const bool)
+	    {
+		    outputTexts.push_back(text);
+		    outputNewLines.push_back(newLine);
+	    });
 	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
 	LuaExecutorWorker executor;
 	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
@@ -2128,21 +1475,28 @@ end
 	QCOMPARE(statusResult.stringResult, QStringLiteral("true|true|true|true|true|true"));
 
 	executeDeferredMutations(callbackResult);
-	const RuntimeStubState &state = runtimeStubState(&runtime);
-	QVERIFY(state.outputLines.contains(QStringLiteral("batch-note")));
-	QVERIFY(state.windowNames.contains(QStringLiteral("batch")));
-	QCOMPARE(state.windowInfo.value(QStringLiteral("batch")).value(1).toInt(), 12);
-	QCOMPARE(state.windowInfo.value(QStringLiteral("batch")).value(2).toInt(), 24);
-	QCOMPARE(state.windowInfo.value(QStringLiteral("batch")).value(3).toInt(), 64);
-	QCOMPARE(state.windowInfo.value(QStringLiteral("batch")).value(4).toInt(), 32);
-	QVERIFY(state.hotspotIds.value(QStringLiteral("batch")).contains(QStringLiteral("drag")));
-	QCOMPARE(state.savePluginStateCalls, 1);
+	QVERIFY(outputTexts.contains(QStringLiteral("batch-note")));
+	QVERIFY(runtime.windowList().contains(QStringLiteral("batch")));
+	QCOMPARE(runtime.windowInfo(QStringLiteral("batch"), 1).toInt(), 12);
+	QCOMPARE(runtime.windowInfo(QStringLiteral("batch"), 2).toInt(), 24);
+	QCOMPARE(runtime.windowInfo(QStringLiteral("batch"), 3).toInt(), 64);
+	QCOMPARE(runtime.windowInfo(QStringLiteral("batch"), 4).toInt(), 32);
+	QVERIFY(runtime.windowHotspotList(QStringLiteral("batch")).contains(QStringLiteral("drag")));
 	teardownWorkerEngine(executor, engine);
 }
 
 void tst_LuaCallbackEngine::workerColourOutputMatchesMushclientGroupingAndNewlineSemantics()
 {
-	WorldRuntime      runtime;
+	WorldRuntime runtime;
+	QStringList  outputTexts;
+	QList<bool>  outputNewLines;
+	QObject::connect(
+	    &runtime, &WorldRuntime::outputStyledRequested, &runtime,
+	    [&](const QString &text, const QVector<WorldRuntime::StyleSpan> &, const bool newLine, const bool)
+	    {
+		    outputTexts.push_back(text);
+		    outputNewLines.push_back(newLine);
+	    });
 	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
 	LuaExecutorWorker executor;
 	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
@@ -2164,17 +1518,31 @@ end
 	dispatchWorkerAndWait(executor, request, result);
 	executeDeferredMutations(result);
 
-	const RuntimeStubState &state = runtimeStubState(&runtime);
-	QCOMPARE(state.outputLines,
+	QCOMPARE(outputTexts,
 	         QStringList({QStringLiteral("note-a"), QStringLiteral("note-b"), QStringLiteral("note-c"),
 	                      QStringLiteral("tell-a"), QStringLiteral("tell-b")}));
-	QCOMPARE(state.outputNewLines, QList<bool>({false, false, true, false, false}));
+	QCOMPARE(outputNewLines, QList<bool>({false, false, true, false, false}));
 	teardownWorkerEngine(executor, engine);
 }
 
 void tst_LuaCallbackEngine::colourTellIgnoresTrailingLuaGsubReturnAndKeepsFollowingNote()
 {
-	WorldRuntime      runtime;
+	WorldRuntime runtime;
+	QStringList  outputTexts;
+	QList<bool>  outputNewLines;
+	QObject::connect(&runtime, &WorldRuntime::outputRequested, &runtime,
+	                 [&](const QString &text, const bool newLine, const bool)
+	                 {
+		                 outputTexts.push_back(text);
+		                 outputNewLines.push_back(newLine);
+	                 });
+	QObject::connect(
+	    &runtime, &WorldRuntime::outputStyledRequested, &runtime,
+	    [&](const QString &text, const QVector<WorldRuntime::StyleSpan> &, const bool newLine, const bool)
+	    {
+		    outputTexts.push_back(text);
+		    outputNewLines.push_back(newLine);
+	    });
 	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
 	LuaExecutorWorker executor;
 	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
@@ -2195,20 +1563,25 @@ end
 	dispatchWorkerAndWait(executor, request, result);
 	executeDeferredMutations(result);
 
-	const RuntimeStubState &state = runtimeStubState(&runtime);
-	QCOMPARE(state.outputLines,
+	QCOMPARE(outputTexts,
 	         QStringList({QStringLiteral("You made "), QStringLiteral("10,000"), QStringLiteral(" gold!")}));
-	QCOMPARE(state.outputNewLines, QList<bool>({false, false, true}));
-	QCOMPARE(logicalOutputLinesFromEntries(state.lineEntries),
-	         QStringList({QStringLiteral("You made 10,000 gold!")}));
+	QCOMPARE(outputNewLines, QList<bool>({false, false, true}));
 	teardownWorkerEngine(executor, engine);
 }
 
 void tst_LuaCallbackEngine::executeScriptNoteUsesRuntimeNoteColour()
 {
-	WorldRuntime runtime;
-	auto        &state  = runtimeStubState(&runtime);
-	auto         engine = QSharedPointer<LuaCallbackEngine>::create();
+	WorldRuntime                     runtime;
+	QString                          outputText;
+	QVector<WorldRuntime::StyleSpan> outputSpans;
+	QObject::connect(
+	    &runtime, &WorldRuntime::outputStyledRequested, &runtime,
+	    [&](const QString &text, const QVector<WorldRuntime::StyleSpan> &spans, const bool, const bool)
+	    {
+		    outputText  = text;
+		    outputSpans = spans;
+	    });
+	auto engine = QSharedPointer<LuaCallbackEngine>::create();
 	engine->setWorldRuntime(&runtime);
 	setEngineScript(*engine, QString());
 
@@ -2233,18 +1606,15 @@ void tst_LuaCallbackEngine::executeScriptNoteUsesRuntimeNoteColour()
 	QVERIFY(result.boolResult);
 	executeDeferredMutations(result);
 
-	QCOMPARE(state.lineEntries.size(), 1);
-	const WorldRuntime::LineEntry &entry = state.lineEntries.constFirst();
-	QCOMPARE(entry.text, QStringLiteral("test"));
-	QVERIFY(!entry.spans.isEmpty());
-	QCOMPARE(entry.spans.constFirst().fore, QColor(0, 255, 255));
-	QCOMPARE(entry.spans.constFirst().back, QColor(Qt::black));
+	QCOMPARE(outputText, QStringLiteral("test"));
+	QVERIFY(!outputSpans.isEmpty());
+	QCOMPARE(outputSpans.constFirst().fore, QColor(0, 255, 255));
+	QCOMPARE(outputSpans.constFirst().back, QColor(Qt::black));
 }
 
 void tst_LuaCallbackEngine::selfPluginInfoMetadataFallsThroughToRuntime()
 {
 	WorldRuntime         runtime;
-	auto                &state = runtimeStubState(&runtime);
 
 	WorldRuntime::Plugin plugin;
 	plugin.attributes.insert(QStringLiteral("id"), QStringLiteral("Plugin.Id"));
@@ -2256,7 +1626,7 @@ void tst_LuaCallbackEngine::selfPluginInfoMetadataFallsThroughToRuntime()
 	plugin.script      = QStringLiteral("Runtime Script");
 	plugin.source      = QStringLiteral("worlds/plugins/runtime_plugin.xml");
 	plugin.directory   = QStringLiteral("worlds/plugins/");
-	state.plugins.push_back(plugin);
+	runtime.pluginsMutable().push_back(plugin);
 
 	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
 	LuaExecutorWorker executor;
@@ -2409,8 +1779,7 @@ void tst_LuaCallbackEngine::nativeShimDiscoveryIsAvailableWithoutShadowPlugin()
 	QVERIFY(soundFile.open(QIODevice::WriteOnly));
 	soundFile.write("RIFF");
 	soundFile.close();
-	runtimeStubState(&runtime).startupDirectory = soundRoot.path();
-	runtimeStubState(&runtime).soundStatusByBuffer.insert(9, 1);
+	runtime.setStartupDirectory(soundRoot.path());
 	auto              engine = QSharedPointer<LuaCallbackEngine>::create();
 	LuaExecutorWorker executor;
 	const QString     shimId = QMudNativePluginRegistry::mushReaderPluginId();
@@ -2456,7 +1825,6 @@ void tst_LuaCallbackEngine::nativeShimDiscoveryIsAvailableWithoutShadowPlugin()
 	LuaBatchDispatchResult result;
 	dispatchWorkerAndWait(executor, request, result);
 	QCOMPARE(result.stringResult, QStringLiteral("MushReader|false|LuaAudio|true|100|1|false"));
-	QCOMPARE(runtimeStubState(&runtime).soundStatusByBuffer.value(9), 1);
 	QVERIFY(runtime.pluginIdList().contains(shimId, Qt::CaseInsensitive));
 	QVERIFY(
 	    runtime.pluginIdList().contains(QMudNativePluginRegistry::luaAudioPluginId(), Qt::CaseInsensitive));
@@ -2477,7 +1845,7 @@ void tst_LuaCallbackEngine::nativeLuaAudioSharedRuntimeStateCoversDirectAndCallP
 	QVERIFY(soundFile.open(QIODevice::WriteOnly));
 	soundFile.write("RIFF");
 	soundFile.close();
-	runtimeStubState(&runtime).startupDirectory = soundRoot.path();
+	runtime.setStartupDirectory(soundRoot.path());
 
 	const QMudNativePluginRegistry::NativeCallResult nativeDelayed = QMudNativePluginRegistry::callRoutine(
 	    &runtime, QMudNativePluginRegistry::luaAudioPluginId(), QStringLiteral("playDelay"),
@@ -2549,25 +1917,6 @@ void tst_LuaCallbackEngine::nativeLuaAudioSharedRuntimeStateCoversDirectAndCallP
 	teardownWorkerEngine(executor, pendingEngine);
 	QVERIFY(QMudNativePluginRegistry::luaAudioRuntimeOwnedBuffers(&runtime).isEmpty());
 
-	auto loopEngine = QSharedPointer<LuaCallbackEngine>::create();
-	initializeWorkerEngine(executor, loopEngine, QStringLiteral(R"lua(
-	function OnPluginEnable()
-	end
-	)lua"),
-	                       &runtime);
-	QMudNativePluginRegistry::LuaAudioRuntimeBufferState loopState;
-	loopState.volume   = 100.0;
-	loopState.loop     = true;
-	loopState.ownerKey = loopEngine.data();
-	QMudNativePluginRegistry::luaAudioMarkRuntimeBuffer(&runtime, 1, loopState);
-	QCOMPARE(runtime.playSound(1, QStringLiteral("coin.wav"), true, 0.0, 0.0), eOK);
-	QCOMPARE(QMudNativePluginRegistry::luaAudioRuntimeOwnedBuffers(&runtime).size(), 1);
-	QCOMPARE(runtimeStubState(&runtime).soundStatusByBuffer.value(1), 2);
-
-	teardownWorkerEngine(executor, loopEngine);
-	QVERIFY(QMudNativePluginRegistry::luaAudioRuntimeOwnedBuffers(&runtime).isEmpty());
-	QCOMPARE(runtimeStubState(&runtime).soundStatusByBuffer.value(1, -2), -2);
-
 	auto timedEngine = QSharedPointer<LuaCallbackEngine>::create();
 	initializeWorkerEngine(executor, timedEngine, QStringLiteral(R"lua(
 	function OnPluginEnable()
@@ -2598,8 +1947,6 @@ void tst_LuaCallbackEngine::nativeLuaAudioSharedRuntimeStateCoversDirectAndCallP
 	fadeState.volume   = 100.0;
 	fadeState.ownerKey = timedEngine.data();
 	QMudNativePluginRegistry::luaAudioMarkRuntimeBuffer(&runtime, 2, fadeState);
-	runtimeStubState(&runtime).soundStatusByBuffer.insert(1, 1);
-	runtimeStubState(&runtime).soundStatusByBuffer.insert(2, 1);
 	auto timedSnapshot = QSharedPointer<LuaCallbackMiniWindowSnapshot>::create();
 	timedSnapshot->soundStatusByBuffer.insert(1, 1);
 	timedSnapshot->soundStatusByBuffer.insert(2, 1);
@@ -2620,7 +1967,7 @@ void tst_LuaCallbackEngine::nativeLuaAudioSharedRuntimeStateCoversDirectAndCallP
 	QCOMPARE(timedState.volume, 40.0);
 	QCOMPARE(timedState.pan, 7.0);
 	QCOMPARE(timedState.pitch, 5.0);
-	QCOMPARE(runtimeStubState(&runtime).soundStatusByBuffer.value(2, -2), -2);
+	QVERIFY(runtime.soundStatus(2) <= 0);
 	teardownWorkerEngine(executor, timedEngine);
 	QVERIFY(QMudNativePluginRegistry::luaAudioRuntimeOwnedBuffers(&runtime).isEmpty());
 }
@@ -2640,7 +1987,7 @@ void tst_LuaCallbackEngine::blacklistedPluginsAreHiddenFromPluginApis()
 	plugin.attributes.insert(QStringLiteral("id"), blacklistedId);
 	plugin.attributes.insert(QStringLiteral("name"), QStringLiteral("Automatic Backup"));
 	plugin.enabled = true;
-	runtimeStubState(&runtime).plugins.push_back(plugin);
+	runtime.pluginsMutable().push_back(plugin);
 
 	initializeWorkerEngine(executor, engine, QStringLiteral(R"lua(
 	function OnPluginEnable()
@@ -2687,13 +2034,12 @@ end
 	                       &runtime);
 
 	const QString           prompt = QStringLiteral("[Library][SAFE]<2084hp 1806sp 1695st> ");
-	RuntimeStubState       &state  = runtimeStubState(&runtime);
 	WorldRuntime::LineEntry promptEntry;
 	promptEntry.text       = prompt;
 	promptEntry.flags      = WorldRuntime::LineOutput;
 	promptEntry.hardReturn = true;
 	promptEntry.lineNumber = 42;
-	state.lineEntries.push_back(promptEntry);
+	runtime.replaceOutputLines({promptEntry});
 
 	LuaBatchDispatchRequest request;
 	request.engines        = {engine};
@@ -2715,8 +2061,8 @@ end
 	QVERIFY(!result.deferredRuntimeMutationBatches.isEmpty());
 	executeDeferredMutations(result);
 
-	const QStringList logicalLines = logicalOutputLinesFromEntries(state.lineEntries);
-	QCOMPARE(logicalLines, QStringList({QStringLiteral("[435, 1226]"), prompt}));
+	const QVector<WorldRuntime::LineEntry> &lines = runtime.lines();
+	QCOMPARE(logicalOutputLinesFromEntries(lines), QStringList({QStringLiteral("[435, 1226]"), prompt}));
 	teardownWorkerEngine(executor, engine);
 }
 
@@ -2858,15 +2204,13 @@ end
 
 	const auto makeSnapshot = [&runtime](const int mouseX, const int mouseY)
 	{
-		const RuntimeStubState    &state    = runtimeStubState(&runtime);
-		const QString              windowId = QStringLiteral("win");
-		const QHash<int, QVariant> info     = state.windowInfo.value(windowId);
-		const int                  left     = info.value(1).toInt();
-		const int                  top      = info.value(2).toInt();
-		const int                  width    = info.value(3).toInt();
-		const int                  height   = info.value(4).toInt();
+		const QString windowId = QStringLiteral("win");
+		const int     left     = runtime.windowInfo(windowId, 1).toInt();
+		const int     top      = runtime.windowInfo(windowId, 2).toInt();
+		const int     width    = runtime.windowInfo(windowId, 3).toInt();
+		const int     height   = runtime.windowInfo(windowId, 4).toInt();
 
-		auto                       snapshot   = QSharedPointer<LuaCallbackMiniWindowSnapshot>::create();
+		auto          snapshot                = QSharedPointer<LuaCallbackMiniWindowSnapshot>::create();
 		snapshot->hasCommandUiSnapshot        = true;
 		snapshot->commandUiHasView            = true;
 		snapshot->commandUiHasFrameData       = true;
@@ -2886,8 +2230,8 @@ end
 		windowInfo.locationY                   = top;
 		windowInfo.width                       = width;
 		windowInfo.height                      = height;
-		windowInfo.position                    = info.value(7).toInt();
-		windowInfo.flags                       = info.value(8).toInt();
+		windowInfo.position                    = runtime.windowInfo(windowId, 7).toInt();
+		windowInfo.flags                       = runtime.windowInfo(windowId, 8).toInt();
 		windowInfo.rectLeft                    = left;
 		windowInfo.rectTop                     = top;
 		windowInfo.rectRight                   = left + width;
@@ -2915,8 +2259,8 @@ end
 	QVERIFY(moveResult.boolResultValid);
 	QVERIFY(!moveResult.boolResult);
 	executeDeferredMutations(moveResult);
-	QCOMPARE(runtimeStubState(&runtime).windowInfo.value(QStringLiteral("win")).value(3).toInt(), 240);
-	QCOMPARE(runtimeStubState(&runtime).windowInfo.value(QStringLiteral("win")).value(4).toInt(), 160);
+	QCOMPARE(runtime.windowInfo(QStringLiteral("win"), 3).toInt(), 240);
+	QCOMPARE(runtime.windowInfo(QStringLiteral("win"), 4).toInt(), 160);
 
 	request.functionName                 = QStringLiteral("OnResizeRelease");
 	request.miniWindowSnapshotArg        = makeSnapshot(145, 165);

--- a/tests/unit/tst_NativePluginRegistry.cpp
+++ b/tests/unit/tst_NativePluginRegistry.cpp
@@ -56,8 +56,8 @@ namespace
 
 	QString writePluginXml(const QTemporaryDir &dir, const QString &id, const QString &script)
 	{
-		const QString path = dir.filePath(QStringLiteral("%1.xml").arg(id));
-		QFile         file(path);
+		QString path = dir.filePath(QStringLiteral("%1.xml").arg(id));
+		QFile   file(path);
 		if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
 			return {};
 		const QString xml = QStringLiteral(R"xml(<?xml version="1.0" encoding="UTF-8"?>
@@ -211,13 +211,15 @@ bool WorldRuntime::enablePlugin(const QString &pluginId, const bool enable)
 	{
 		if (plugin.attributes.value(QStringLiteral("id")).compare(id, Qt::CaseInsensitive) != 0)
 			continue;
-		if (plugin.nativeShim && id == QMudNativePluginRegistry::mushReaderPluginId())
-			QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, enable);
-		if (plugin.nativeShim && id == QMudNativePluginRegistry::luaAudioPluginId() && !enable)
-			QMudNativePluginRegistry::luaAudioStopRuntime(this);
+		if (plugin.enabled == enable)
+			return true;
 		plugin.enabled = enable;
 		plugin.attributes.insert(QStringLiteral("enabled"),
 		                         enable ? QStringLiteral("1") : QStringLiteral("0"));
+		if (plugin.nativeShim && id == QMudNativePluginRegistry::mushReaderPluginId())
+			QMudNativePluginRegistry::setMushReaderPluginEnabled(this, enable);
+		if (plugin.nativeShim && id == QMudNativePluginRegistry::luaAudioPluginId() && !enable)
+			QMudNativePluginRegistry::luaAudioStopRuntime(this);
 		return true;
 	}
 	return QMudNativePluginRegistry::isShimId(id);
@@ -233,7 +235,7 @@ bool WorldRuntime::unloadPlugin(const QString &pluginId, QString *error)
 		if (state.plugins.at(i).attributes.value(QStringLiteral("id")).compare(id, Qt::CaseInsensitive) != 0)
 			continue;
 		if (state.plugins.at(i).nativeShim && id == QMudNativePluginRegistry::mushReaderPluginId())
-			QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(this, false);
+			QMudNativePluginRegistry::setMushReaderPluginEnabled(this, false);
 		if (state.plugins.at(i).nativeShim && id == QMudNativePluginRegistry::luaAudioPluginId())
 			QMudNativePluginRegistry::luaAudioStopRuntime(this);
 		state.plugins.removeAt(i);
@@ -747,37 +749,96 @@ class tst_NativePluginRegistry : public QObject
 			QVERIFY(found);
 		}
 
-		void passiveSpeechEnabledStateTracksTtsToggle()
+		void ttsToggleUsesMushReaderSpeechGateOnlyWhenMushReaderIsEnabled()
 		{
-			WorldRuntime runtime;
+			WorldRuntime                                       runtime;
+			QVector<QMudNativePluginRegistry::TestSpeechEvent> events;
 			QMudNativePluginRegistry::setTestSpeechSink(
-			    [](const QMudNativePluginRegistry::TestSpeechEvent &) {});
+			    [&events](const QMudNativePluginRegistry::TestSpeechEvent &event)
+			    { events.push_back(event); });
+
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
 			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 
 			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+			QVERIFY(events.size() >= 2);
+			QVERIFY(events.at(events.size() - 2).stop);
+			QCOMPARE(events.constLast().text, QStringLiteral("speech on"));
 
 			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
 			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+
+			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 
 			WorldRuntime::Plugin mushReaderPlugin;
 			mushReaderPlugin.nativeShim = true;
-			mushReaderPlugin.enabled    = true;
+			mushReaderPlugin.enabled    = false;
 			mushReaderPlugin.attributes.insert(QStringLiteral("id"),
 			                                   QMudNativePluginRegistry::mushReaderPluginId());
 			stateFor(&runtime).plugins.push_back(mushReaderPlugin);
 
 			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), true));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
-			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), false));
-			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+
+			events.clear();
+			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
+			                                                     QStringLiteral("mushreader line"));
+			QCOMPARE(events.size(), 1);
+			QCOMPARE(events.constFirst().text, QStringLiteral("mushreader line"));
+
+			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(events.size() >= 3);
+			QVERIFY(events.at(events.size() - 2).stop);
+			QCOMPARE(events.constLast().text, QStringLiteral("speech off"));
+
+			events.clear();
+			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
+			                                                     QStringLiteral("muted line"));
+			QVERIFY(events.isEmpty());
+
 			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), true));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
+			                                                     QStringLiteral("still muted line"));
+			QVERIFY(events.isEmpty());
+
+			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+
+			events.clear();
+			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
+			                                                     QStringLiteral("enabled line"));
+			QCOMPARE(events.size(), 1);
+			QCOMPARE(events.constFirst().text, QStringLiteral("enabled line"));
+
+			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), false));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+
+			events.clear();
+			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
+			                                                     QStringLiteral("passive line"));
+			QCOMPARE(events.size(), 1);
+			QCOMPARE(events.constFirst().text, QStringLiteral("passive line"));
+
+			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), true));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 
 			QString unloadError;
 			QVERIFY(runtime.unloadPlugin(QMudNativePluginRegistry::mushReaderPluginId(), &unloadError));
 			QVERIFY(unloadError.isEmpty());
-			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 		}
 
 		void blacklistAndProtectedPluginXmlClassification()


### PR DESCRIPTION
## Summary

- Use DontUseNativeDialog for font dialogs on Mac. There's an issue with Qt and the native dialog. Fixes #114 
- Properly separate MushReader from passive TTS engine. Ctrl-shift-F12 should now work properly with MushReader.
- Adjust Ctrl-R semantics. Send the last command instead of loading it on command input.
- Fix tab button navigation in plugins dialog. Tab is no longer consumed by the table.
- Fix typo on QMUD_ENABLE_SOUND disabling lua audio. Preprocessor macro typo was disabling audio functionality.
- Refactor LuaCallbackEngine tests. Remove the minimal bindings as it was breaking coverage upload due to LuaCallbackEngine being compiled in 2 different modes. This exposes far bigger surface so it'll probably affect reported coverage negatively. Still it was going to happen eventually as more branches get coverage.

## Scope

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- Ctrl-R should work as on MUSHclient.
- Tab should navigate plugin dialog buttons like on MUSHclient.
- Ctrl-shift-F12 should work as it does on MUSHclient with MushReader plugin for VI packages.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

