### PR TITLE
Properly support compressed audio formats. Fix MushReader and passive TTS engine layering. Refactor TTS engine teardown. Implement Import from MUSHclient functionality. Allow update from CI build to stable if same version. Fix Macro Send now and Replace parity. Adjust tab focus. Increase max command input history size to 50k. Implement custom indexed ring-buffer. Refactor view caches.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ set(QMUD_SOURCES
         helpers/HyperlinkActionUtils.cpp
         helpers/NoteColourUtils.cpp
         helpers/WorldCommandProcessorUtils.cpp
+        helpers/SoundFileRoutingUtils.cpp
         helpers/LuaExecutionUtils.cpp
         helpers/LuaModalDialogUtils.cpp
         helpers/AccessibleTextUtils.cpp
@@ -283,6 +284,7 @@ set(QMUD_HEADERS
         helpers/NoteColourUtils.h
         CommandMappingTypes.h
         helpers/WorldCommandProcessorUtils.h
+        helpers/SoundFileRoutingUtils.h
         ErrorDescriptions.h
         InfoTypesMetadata.h
         InfoTypeData.inc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ set(QMUD_SOURCES
         helpers/WorldSessionRestoreFlowUtils.cpp
         helpers/WorldSessionStateUtils.cpp
         helpers/ReloadUtils.cpp
+        helpers/MushclientImportUtils.cpp
         Environment.cpp
         Accelerators.cpp
         helpers/AliasMatchUtils.cpp
@@ -274,6 +275,7 @@ set(QMUD_HEADERS
         Environment.h
         helpers/LogCompressionUtils.h
         helpers/ReloadUtils.h
+        helpers/MushclientImportUtils.h
         helpers/WorldSessionRestoreFlowUtils.h
         helpers/WorldSessionStateUtils.h
         helpers/PluginCallbackCatalogUtils.h

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ The official site and documentation of QMud is here: [qmud.dev](https://qmud.dev
 ## Project status
 
 QMud is fully functional and early porting issues have been ironed out.
-There are several improvements and new features implemented already.
-It is now also the first and only, at the time of this writing, MUD client with a multithreaded Lua engine.
+There are several improvements and new features implemented already and many more on TODO.
+It is now also the FIRST and ONLY, at the time of this writing, MUD client with a multithreaded Lua engine.
+v11.00 essentially marks the first production release. QMud started with a v10 versioning offset in order to guarrantee
+higher than MUSHclient versioning for compatibility/importing reasons.
 Please use the issue tracker, with the appropriate template to report issues, request features, etc.
 
 ## Features
@@ -33,11 +35,11 @@ Please use the issue tracker, with the appropriate template to report issues, re
 - Cross-platform (Linux, Windows, macOS).
 - Unicode, NAWS, Terminal Type, CHARSET, EOR, ECHO, MXP, MSP, MCCP, MMCP, OSC8, xterm256 color, Truecolor, TLS (Direct &
   Upgrade).
-- Lua scripting. The first and only MUD client with a multithreaded Lua engine that allows ridiculously heavy Lua plugin
-  workloads without lagging the client.
+- Lua scripting. The FIRST and ONLY, currently, MUD client with a multithreaded Lua engine that allows ridiculously
+  heavy Lua plugin workloads without lagging the client.
 - Copyover-style in-place reload on Linux/macOS (`File -> Reload QMud`).
 - MushReader and LuaAudio implemented natively for VI workflows and are activated by the presence of those plugins in
-  existing world files or by loading the included stud plugins.
+  existing world files or by loading the included stub plugins.
 - Passive TTS engine enabled automatically when a native screenreader is detected.
 - Split-pane scrollback buffer, persistent scrollback buffer/command history.
 - Autosave, autobackup, log rotation, log compression.
@@ -56,9 +58,9 @@ Do **NOT** use the issue tracker for general support requests.
 - Bug fix PRs are welcome.
 - Feature PRs have to be discussed first either on Issue tracker or Discord.
 - You can also contribute with documentation or translations (once work on translations is started; but you can apply to
-  help before that)
+  help before that).
 - You can test plugins of various MUDs and see if they're working right or not. Open detailed issues if something's not
-  working including a link to the source for the plugin in question.
+  working and make sure to include a link to the source for the plugin in question.
 - You can also contribute with funding as funds are needed for code signing certificate, Apple registration etc.
   in order to bring QMud to the Apple Store/avoid issues with Windows SmartScreen/WDAC.
 
@@ -85,7 +87,7 @@ QMud can migrate an existing MUSHclient data tree.
 4. Wait until it's done. At the end, it will show statistics on what was imported and will prompt to reload or restart
    depending on platform.
 
-### Old manual Migration method. (Outdated)
+### Old manual Migration method. (Still working but obsolete)
 
 Migration is copy-based, so source files are preserved and moved under a `migrated` marker
 path after successful import to avoid reprocessing.

--- a/README.md
+++ b/README.md
@@ -23,19 +23,22 @@ The official site and documentation of QMud is here: [qmud.dev](https://qmud.dev
 
 ## Project status
 
-The porting has been completed. Behavior aims for high compatibility
-with original persistence and Lua workflows while using a modern Qt
-implementation. There are several improvements and new features implemented
-already. Please use the issue tracker, with the appropriate template to report
-issues, request features, etc.
+QMud is fully functional and early porting issues have been ironed out.
+There are several improvements and new features implemented already.
+It is now also the first and only, at the time of this writing, MUD client with a multithreaded Lua engine.
+Please use the issue tracker, with the appropriate template to report issues, request features, etc.
 
 ## Features
 
 - Cross-platform (Linux, Windows, macOS).
 - Unicode, NAWS, Terminal Type, CHARSET, EOR, ECHO, MXP, MSP, MCCP, MMCP, OSC8, xterm256 color, Truecolor, TLS (Direct &
   Upgrade).
-- Lua scripting.
+- Lua scripting. The first and only MUD client with a multithreaded Lua engine that allows ridiculously heavy Lua plugin
+  workloads without lagging the client.
 - Copyover-style in-place reload on Linux/macOS (`File -> Reload QMud`).
+- MushReader and LuaAudio implemented natively for VI workflows and are activated by the presence of those plugins in
+  existing world files or by loading the included stud plugins.
+- Passive TTS engine enabled automatically when a native screenreader is detected.
 - Split-pane scrollback buffer, persistent scrollback buffer/command history.
 - Autosave, autobackup, log rotation, log compression.
 - Autoupdates.
@@ -52,10 +55,10 @@ Do **NOT** use the issue tracker for general support requests.
 
 - Bug fix PRs are welcome.
 - Feature PRs have to be discussed first either on Issue tracker or Discord.
-- You can also contribute with documentation or translations (once work on both is started; but you can apply to help
-  before that)
+- You can also contribute with documentation or translations (once work on translations is started; but you can apply to
+  help before that)
 - You can test plugins of various MUDs and see if they're working right or not. Open detailed issues if something's not
-  working including a source for the plugin in question.
+  working including a link to the source for the plugin in question.
 - You can also contribute with funding as funds are needed for code signing certificate, Apple registration etc.
   in order to bring QMud to the Apple Store/avoid issues with Windows SmartScreen/WDAC.
 
@@ -72,8 +75,19 @@ touching AND be able to make requested changes after review. "Vibe coding" is NO
 
 ## Migration from MUSHclient data
 
-QMud can migrate an existing MUSHclient data tree on first run. Migration is
-copy-based, so source files are preserved and moved under a `migrated` marker
+QMud can migrate an existing MUSHclient data tree.
+
+### How to Migrate
+
+1. Run QMud.
+2. Go to Help → Import from MUSHclient.
+3. Select the MUSHclient directory. Migration treats the source directory as READONLY.
+4. Wait until it's done. At the end, it will show statistics on what was imported and will prompt to reload or restart
+   depending on platform.
+
+### Old manual Migration method. (Outdated)
+
+Migration is copy-based, so source files are preserved and moved under a `migrated` marker
 path after successful import to avoid reprocessing.
 
 What is migrated:
@@ -85,8 +99,6 @@ What is migrated:
 Path handling during migration normalizes legacy Windows-style paths (for
 example `C:\...`) so migrated worlds resolve correctly on the active platform.
 
-### How to Migrate
-
 1. Install/Run QMud (depending on platform) to create fresh QMud home directory.
 2. Copy your MUSHclient's lua contents into QMud/lua directory without overwriting anything. (*IF* you have placed any
    custom lua modules there)
@@ -95,12 +107,14 @@ example `C:\...`) so migrated worlds resolve correctly on the active platform.
 4. Copy your MUSHclient world directory into QMud/ without overwriting anything.
 5. Delete QMud.conf and QMud.sqlite from QMud/ directory.
 6. Copy your mushclient.ini and mushclient_prefs.sqlite to QMud/ directory.
-7. Run QMud.
-8. Change Terminal Type (TTYPE) in world preferences to "QMud" unless you have a reason to keep it mushclient (e.g. Mud
+7. Copy your *.db sqlite databases to QMud/ directory.
+8. Run QMud.
+9. Change Terminal Type (TTYPE) in world preferences to "QMud" unless you have a reason to keep it mushclient (e.g. Mud
    does some special handling on TTYPE).
-9. (Optional) Do a manual check on your .qdl world files with a text editor to make sure paths have migrated normally.
-   QMud saves paths ALWAYS as RELATIVE to the QMUD_HOME directory and with FORWARD slashes even on Windows. So all paths
-   in the world file should look like: `<include name="./worlds/plugins/CthulhuMUD/CthulhuMUD_Mapper.xml" plugin="y" />`
+10. (Optional) Do a manual check on your .qdl world files with a text editor to make sure paths have migrated normally.
+    QMud saves paths ALWAYS as RELATIVE to the QMUD_HOME directory and with FORWARD slashes even on Windows. So all
+    paths in the world file should look like:
+    `<include name="./worlds/plugins/CthulhuMUD/CthulhuMUD_Mapper.xml" plugin="y" />`
 
 Always keep a copy of your original MUSHclient directory. Extensive testing has been done but better safe than sorry.
 

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -24,6 +24,7 @@
 #include "MainFrame.h"
 #include "MainWindowHost.h"
 #include "MainWindowHostResolver.h"
+#include "MushclientImportUtils.h"
 #include "NameGeneration.h"
 #include "ReloadUtils.h"
 #include "SqliteCompat.h"
@@ -70,6 +71,7 @@ extern "C"
 #include <QByteArrayView>
 #include <QCheckBox>
 #include <QClipboard>
+#include <QCloseEvent>
 #include <QColor>
 #include <QComboBox>
 #include <QCoreApplication>
@@ -119,7 +121,9 @@ extern "C"
 #include <QPointer>
 #include <QPrintDialog>
 #include <QPrinter>
+// ReSharper disable once CppUnusedIncludeDirective
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QRegularExpression>
@@ -143,6 +147,8 @@ extern "C"
 #include <QTimer>
 #include <QTranslator>
 #include <QUrl>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QVBoxLayout>
 #include <QVariant>
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlError>
@@ -193,6 +199,22 @@ namespace
 			const char *mimeType;
 			const char *modernExtension;
 			const char *legacyExtension;
+	};
+
+	class ImportProgressDialog final : public QDialog
+	{
+		public:
+			using QDialog::QDialog;
+
+			void reject() override
+			{
+			}
+
+		protected:
+			void closeEvent(QCloseEvent *event) override
+			{
+				event->ignore();
+			}
 	};
 
 	constexpr quint8 kXtermCubeValues[6]         = {0, 95, 135, 175, 215, 255};
@@ -1314,11 +1336,6 @@ namespace
 		return transformed.join(QLatin1Char('*'));
 	}
 
-	QString normalizePathList(const QString &input)
-	{
-		return transformPathList(input, normalizePathString);
-	}
-
 	QString pathForRuntime(const QString &input)
 	{
 		return normalizePathString(input);
@@ -2057,111 +2074,6 @@ namespace
 		return QDir::cleanPath(QDir(baseDir).filePath(normalized));
 	}
 
-	QString archiveRelativePathFor(const QString &baseDir, const QString &absolutePath);
-
-	QString resolveExistingPathCaseInsensitive(const QString &path)
-	{
-		QString cleaned = QDir::cleanPath(path);
-		if (cleaned.isEmpty())
-			return {};
-		if (QFileInfo::exists(cleaned))
-			return cleaned;
-#ifdef Q_OS_WIN
-		return {};
-#else
-		if (!QDir::isAbsolutePath(cleaned))
-			return {};
-		QStringList segments = cleaned.split(QLatin1Char('/'), Qt::SkipEmptyParts);
-		QString     current  = QStringLiteral("/");
-		for (const QString &segment : segments)
-		{
-			const QDir      dir(current);
-			const QFileInfo matched = [&]() -> QFileInfo
-			{
-				const QFileInfoList entries =
-				    dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System);
-				for (const QFileInfo &entry : entries)
-				{
-					if (entry.fileName().compare(segment, Qt::CaseInsensitive) == 0)
-						return entry;
-				}
-				return {};
-			}();
-			if (!matched.exists())
-				return {};
-			current = matched.absoluteFilePath();
-		}
-		return QDir::cleanPath(current);
-#endif
-	}
-
-	QString storagePathFromAbsolute(const QString &baseDir, const QString &sourcePath,
-	                                const QString &absolutePath)
-	{
-		Q_UNUSED(sourcePath);
-		return dotRelativeStoragePath(baseDir, absolutePath, false);
-	}
-
-	QString remapLegacyWindowsWorldPathToBase(const QString &baseDir, const QString &path)
-	{
-		const QString normalized = normalizePathString(path.trimmed());
-		const bool    hasDrive =
-		    normalized.size() > 1 && normalized.at(0).isLetter() && normalized.at(1) == QLatin1Char(':');
-		if (!hasDrive)
-			return {};
-		const qsizetype worldsPos = normalized.indexOf(QStringLiteral("/worlds/"), 0, Qt::CaseInsensitive);
-		if (worldsPos < 0)
-			return {};
-		const QString relativeWorldPath = normalized.mid(worldsPos + 1); // strip leading '/'
-		return absolutePathFromBase(baseDir, relativeWorldPath);
-	}
-
-	QString stripOptionalQuotes(const QString &value)
-	{
-		if (value.size() < 2)
-			return value;
-		if (const QChar first = value.front(), last = value.back();
-		    (first == QLatin1Char('"') && last == QLatin1Char('"')) ||
-		    (first == QLatin1Char('\'') && last == QLatin1Char('\'')))
-			return value.mid(1, value.size() - 2);
-		return value;
-	}
-
-	QString archiveRelativePathFor(const QString &baseDir, const QString &absolutePath)
-	{
-		QString relative = QDir(baseDir).relativeFilePath(absolutePath);
-		if (relative == QStringLiteral("..") || relative.startsWith(QStringLiteral("../")) ||
-		    QDir::isAbsolutePath(relative))
-		{
-			relative = QDir::cleanPath(absolutePath);
-#ifdef Q_OS_WIN
-			if (relative.size() > 1 && relative.at(1) == QLatin1Char(':'))
-				relative.replace(1, 1, QStringLiteral("_"));
-#endif
-			while (relative.startsWith(QLatin1Char('/')))
-				relative.remove(0, 1);
-		}
-		return normalizePathString(relative);
-	}
-
-	bool moveFileToArchive(const QString &sourcePath, const QString &targetPath)
-	{
-		const QFileInfo targetInfo(targetPath);
-		if (const QString targetDir = targetInfo.absolutePath(); !QDir().mkpath(targetDir))
-			return false;
-
-		if (QFileInfo::exists(targetPath) && !QFile::remove(targetPath))
-			return false;
-
-		if (QFile::rename(sourcePath, targetPath))
-			return true;
-
-		if (!QFile::copy(sourcePath, targetPath))
-			return false;
-
-		return QFile::remove(sourcePath);
-	}
-
 	bool directoryContainsFileCaseInsensitive(const QString &directoryPath, const QString &fileName)
 	{
 		const QDir dir(directoryPath);
@@ -2270,342 +2182,42 @@ namespace
 
 	QString migrateLegacyWorldFilePath(const QString &baseDir, const QString &path)
 	{
-		QString normalizedPath = stripOptionalQuotes(normalizePathString(path).trimmed());
-		if (normalizedPath.startsWith(QStringLiteral("./")) && normalizedPath.size() > 3 &&
-		    normalizedPath.at(2).isLetter() && normalizedPath.at(3) == QLatin1Char(':'))
-		{
-			normalizedPath = normalizedPath.mid(2);
-		}
-		if (normalizedPath.startsWith(QLatin1Char('/')) && normalizedPath.size() > 3 &&
-		    normalizedPath.at(1).isLetter() && normalizedPath.at(2) == QLatin1Char(':'))
-		{
-			normalizedPath = normalizedPath.mid(1);
-		}
-		if (normalizedPath.trimmed().isEmpty())
-			return normalizedPath;
-
-		const QString suffix = QFileInfo(normalizedPath).suffix().toLower();
-		if (!QMudFileExtensions::isWorldSuffix(suffix))
-			return QMudFileExtensions::canonicalizePathExtension(normalizedPath);
-
-		QString canonicalPath = QMudFileExtensions::canonicalizePathExtension(normalizedPath);
-		if (!QMudFileExtensions::isLegacyWorldSuffix(suffix))
-		{
-			if (const QString modernAbsolutePath = absolutePathFromBase(baseDir, canonicalPath);
-			    QFileInfo::exists(modernAbsolutePath))
-				return storagePathFromAbsolute(baseDir, normalizedPath, modernAbsolutePath);
-			if (const QString resolvedModernPath =
-			        resolveExistingPathCaseInsensitive(absolutePathFromBase(baseDir, canonicalPath));
-			    !resolvedModernPath.isEmpty())
-				return storagePathFromAbsolute(baseDir, normalizedPath, resolvedModernPath);
-			if (const QString remappedModernPath = resolveExistingPathCaseInsensitive(
-			        remapLegacyWindowsWorldPathToBase(baseDir, canonicalPath));
-			    !remappedModernPath.isEmpty())
-			{
-				return storagePathFromAbsolute(baseDir, normalizedPath, remappedModernPath);
-			}
-			const QString legacyFallbackPath =
-			    QMudFileExtensions::replaceOrAppendExtension(normalizedPath, QStringLiteral("mcl"));
-			if (const QString legacyFallbackAbsolutePath = absolutePathFromBase(baseDir, legacyFallbackPath);
-			    QFileInfo::exists(legacyFallbackAbsolutePath) ||
-			    !resolveExistingPathCaseInsensitive(legacyFallbackAbsolutePath).isEmpty())
-				return migrateLegacyWorldFilePath(baseDir, legacyFallbackPath);
-			return canonicalPath;
-		}
-
-		const QString legacyAbsolutePath = absolutePathFromBase(baseDir, normalizedPath);
-		QString       resolvedLegacyPath = QFileInfo::exists(legacyAbsolutePath)
-		                                       ? QDir::cleanPath(legacyAbsolutePath)
-		                                       : resolveExistingPathCaseInsensitive(legacyAbsolutePath);
-		if (resolvedLegacyPath.isEmpty())
-		{
-			if (const QString remappedLegacyPath = resolveExistingPathCaseInsensitive(
-			        remapLegacyWindowsWorldPathToBase(baseDir, normalizedPath));
-			    !remappedLegacyPath.isEmpty())
-			{
-				resolvedLegacyPath = remappedLegacyPath;
-			}
-		}
-		const QString defaultModernAbsolutePath = absolutePathFromBase(baseDir, canonicalPath);
-		QString resolvedModernPath = QFileInfo::exists(defaultModernAbsolutePath)
-		                                 ? QDir::cleanPath(defaultModernAbsolutePath)
-		                                 : resolveExistingPathCaseInsensitive(defaultModernAbsolutePath);
-		if (resolvedModernPath.isEmpty())
-		{
-			if (const QString remappedModernPath = resolveExistingPathCaseInsensitive(
-			        remapLegacyWindowsWorldPathToBase(baseDir, canonicalPath));
-			    !remappedModernPath.isEmpty())
-			{
-				resolvedModernPath = remappedModernPath;
-			}
-		}
-
-		if (resolvedLegacyPath.isEmpty())
-		{
-			if (!resolvedModernPath.isEmpty())
-				return storagePathFromAbsolute(baseDir, normalizedPath, resolvedModernPath);
-			return normalizedPath;
-		}
-
-		QString effectiveModernAbsolutePath =
-		    !resolvedModernPath.isEmpty()
-		        ? resolvedModernPath
-		        : QMudFileExtensions::replaceOrAppendExtension(resolvedLegacyPath, QStringLiteral("qdl"));
-
-		if (!QFileInfo::exists(effectiveModernAbsolutePath))
-		{
-			if (const QString modernDir = QFileInfo(effectiveModernAbsolutePath).absolutePath();
-			    !QDir().mkpath(modernDir))
-			{
-				qWarning() << "Failed to create migrated world directory:" << modernDir;
-				return normalizedPath;
-			}
-
-			QFile legacyFile(resolvedLegacyPath);
-			if (!legacyFile.open(QIODevice::ReadOnly))
-			{
-				qWarning() << "Failed to read legacy world file:" << resolvedLegacyPath;
-				return normalizedPath;
-			}
-			const QByteArray data = legacyFile.readAll();
-			legacyFile.close();
-
-			QSaveFile modernFile(effectiveModernAbsolutePath);
-			if (!modernFile.open(QIODevice::WriteOnly))
-			{
-				qWarning() << "Failed to create migrated world file:" << effectiveModernAbsolutePath;
-				return normalizedPath;
-			}
-			if (modernFile.write(data) != data.size() || !modernFile.commit())
-			{
-				qWarning() << "Failed to write migrated world file:" << effectiveModernAbsolutePath;
-				return normalizedPath;
-			}
-		}
-
-		const QString relativeLegacy = archiveRelativePathFor(baseDir, resolvedLegacyPath);
-		const QString archivePath    = QDir(baseDir).filePath(QStringLiteral("migrated/") + relativeLegacy);
-		if (!moveFileToArchive(resolvedLegacyPath, archivePath))
-			qWarning() << "Failed to archive legacy world file:" << resolvedLegacyPath << "->" << archivePath;
-
-		return storagePathFromAbsolute(baseDir, normalizedPath, effectiveModernAbsolutePath);
+		return QMudMushclientImportUtils::migrateLegacyWorldFilePath(baseDir, baseDir, path, true);
 	}
 
 	QString migrateWorldListPaths(const QString &baseDir, const QString &worldList, bool *changed = nullptr)
 	{
-		const QStringList items = splitSerializedWorldList(worldList);
-		QStringList       migrated;
-		migrated.reserve(items.size());
-		bool anyChanged = false;
-		for (const QString &item : items)
-		{
-			const QString value = migrateLegacyWorldFilePath(baseDir, item);
-			if (value != item)
-				anyChanged = true;
-			migrated.push_back(value);
-		}
-		const QString joined = migrated.join(QLatin1Char('*'));
-		if (changed)
-			*changed = anyChanged || (joined != worldList);
-		return joined;
+		return QMudMushclientImportUtils::migrateWorldListPaths(baseDir, worldList, changed);
 	}
 
 	QString canonicalizeWorldListForRuntime(const QString &worldList)
 	{
-		return splitSerializedWorldList(worldList).join(QLatin1Char('*'));
-	}
-
-	QString migrateLegacyPluginFilePath(const QString &baseDir, const QString &path)
-	{
-		QString normalizedPath = stripOptionalQuotes(normalizePathString(path).trimmed());
-		if (normalizedPath.startsWith(QStringLiteral("./")) && normalizedPath.size() > 3 &&
-		    normalizedPath.at(2).isLetter() && normalizedPath.at(3) == QLatin1Char(':'))
-		{
-			normalizedPath = normalizedPath.mid(2);
-		}
-		if (normalizedPath.startsWith(QLatin1Char('/')) && normalizedPath.size() > 3 &&
-		    normalizedPath.at(1).isLetter() && normalizedPath.at(2) == QLatin1Char(':'))
-		{
-			normalizedPath = normalizedPath.mid(1);
-		}
-		if (normalizedPath.trimmed().isEmpty())
-			return normalizedPath;
-
-		const QString defaultAbsolutePath = absolutePathFromBase(baseDir, normalizedPath);
-		if (const QString resolvedPath = QFileInfo::exists(defaultAbsolutePath)
-		                                     ? QDir::cleanPath(defaultAbsolutePath)
-		                                     : resolveExistingPathCaseInsensitive(defaultAbsolutePath);
-		    !resolvedPath.isEmpty())
-		{
-			return storagePathFromAbsolute(baseDir, normalizedPath, resolvedPath);
-		}
-
-		if (const QString remappedPath = resolveExistingPathCaseInsensitive(
-		        remapLegacyWindowsWorldPathToBase(baseDir, normalizedPath));
-		    !remappedPath.isEmpty())
-		{
-			return storagePathFromAbsolute(baseDir, normalizedPath, remappedPath);
-		}
-
-		return normalizedPath;
+		return QMudMushclientImportUtils::canonicalizeWorldListForRuntime(worldList);
 	}
 
 	QString migratePluginListPaths(const QString &baseDir, const QString &pluginList, bool *changed = nullptr)
 	{
-		const QStringList items = splitSerializedPathList(pluginList);
-		QStringList       migrated;
-		migrated.reserve(items.size());
-		bool anyChanged = false;
-		for (const QString &item : items)
-		{
-			const QString value = migrateLegacyPluginFilePath(baseDir, item);
-			if (value != item)
-				anyChanged = true;
-			migrated.push_back(value);
-		}
-		const QString joined = migrated.join(QLatin1Char('*'));
-		if (changed)
-			*changed = anyChanged || (joined != pluginList);
-		return joined;
+		return QMudMushclientImportUtils::migratePluginListPaths(baseDir, pluginList, changed);
 	}
 
 	QString canonicalizePluginListForRuntime(const QString &pluginList)
 	{
-		return splitSerializedPathList(pluginList).join(QLatin1Char('*'));
+		return QMudMushclientImportUtils::canonicalizePluginListForRuntime(pluginList);
 	}
 
 	void migrateLegacyWorldTree(const QString &baseDir, const QString &worldDirectory)
 	{
-		const QString normalizedWorldDir = normalizePathString(worldDirectory.trimmed());
-		if (normalizedWorldDir.isEmpty())
-			return;
-
-		const QString absoluteWorldDir = absolutePathFromBase(baseDir, normalizedWorldDir);
-		const QDir    rootDir(absoluteWorldDir);
-		if (!rootDir.exists())
-			return;
-
-		QStringList  legacyWorldFiles;
-		QDirIterator iterator(rootDir.absolutePath(),
-		                      QDir::Files | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System,
-		                      QDirIterator::Subdirectories);
-		while (iterator.hasNext())
-		{
-			const QString filePath = iterator.next();
-			const QString suffix   = iterator.fileInfo().suffix().toLower();
-			if (!QMudFileExtensions::isLegacyWorldSuffix(suffix))
-				continue;
-			legacyWorldFiles.push_back(QDir::cleanPath(filePath));
-		}
-
-		for (const QString &legacyAbsolutePath : legacyWorldFiles)
-		{
-			const QString migrationInput = archiveRelativePathFor(baseDir, legacyAbsolutePath);
-			(void)migrateLegacyWorldFilePath(baseDir, migrationInput);
-		}
+		QMudMushclientImportUtils::migrateLegacyWorldTree(baseDir, worldDirectory);
 	}
 
 	QString migrateLegacyIniPathValue(const QString &baseDir, const QString &key, const QString &value)
 	{
-		const QString leaf = keyLeafName(key);
-		if (isPathListKey(leaf))
-		{
-			if (leaf.compare(QStringLiteral("WorldList"), Qt::CaseInsensitive) == 0)
-				return migrateWorldListPaths(baseDir, value);
-			if (leaf.compare(QStringLiteral("PluginList"), Qt::CaseInsensitive) == 0)
-				return migratePluginListPaths(baseDir, value);
-			return normalizePathList(value);
-		}
-
-		if (!shouldNormalizePathKey(leaf))
-			return value;
-
-		const QString normalized = normalizePathString(value);
-		if (const QString suffix = QFileInfo(normalized).suffix().toLower();
-		    QMudFileExtensions::isWorldSuffix(suffix))
-			return migrateLegacyWorldFilePath(baseDir, normalized);
-		return QMudFileExtensions::canonicalizePathExtension(normalized);
-	}
-
-	QVariant migrateLegacyIniValue(const QString &baseDir, const QString &key, const QVariant &value)
-	{
-		if (value.canConvert<QStringList>())
-		{
-			const QStringList list = value.toStringList();
-			QStringList       migrated;
-			migrated.reserve(list.size());
-			for (const QString &item : list)
-				migrated.push_back(migrateLegacyIniPathValue(baseDir, key, item));
-			return {migrated};
-		}
-
-		if (value.canConvert<QString>())
-			return migrateLegacyIniPathValue(baseDir, key, value.toString());
-
-		return value;
+		return QMudMushclientImportUtils::migrateLegacyIniPathValue(baseDir, key, value);
 	}
 
 	bool isLikelyCorruptedRelativeWorldPath(const QString &path)
 	{
-		const QString normalized = normalizePathString(path.trimmed());
-		if (normalized.isEmpty())
-			return false;
-		if (const QString suffix = QFileInfo(normalized).suffix().toLower();
-		    !QMudFileExtensions::isWorldSuffix(suffix))
-			return false;
-		if (!normalized.startsWith(QLatin1Char('.')))
-			return false;
-		return !normalized.contains(QLatin1Char('/'));
-	}
-
-	QHash<QString, QString> parseLegacyIniRawValues(const QString &iniPath)
-	{
-		QHash<QString, QString> values;
-		QFile                   file(iniPath);
-		if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-			return values;
-
-		QString           currentSection;
-		const QString     content = QString::fromUtf8(file.readAll());
-		const QStringList lines =
-		    content.split(QRegularExpression(QStringLiteral("[\r\n]+")), Qt::KeepEmptyParts);
-		for (QString line : lines)
-		{
-			line = line.trimmed();
-			if (line.isEmpty())
-				continue;
-			if (line.startsWith(QLatin1Char(';')) || line.startsWith(QLatin1Char('#')))
-				continue;
-
-			if (line.startsWith(QLatin1Char('[')) && line.endsWith(QLatin1Char(']')) && line.size() >= 2)
-			{
-				currentSection = line.mid(1, line.size() - 2).trimmed();
-				continue;
-			}
-
-			const qsizetype equalsPos = line.indexOf(QLatin1Char('='));
-			if (equalsPos < 0)
-				continue;
-
-			const QString key   = line.left(equalsPos).trimmed();
-			const QString value = line.mid(equalsPos + 1);
-			if (key.isEmpty())
-				continue;
-
-			const QString fullKey = currentSection.isEmpty() ? key : currentSection + QLatin1Char('/') + key;
-			values.insert(fullKey, value);
-		}
-		return values;
-	}
-
-	QVariant migrateLegacyIniValueWithRawSource(const QString &baseDir, const QString &key,
-	                                            const QVariant                &value,
-	                                            const QHash<QString, QString> &rawValues)
-	{
-		if (const QString leaf = keyLeafName(key);
-		    (isPathListKey(leaf) || shouldNormalizePathKey(leaf)) && rawValues.contains(key))
-			return migrateLegacyIniPathValue(baseDir, key, rawValues.value(key));
-		return migrateLegacyIniValue(baseDir, key, value);
+		return QMudMushclientImportUtils::isLikelyCorruptedRelativeWorldPath(path);
 	}
 
 	void pruneLegacyCtrlBarsGroups(QSettings &modern)
@@ -2622,33 +2234,7 @@ namespace
 
 	void migrateLegacyIniToQmudConf(const QString &workingDir)
 	{
-		const QString baseDir    = QDir::cleanPath(workingDir);
-		const QString legacyPath = QDir(baseDir).filePath(QStringLiteral("MUSHclient.ini"));
-		if (!QFileInfo::exists(legacyPath))
-			return;
-
-		const QString                 newPath = QDir(baseDir).filePath(QStringLiteral("QMud.conf"));
-		const QSettings               legacy(legacyPath, QSettings::IniFormat);
-		QSettings                     modern(newPath, QSettings::IniFormat);
-		const QHash<QString, QString> rawValues = parseLegacyIniRawValues(legacyPath);
-		for (const QStringList keys = legacy.allKeys(); const QString &key : keys)
-			modern.setValue(key,
-			                migrateLegacyIniValueWithRawSource(baseDir, key, legacy.value(key), rawValues));
-		pruneLegacyCtrlBarsGroups(modern);
-		modern.sync();
-
-		const QString migratedDir = QDir(baseDir).filePath(QStringLiteral("migrated"));
-		if (!QDir().mkpath(migratedDir))
-		{
-			qWarning() << "Failed to create migrated directory:" << migratedDir;
-			return;
-		}
-
-		const QString migratedPath = QDir(migratedDir).filePath(QStringLiteral("MUSHclient.ini"));
-		if (QFileInfo::exists(migratedPath))
-			QFile::remove(migratedPath);
-		if (!QFile::rename(legacyPath, migratedPath))
-			qWarning() << "Failed to archive legacy config file:" << legacyPath << "->" << migratedPath;
+		QMudMushclientImportUtils::migrateLegacyIniToQmudConf(workingDir, workingDir, true);
 	}
 } // namespace
 
@@ -8943,6 +8529,8 @@ void AppController::onCommandTriggered(const QString &cmdName)
 		ImportXmlDialog dlg(this, m_mainWindow);
 		dlg.exec();
 	}
+	else if (cmdName == QStringLiteral("ImportFromMushclient"))
+		handleImportFromMushclient();
 	else if (cmdName == QStringLiteral("ResetToolbars"))
 	{
 		if (m_mainWindow)
@@ -14341,9 +13929,208 @@ void AppController::handleLogSession() const
 	}
 }
 
-void AppController::handleReloadQmud()
+void AppController::handleImportFromMushclient()
+{
+	if (!m_mainWindow)
+		return;
+
+	const QString selectedDir = QFileDialog::getExistingDirectory(
+	    m_mainWindow, QStringLiteral("Import from MUSHclient"),
+	    m_fileBrowsingDir.trimmed().isEmpty() ? QString() : m_fileBrowsingDir);
+	if (selectedDir.trimmed().isEmpty())
+		return;
+
+	const QFileInfo selectedInfo(selectedDir);
+	if (!selectedInfo.isDir())
+	{
+		QMessageBox::warning(m_mainWindow, QStringLiteral("Import from MUSHclient"),
+		                     QStringLiteral("Select a valid MUSHclient directory."));
+		return;
+	}
+	m_fileBrowsingDir = selectedInfo.absoluteFilePath();
+
+	const QString mushclientRoot    = QDir::cleanPath(selectedInfo.absoluteFilePath());
+	const QString qmudHome          = QDir::cleanPath(m_workingDir);
+	const QString selectedCanonical = selectedInfo.canonicalFilePath();
+	const QString qmudCanonical     = QFileInfo(qmudHome).canonicalFilePath();
+	if (!selectedCanonical.isEmpty() && !qmudCanonical.isEmpty() &&
+	    selectedCanonical.compare(qmudCanonical,
+#ifdef Q_OS_WIN
+	                              Qt::CaseInsensitive
+#else
+	                              Qt::CaseSensitive
+#endif
+	                              ) == 0)
+	{
+		QMessageBox::warning(m_mainWindow, QStringLiteral("Import from MUSHclient"),
+		                     QStringLiteral("Select the MUSHclient directory, not the QMud data directory."));
+		return;
+	}
+
+	ImportProgressDialog progressDialog(m_mainWindow);
+	progressDialog.setWindowTitle(QStringLiteral("Import from MUSHclient"));
+	progressDialog.setWindowModality(Qt::ApplicationModal);
+	progressDialog.setWindowFlag(Qt::WindowCloseButtonHint, false);
+	auto *layout = new QVBoxLayout(&progressDialog);
+	auto *label  = new QLabel(
+	    QStringLiteral("Please wait while MUSHclient data are being imported.\n"
+	                   "Do NOT close QMud until this process is finished.\n"
+	                   "If you do close it, you have to start with a fresh QMud installation and rerun "
+	                   "the \"Import from MUSHclient\" procedure."),
+	    &progressDialog);
+	label->setWordWrap(true);
+	layout->addWidget(label);
+	progressDialog.show();
+	QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+
+	QMudMushclientImportUtils::ImportStats stats =
+	    QMudMushclientImportUtils::importDirectory(mushclientRoot, qmudHome);
+	QMudMushclientImportUtils::importPreferencesDatabase(mushclientRoot, m_db, stats);
+	progressDialog.hide();
+	if (stats.errors > 0)
+	{
+		QString details = stats.errorDetails.join(QLatin1Char('\n'));
+		if (stats.errors > stats.errorDetails.size())
+		{
+			details +=
+			    QStringLiteral("\n...and %1 more error(s).").arg(stats.errors - stats.errorDetails.size());
+		}
+		if (stats.warnings > 0)
+		{
+			QString warningDetails = stats.warningDetails.join(QLatin1Char('\n'));
+			if (stats.warnings > stats.warningDetails.size())
+			{
+				warningDetails += QStringLiteral("\n...and %1 more warning(s).")
+				                      .arg(stats.warnings - stats.warningDetails.size());
+			}
+			details += QStringLiteral("\n\nWarning(s):\n%1").arg(warningDetails);
+		}
+		QMessageBox::warning(
+		    m_mainWindow, QStringLiteral("Import from MUSHclient"),
+		    QStringLiteral("Import encountered %1 error(s).\n\n%2").arg(stats.errors).arg(details));
+		return;
+	}
+
+	const QString summary =
+	    QStringLiteral("Files copied: %1\nWorlds converted: %2\nExisting files skipped: "
+	                   "%3\nFiltered files skipped: %4\nConfig files imported: %5\nPreference databases "
+	                   "imported: %6")
+	        .arg(stats.filesCopied)
+	        .arg(stats.worldsConverted)
+	        .arg(stats.filesSkippedExisting)
+	        .arg(stats.filesSkippedFiltered)
+	        .arg(stats.configsImported)
+	        .arg(stats.preferenceDatabasesImported);
+	if (stats.warnings > 0)
+	{
+		QString details = stats.warningDetails.join(QLatin1Char('\n'));
+		if (stats.warnings > stats.warningDetails.size())
+		{
+			details += QStringLiteral("\n...and %1 more warning(s).")
+			               .arg(stats.warnings - stats.warningDetails.size());
+		}
+		QMessageBox::warning(
+		    m_mainWindow, QStringLiteral("Import from MUSHclient"),
+		    QStringLiteral("Import completed with %1 warning(s).\n\n%2\n\n%3\n\nQMud will now reload or "
+		                   "restart to use the imported data.")
+		        .arg(stats.warnings)
+		        .arg(summary, details));
+	}
+	else
+	{
+		QMessageBox::information(
+		    m_mainWindow, QStringLiteral("Import from MUSHclient"),
+		    QStringLiteral(
+		        "Import completed.\n\n%1\n\nQMud will now reload or restart to use the imported data.")
+		        .arg(summary));
+	}
+
+	reloadOrRestartAfterImport();
+}
+
+bool AppController::prepareForApplicationRestart(const QString &title, const bool persistRuntimePreferences)
+{
+	if (persistRuntimePreferences)
+		saveViewPreferences();
+	saveWindowPlacement();
+	saveSessionState();
+
+	QString error;
+	if (!saveDirtyAutoSaveWorldsBeforeRestart(&error))
+	{
+		QMessageBox::warning(m_mainWindow, title,
+		                     QStringLiteral("Failed to save dirty worlds before restart.\n%1").arg(error));
+		return false;
+	}
+	if (!closeOpenWorldLogsBeforeRestart(&error))
+	{
+		QMessageBox::warning(
+		    m_mainWindow, title,
+		    QStringLiteral("Failed to close active world logs before restart.\n%1").arg(error));
+		return false;
+	}
+	if (!saveOpenWorldPluginStatesBeforeRestart(&error))
+	{
+		QMessageBox::warning(m_mainWindow, title,
+		                     QStringLiteral("Failed to save plugin state before restart.\n%1").arg(error));
+		return false;
+	}
+	if (!saveOpenWorldSessionStatesBeforeRestart(&error))
+	{
+		QMessageBox::warning(
+		    m_mainWindow, title,
+		    QStringLiteral("Failed to persist world session state before restart.\n%1").arg(error));
+		return false;
+	}
+	return true;
+}
+
+void AppController::reloadOrRestartAfterImport()
+{
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+	if (getGlobalOption(QStringLiteral("EnableReloadFeature")).toInt() != 0)
+	{
+		const QByteArray previousReloadAssume = qgetenv("QMUD_RELOAD_ASSUME_YES");
+		qputenv("QMUD_RELOAD_ASSUME_YES", QByteArrayLiteral("1"));
+		handleReloadQmud(false);
+		if (previousReloadAssume.isNull())
+			qunsetenv("QMUD_RELOAD_ASSUME_YES");
+		else
+			qputenv("QMUD_RELOAD_ASSUME_YES", previousReloadAssume);
+		if (m_reloadInProgress)
+			return;
+	}
+#endif
+
+	const QString title = QStringLiteral("Import from MUSHclient");
+	if (!prepareForApplicationRestart(title, false))
+		return;
+
+	const QString executablePath = QCoreApplication::applicationFilePath();
+	QStringList   arguments      = QCoreApplication::arguments();
+	if (!arguments.isEmpty())
+		arguments.removeFirst();
+
+	QProcess            process;
+	QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+	environment.insert(QStringLiteral("QMUD_ALLOW_MULTI_INSTANCE"), QStringLiteral("1"));
+	environment.insert(QStringLiteral("QMUD_HOME"), QDir::cleanPath(m_workingDir));
+	process.setProcessEnvironment(environment);
+	process.setProgram(executablePath);
+	process.setArguments(arguments);
+	if (!process.startDetached())
+	{
+		QMessageBox::warning(m_mainWindow, title,
+		                     QStringLiteral("Import completed, but QMud could not restart automatically."));
+		return;
+	}
+	QCoreApplication::quit();
+}
+
+void AppController::handleReloadQmud(const bool persistRuntimePreferences)
 {
 #if !defined(Q_OS_LINUX) && !defined(Q_OS_MACOS)
+	Q_UNUSED(persistRuntimePreferences);
 	QMessageBox::information(m_mainWindow, QStringLiteral("Reload QMud"),
 	                         QStringLiteral("Reload QMud is available only on Linux and macOS."));
 #else
@@ -14397,7 +14184,8 @@ void AppController::handleReloadQmud()
 	}
 
 	// Persist current frame visibility/layout before reload handoff.
-	saveViewPreferences();
+	if (persistRuntimePreferences)
+		saveViewPreferences();
 	saveWindowPlacement();
 	saveSessionState();
 

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -5565,7 +5565,7 @@ void AppController::handleUpdateCheckResponse(const bool manual, const QByteArra
 		return;
 	}
 
-	const QString currentVersion = versionCore(m_version);
+	const QString currentVersion = m_version;
 	const QString skipVersion =
 	    versionCore(getGlobalOption(QStringLiteral("SkipUpdateNotificationVersion")).toString());
 

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -14184,6 +14184,18 @@ void AppController::handleReloadQmud(const bool persistRuntimePreferences)
 			qInfo() << kReloadLogTag << "Auto-confirm enabled by QMUD_RELOAD_ASSUME_YES.";
 	}
 
+	++m_reloadAttempts;
+	m_reloadInProgress = true;
+	if (m_mainWindow)
+		m_mainWindow->showStatusMessage(QStringLiteral("Preparing Reload QMud..."), 0);
+
+	const auto abortReloadPreparation = [this]()
+	{
+		m_reloadInProgress = false;
+		if (m_mainWindow)
+			m_mainWindow->setStatusNormal();
+	};
+
 	// Persist current frame visibility/layout before reload handoff.
 	if (persistRuntimePreferences)
 		saveViewPreferences();
@@ -14193,6 +14205,7 @@ void AppController::handleReloadQmud(const bool persistRuntimePreferences)
 	QString preReloadSaveError;
 	if (!saveDirtyAutoSaveWorldsBeforeRestart(&preReloadSaveError))
 	{
+		abortReloadPreparation();
 		QMessageBox::warning(
 		    m_mainWindow, QStringLiteral("Reload QMud"),
 		    QStringLiteral("Failed to save dirty worlds before reload.\n%1").arg(preReloadSaveError));
@@ -14202,6 +14215,7 @@ void AppController::handleReloadQmud(const bool persistRuntimePreferences)
 	QString preReloadPluginStateError;
 	if (!closeOpenWorldLogsBeforeRestart(&preReloadLogCloseError))
 	{
+		abortReloadPreparation();
 		QMessageBox::warning(m_mainWindow, QStringLiteral("Reload QMud"),
 		                     QStringLiteral("Failed to close active world logs before reload.\n%1")
 		                         .arg(preReloadLogCloseError));
@@ -14209,6 +14223,7 @@ void AppController::handleReloadQmud(const bool persistRuntimePreferences)
 	}
 	if (!saveOpenWorldPluginStatesBeforeRestart(&preReloadPluginStateError))
 	{
+		abortReloadPreparation();
 		QMessageBox::warning(
 		    m_mainWindow, QStringLiteral("Reload QMud"),
 		    QStringLiteral("Failed to save plugin state before reload.\n%1").arg(preReloadPluginStateError));
@@ -14217,16 +14232,13 @@ void AppController::handleReloadQmud(const bool persistRuntimePreferences)
 	QString preReloadSessionStateError;
 	if (!saveOpenWorldSessionStatesBeforeRestart(&preReloadSessionStateError))
 	{
+		abortReloadPreparation();
 		QMessageBox::warning(m_mainWindow, QStringLiteral("Reload QMud"),
 		                     QStringLiteral("Failed to persist world session state before reload.\n%1")
 		                         .arg(preReloadSessionStateError));
 		return;
 	}
 
-	++m_reloadAttempts;
-	m_reloadInProgress = true;
-	if (m_mainWindow)
-		m_mainWindow->showStatusMessage(QStringLiteral("Preparing Reload QMud..."), 0);
 	qInfo() << kReloadLogTag << "Preparing reload handoff. attempt=" << m_reloadAttempts
 	        << "exec_failures=" << m_reloadExecFailures << "recoveries=" << m_reloadRecoveryRuns
 	        << "mccp_disable_timeout_ms=" << mccpDisableTimeoutMs;

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -2736,7 +2736,7 @@ QString AppController::worldSessionStateFilePath(const WorldRuntime *runtime) co
 	    .filePath(worldId + QString::fromLatin1(kWorldSessionStateSuffix));
 }
 
-void AppController::saveWorldSessionStateAsync(const WorldRuntime *runtime, const WorldView *view,
+void AppController::saveWorldSessionStateAsync(WorldRuntime *runtime, const WorldView *view,
                                                std::function<void(bool, const QString &)> completion) const
 {
 	const auto completionFn =
@@ -2768,10 +2768,13 @@ void AppController::saveWorldSessionStateAsync(const WorldRuntime *runtime, cons
 
 	QMudWorldSessionState::WorldSessionStateData state;
 	const TelnetProcessor::MxpSessionState       mxpState = runtime->mxpSessionState();
-	state.hasOutputBuffer                                 = persistOutputBuffer;
-	state.hasCommandHistory                               = persistCommandHistory;
-	state.hasCustomMxpElements                            = runtime->customElementCount() > 0;
-	state.hasMxpSessionState                              = mxpState.enabled;
+	QPointer<WorldRuntime>                       runtimeGuard(runtime);
+	if (persistOutputBuffer)
+		runtime->setSessionStateOutputBufferSealed(true);
+	state.hasOutputBuffer      = persistOutputBuffer;
+	state.hasCommandHistory    = persistCommandHistory;
+	state.hasCustomMxpElements = runtime->customElementCount() > 0;
+	state.hasMxpSessionState   = mxpState.enabled;
 	if (persistOutputBuffer)
 		state.outputLines = runtime->lines();
 	if (persistCommandHistory)
@@ -2782,7 +2785,7 @@ void AppController::saveWorldSessionStateAsync(const WorldRuntime *runtime, cons
 		state.mxpSessionState = mxpState;
 
 	QThreadPool::globalInstance()->start(
-	    [filePath, state = std::move(state), completionFn]
+	    [filePath, state = std::move(state), completionFn, runtimeGuard, persistOutputBuffer]
 	    {
 		    QString error;
 		    bool    ok = true;
@@ -2794,8 +2797,10 @@ void AppController::saveWorldSessionStateAsync(const WorldRuntime *runtime, cons
 
 		    QMetaObject::invokeMethod(
 		        qApp,
-		        [completionFn, ok, error]
+		        [completionFn, runtimeGuard, persistOutputBuffer, ok, error]
 		        {
+			        if (persistOutputBuffer && runtimeGuard)
+				        runtimeGuard->setSessionStateOutputBufferSealed(false);
 			        if (completionFn && *completionFn)
 				        (*completionFn)(ok, error);
 		        },
@@ -8960,10 +8965,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 
 		WorldPreferencesDialog dlg(runtime, view, m_mainWindow);
 		dlg.setInitialPage(page);
-		if (dlg.exec() == QDialog::Accepted)
-		{
-			saveWorldSessionStateAsync(runtime, view, [](const bool, const QString &) {});
-		}
+		dlg.exec();
 		m_mainWindow->updateStatusBar();
 		m_mainWindow->refreshActionState();
 	}
@@ -10751,7 +10753,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 
 		if (view->hasOutputSelection())
 		{
-			const QVector<WorldRuntime::LineEntry> &lines = runtime->lines();
+			const auto &lines = runtime->lines();
 			if (const int lineIndex = view->outputSelectionStartLine() - 1;
 			    lineIndex >= 0 && lineIndex < lines.size())
 			{
@@ -10879,8 +10881,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 			return;
 		constexpr int kBookmarkFlag = 0x08;
 		bool          isBookmarked  = false;
-		if (const QVector<WorldRuntime::LineEntry> &lines = runtime->lines();
-		    line >= 1 && line <= lines.size())
+		if (const auto &lines = runtime->lines(); line >= 1 && line <= lines.size())
 			isBookmarked = lines.at(line - 1).flags & kBookmarkFlag;
 		runtime->bookmarkLine(line, !isBookmarked);
 		view->selectOutputLine(line - 1);
@@ -13090,7 +13091,7 @@ void AppController::onCommandTriggered(const QString &cmdName)
 			}
 		};
 
-		auto printRuntimeLines = [&](const QVector<WorldRuntime::LineEntry> &lines)
+		auto printRuntimeLines = [&](const auto &lines)
 		{
 			if (lines.isEmpty())
 				return;
@@ -13831,8 +13832,8 @@ void AppController::handleLogSession() const
 
 	if (lines > 0)
 	{
-		const QVector<WorldRuntime::LineEntry> &buffer = runtime->lines();
-		const int start = buffer.size() > lines ? static_cast<int>(buffer.size()) - lines : 0;
+		const auto &buffer = runtime->lines();
+		const int   start  = buffer.size() > lines ? static_cast<int>(buffer.size()) - lines : 0;
 		for (int i = start; i < buffer.size(); ++i)
 		{
 			const WorldRuntime::LineEntry &entry = buffer.at(i);

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -970,7 +970,7 @@ class AppController : public QObject
 		 * @param view World view.
 		 * @param completion Completion callback executed on the GUI thread.
 		 */
-		void saveWorldSessionStateAsync(const WorldRuntime *runtime, const WorldView *view,
+		void saveWorldSessionStateAsync(WorldRuntime *runtime, const WorldView *view,
 		                                std::function<void(bool, const QString &)> completion) const;
 		/**
 		 * @brief Loads one world's session state on a worker thread and applies it.

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -891,21 +891,37 @@ class AppController : public QObject
 		void                  handleLogSession() const;
 		/**
 		 * @brief Handles reload-QMud action with socket handoff/reconnect policies.
+		 * @param persistRuntimePreferences Persist current QMud DB-backed runtime preferences.
 		 */
-		void                  handleReloadQmud();
+		void                  handleReloadQmud(bool persistRuntimePreferences = true);
+		/**
+		 * @brief Handles explicit MUSHclient directory import.
+		 */
+		void                  handleImportFromMushclient();
+		/**
+		 * @brief Saves runtime state before a process restart.
+		 * @param title Dialog title used for errors.
+		 * @param persistRuntimePreferences Persist current QMud DB-backed runtime preferences.
+		 * @return `true` when state was prepared.
+		 */
+		[[nodiscard]] bool prepareForApplicationRestart(const QString &title, bool persistRuntimePreferences);
+		/**
+		 * @brief Reloads or restarts QMud after an import operation.
+		 */
+		void               reloadOrRestartAfterImport();
 		/**
 		 * @brief Handles output-find command variants.
 		 * @param again Repeat previous find operation.
 		 * @param forceDirection Force search direction when `true`.
 		 * @param forwards Search forward when `true`, backward otherwise.
 		 */
-		void                  handleOutputFind(bool again, bool forceDirection, bool forwards) const;
+		void               handleOutputFind(bool again, bool forceDirection, bool forwards) const;
 		/**
 		 * @brief Activates notepad by title.
 		 * @param title Notepad title.
 		 * @return `true` when a matching notepad is activated.
 		 */
-		[[nodiscard]] bool    activateNotepad(const QString &title) const;
+		[[nodiscard]] bool activateNotepad(const QString &title) const;
 		/**
 		 * @brief Appends/replaces notepad content.
 		 * @param title Notepad title.
@@ -913,30 +929,30 @@ class AppController : public QObject
 		 * @param replace Replace existing content when `true`; append otherwise.
 		 * @return `true` when destination notepad is found or created successfully.
 		 */
-		[[nodiscard]] bool    appendToNotepad(const QString &title, const QString &text, bool replace) const;
+		[[nodiscard]] bool appendToNotepad(const QString &title, const QString &text, bool replace) const;
 		/**
 		 * @brief Sends text to notepad, replacing existing content.
 		 * @param title Notepad title.
 		 * @param text Text payload.
 		 * @return `true` when destination notepad is found or created successfully.
 		 */
-		[[nodiscard]] bool    sendToNotepad(const QString &title, const QString &text) const;
+		[[nodiscard]] bool sendToNotepad(const QString &title, const QString &text) const;
 		/**
 		 * @brief Applies app-level initialization to a new world runtime.
 		 * @param runtime Runtime to initialize.
 		 */
-		void                  initializeWorldRuntime(WorldRuntime *runtime) const;
+		void               initializeWorldRuntime(WorldRuntime *runtime) const;
 		/**
 		 * @brief Emits startup banner lines to runtime output.
 		 * @param runtime Runtime that receives startup banner output.
 		 */
-		static void           emitStartupBanner(WorldRuntime *runtime);
+		static void        emitStartupBanner(WorldRuntime *runtime);
 		/**
 		 * @brief Opens and initializes one world document.
 		 * @param path World-document path.
 		 * @return `true` when world document opens successfully.
 		 */
-		bool                  openWorldDocument(const QString &path);
+		bool               openWorldDocument(const QString &path);
 		/**
 		 * @brief Resolves world session-state directory under the data directory.
 		 * @return Absolute world session-state directory path.

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -669,6 +669,8 @@ void MainWindow::buildMenus()
 	addActionToMenu(helpMenu, QStringLiteral("TipOfTheDay"), QStringLiteral("&Tip Of The Day..."));
 	helpMenu->addSeparator();
 	addActionToMenu(helpMenu, QStringLiteral("GettingStarted"), QStringLiteral("&Getting Started..."));
+	addActionToMenu(helpMenu, QStringLiteral("ImportFromMushclient"),
+	                QStringLiteral("Import from &MUSHclient..."));
 	helpMenu->addSeparator();
 	addActionToMenu(helpMenu, QStringLiteral("HelpContents"), QStringLiteral("&Contents"));
 	addActionToMenu(helpMenu, QStringLiteral("HelpIndex"), QStringLiteral("&Index"));

--- a/src/NativePluginRegistry.cpp
+++ b/src/NativePluginRegistry.cpp
@@ -1869,6 +1869,7 @@ namespace QMudNativePluginRegistry
 			bool             enabled;
 			if (state.mushReaderPluginEnabled)
 			{
+				state.passiveSpeechEnabled    = false;
 				state.mushReaderSpeechEnabled = !state.mushReaderSpeechEnabled;
 				enabled                       = state.mushReaderSpeechEnabled;
 			}
@@ -2053,9 +2054,14 @@ namespace QMudNativePluginRegistry
 	{
 		if (!runtime)
 			return;
-		MushReaderState &state        = stateFor(runtime);
+		MushReaderState &state       = stateFor(runtime);
+		const bool stopPassiveSpeech = enable && !state.mushReaderPluginEnabled && state.passiveSpeechEnabled;
 		state.mushReaderPluginEnabled = enable;
 		state.mushReaderSpeechEnabled = enable;
+		if (enable)
+			state.passiveSpeechEnabled = false;
+		if (stopPassiveSpeech)
+			stopSpeech(runtime);
 		if (!enable)
 			stopSpeech(runtime);
 	}
@@ -2074,7 +2080,7 @@ namespace QMudNativePluginRegistry
 		if (!runtime)
 			return;
 		MushReaderState &state     = stateFor(runtime);
-		state.passiveSpeechEnabled = enable;
+		state.passiveSpeechEnabled = enable && !state.mushReaderPluginEnabled;
 		if (!enable)
 			stopSpeech(runtime);
 	}

--- a/src/NativePluginRegistry.cpp
+++ b/src/NativePluginRegistry.cpp
@@ -405,8 +405,6 @@ namespace
 			bool stop() override
 			{
 				if (!m_tts)
-					m_tts = QMudTtsEngine::TtsEngine::create();
-				if (!m_tts)
 					return false;
 				m_tts->enqueueUtterance(QString(), true);
 				return true;
@@ -434,9 +432,9 @@ namespace
 		return mutex;
 	}
 
-	std::unordered_map<const WorldRuntime *, std::unique_ptr<MushReaderState>> &states()
+	std::unordered_map<const WorldRuntime *, std::shared_ptr<MushReaderState>> &states()
 	{
-		static std::unordered_map<const WorldRuntime *, std::unique_ptr<MushReaderState>> runtimeStates;
+		static std::unordered_map<const WorldRuntime *, std::shared_ptr<MushReaderState>> runtimeStates;
 		return runtimeStates;
 	}
 
@@ -468,13 +466,20 @@ namespace
 	}
 #endif
 
-	MushReaderState &stateFor(const WorldRuntime *runtime)
+	std::shared_ptr<MushReaderState> stateFor(const WorldRuntime *runtime)
 	{
 		QMutexLocker locker(&stateMutex());
 		auto        &slot = states()[runtime];
 		if (!slot)
-			slot = std::make_unique<MushReaderState>();
-		return *slot;
+			slot = std::make_shared<MushReaderState>();
+		return slot;
+	}
+
+	std::shared_ptr<const MushReaderState> existingStateFor(const WorldRuntime *runtime)
+	{
+		QMutexLocker locker(&stateMutex());
+		const auto   it = states().find(runtime);
+		return it == states().end() ? std::shared_ptr<const MushReaderState>() : it->second;
 	}
 
 	QString substitutionsFilePath(const WorldRuntime *runtime)
@@ -542,9 +547,9 @@ namespace
 		if (dispatchTestSpeechEvent(makeTestSpeechEvent(text, interrupt, false)))
 			return true;
 #endif
-		MushReaderState &state = stateFor(runtime);
-		ensureBackends(state);
-		for (const auto &backend : state.backends)
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		ensureBackends(*state);
+		for (const auto &backend : state->backends)
 		{
 			if (backend && backend->speak(text, interrupt))
 				return true;
@@ -560,10 +565,11 @@ namespace
 		if (dispatchTestSpeechEvent(makeTestSpeechEvent(QString(), true, true)))
 			return true;
 #endif
-		MushReaderState &state = stateFor(runtime);
-		ensureBackends(state);
+		const std::shared_ptr<const MushReaderState> state = existingStateFor(runtime);
+		if (!state)
+			return false;
 		bool stopped = false;
-		for (const auto &backend : state.backends)
+		for (const auto &backend : state->backends)
 		{
 			if (backend)
 				stopped = backend->stop() || stopped;
@@ -609,8 +615,8 @@ namespace
 
 	void handleSubstitutionCommand(WorldRuntime *runtime, const QString &argument)
 	{
-		MushReaderState &state = stateFor(runtime);
-		loadSubstitutions(runtime, state);
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		loadSubstitutions(runtime, *state);
 
 		const QString trimmed = argument.trimmed();
 		const QString lower   = trimmed.toLower();
@@ -622,39 +628,39 @@ namespace
 		}
 		if (lower == QStringLiteral("on"))
 		{
-			state.substitutionsEnabled = true;
-			saveSubstitutions(runtime, state);
+			state->substitutionsEnabled = true;
+			saveSubstitutions(runtime, *state);
 			outputLine(*runtime, QStringLiteral("Substitutions on."));
 			return;
 		}
 		if (lower == QStringLiteral("off"))
 		{
-			state.substitutionsEnabled = false;
-			saveSubstitutions(runtime, state);
+			state->substitutionsEnabled = false;
+			saveSubstitutions(runtime, *state);
 			outputLine(*runtime, QStringLiteral("Substitutions off."));
 			return;
 		}
 		if (lower == QStringLiteral("list"))
 		{
-			if (state.substitutions.isEmpty())
+			if (state->substitutions.isEmpty())
 			{
 				outputLine(*runtime, QStringLiteral("No substitutions."));
 				return;
 			}
-			for (auto it = state.substitutions.constBegin(); it != state.substitutions.constEnd(); ++it)
+			for (auto it = state->substitutions.constBegin(); it != state->substitutions.constEnd(); ++it)
 				outputLine(*runtime, QStringLiteral("%1 == %2").arg(it.key(), it.value()));
 			return;
 		}
 		if (lower == QStringLiteral("clear"))
 		{
-			state.substitutions.clear();
-			saveSubstitutions(runtime, state);
+			state->substitutions.clear();
+			saveSubstitutions(runtime, *state);
 			outputLine(*runtime, QStringLiteral("Substitutions cleared."));
 			return;
 		}
 		if (lower == QStringLiteral("save"))
 		{
-			outputLine(*runtime, saveSubstitutions(runtime, state)
+			outputLine(*runtime, saveSubstitutions(runtime, *state)
 			                         ? QStringLiteral("Substitutions saved.")
 			                         : QStringLiteral("Unable to save substitutions."));
 			return;
@@ -662,8 +668,8 @@ namespace
 		if (lower.startsWith(QStringLiteral("remove ")))
 		{
 			const QString key = trimmed.mid(7).trimmed();
-			state.substitutions.remove(key);
-			saveSubstitutions(runtime, state);
+			state->substitutions.remove(key);
+			saveSubstitutions(runtime, *state);
 			outputLine(*runtime, QStringLiteral("Substitution removed."));
 			return;
 		}
@@ -683,8 +689,8 @@ namespace
 				outputLine(*runtime, QStringLiteral("Substitution text cannot be empty."));
 				return;
 			}
-			state.substitutions.insert(key, value);
-			saveSubstitutions(runtime, state);
+			state->substitutions.insert(key, value);
+			saveSubstitutions(runtime, *state);
 			outputLine(*runtime, QStringLiteral("Substitution added."));
 			return;
 		}
@@ -693,16 +699,16 @@ namespace
 
 	QString substitutionAppliedText(const WorldRuntime *runtime, const QString &text, bool &skip)
 	{
-		skip                   = false;
-		MushReaderState &state = stateFor(runtime);
-		loadSubstitutions(runtime, state);
-		if (!state.substitutionsEnabled)
+		skip                                         = false;
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		loadSubstitutions(runtime, *state);
+		if (!state->substitutionsEnabled)
 		{
 			skip = true;
 			return {};
 		}
-		const auto it = state.substitutions.constFind(text);
-		if (it == state.substitutions.constEnd())
+		const auto it = state->substitutions.constFind(text);
+		if (it == state->substitutions.constEnd())
 			return text;
 		if (it.value() == QStringLiteral("!skip"))
 		{
@@ -1865,18 +1871,18 @@ namespace QMudNativePluginRegistry
 		}
 		if (lower == QStringLiteral("tts"))
 		{
-			MushReaderState &state = stateFor(runtime);
-			bool             enabled;
-			if (state.mushReaderPluginEnabled)
+			const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+			bool                                   enabled;
+			if (state->mushReaderPluginEnabled)
 			{
-				state.passiveSpeechEnabled    = false;
-				state.mushReaderSpeechEnabled = !state.mushReaderSpeechEnabled;
-				enabled                       = state.mushReaderSpeechEnabled;
+				state->passiveSpeechEnabled    = false;
+				state->mushReaderSpeechEnabled = !state->mushReaderSpeechEnabled;
+				enabled                        = state->mushReaderSpeechEnabled;
 			}
 			else
 			{
-				state.passiveSpeechEnabled = !state.passiveSpeechEnabled;
-				enabled                    = state.passiveSpeechEnabled;
+				state->passiveSpeechEnabled = !state->passiveSpeechEnabled;
+				enabled                     = state->passiveSpeechEnabled;
 			}
 			runtime->notifyNativePluginStateChanged();
 			stopSpeech(runtime);
@@ -2032,8 +2038,8 @@ namespace QMudNativePluginRegistry
 	{
 		if (!runtime || (type != 0 && type != 1) || text.trimmed().isEmpty())
 			return;
-		MushReaderState &state = stateFor(runtime);
-		if (!effectiveMushReaderSpeechEnabled(state))
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		if (!effectiveMushReaderSpeechEnabled(*state))
 			return;
 		bool    skip = false;
 		QString line = substitutionAppliedText(runtime, text, skip);
@@ -2045,8 +2051,8 @@ namespace QMudNativePluginRegistry
 	{
 		if (!runtime || text.trimmed().isEmpty())
 			return;
-		MushReaderState &state = stateFor(runtime);
-		if (effectiveMushReaderSpeechEnabled(state))
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		if (effectiveMushReaderSpeechEnabled(*state))
 			speak(runtime, text, false);
 	}
 
@@ -2054,12 +2060,13 @@ namespace QMudNativePluginRegistry
 	{
 		if (!runtime)
 			return;
-		MushReaderState &state       = stateFor(runtime);
-		const bool stopPassiveSpeech = enable && !state.mushReaderPluginEnabled && state.passiveSpeechEnabled;
-		state.mushReaderPluginEnabled = enable;
-		state.mushReaderSpeechEnabled = enable;
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		const bool                             stopPassiveSpeech =
+		    enable && !state->mushReaderPluginEnabled && state->passiveSpeechEnabled;
+		state->mushReaderPluginEnabled = enable;
+		state->mushReaderSpeechEnabled = enable;
 		if (enable)
-			state.passiveSpeechEnabled = false;
+			state->passiveSpeechEnabled = false;
 		if (stopPassiveSpeech)
 			stopSpeech(runtime);
 		if (!enable)
@@ -2079,8 +2086,8 @@ namespace QMudNativePluginRegistry
 	{
 		if (!runtime)
 			return;
-		MushReaderState &state     = stateFor(runtime);
-		state.passiveSpeechEnabled = enable && !state.mushReaderPluginEnabled;
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		state->passiveSpeechEnabled                  = enable && !state->mushReaderPluginEnabled;
 		if (!enable)
 			stopSpeech(runtime);
 	}
@@ -2098,18 +2105,32 @@ namespace QMudNativePluginRegistry
 	{
 		if (!runtime)
 			return;
-		MushReaderState &state = stateFor(runtime);
-		installMushReaderAccelerator(runtime, state);
+		const std::shared_ptr<MushReaderState> state = stateFor(runtime);
+		installMushReaderAccelerator(runtime, *state);
 	}
 
 	void discardRuntimeState(const WorldRuntime *runtime)
 	{
-		QMutexLocker locker(&stateMutex());
-		states().erase(runtime);
-		luaAudioNativeStates().erase(runtime);
+		std::shared_ptr<MushReaderState> removedMushReaderState;
+		{
+			QMutexLocker locker(&stateMutex());
+			if (const auto it = states().find(runtime); it != states().end())
+			{
+				removedMushReaderState = std::move(it->second);
+				states().erase(it);
+			}
+			luaAudioNativeStates().erase(runtime);
+		}
+		removedMushReaderState.reset();
 	}
 
 #ifdef QMUD_NATIVEPLUGINREGISTRY_TEST_HOOKS
+	std::size_t mushReaderTestBackendCount(const WorldRuntime *runtime)
+	{
+		const std::shared_ptr<const MushReaderState> state = existingStateFor(runtime);
+		return state ? state->backends.size() : 0U;
+	}
+
 	void setTestSpeechSink(std::function<void(const TestSpeechEvent &)> sink)
 	{
 		QMutexLocker locker(&stateMutex());

--- a/src/NativePluginRegistry.cpp
+++ b/src/NativePluginRegistry.cpp
@@ -2137,5 +2137,20 @@ namespace QMudNativePluginRegistry
 		testSpeechSink() = std::move(sink);
 	}
 #endif
+#else
+	bool isShimId(const QString &pluginId)
+	{
+		return shimIds().contains(normalizedId(pluginId));
+	}
+
+	bool isBlacklistedId(const QString &pluginId)
+	{
+		return blacklistedIds().contains(normalizedId(pluginId));
+	}
+
+	bool isProtectedId(const QString &pluginId)
+	{
+		return isShimId(pluginId) || isBlacklistedId(pluginId);
+	}
 #endif
 } // namespace QMudNativePluginRegistry

--- a/src/NativePluginRegistry.h
+++ b/src/NativePluginRegistry.h
@@ -17,6 +17,7 @@
 #include <QVariant>
 #include <QVector>
 #include <atomic>
+#include <cstddef>
 #include <functional>
 #include <memory>
 
@@ -416,7 +417,13 @@ namespace QMudNativePluginRegistry
 	 * @brief Installs a test-only speech sink that bypasses platform reader backends.
 	 * @param sink Event receiver; empty sink restores normal backend routing.
 	 */
-	void setTestSpeechSink(std::function<void(const TestSpeechEvent &)> sink);
+	void                      setTestSpeechSink(std::function<void(const TestSpeechEvent &)> sink);
+	/**
+	 * @brief Returns the number of initialized MushReader speech backends for tests.
+	 * @param runtime Runtime to inspect.
+	 * @return Initialized backend count, or zero when no speech state exists.
+	 */
+	[[nodiscard]] std::size_t mushReaderTestBackendCount(const WorldRuntime *runtime);
 #endif
 } // namespace QMudNativePluginRegistry
 

--- a/src/TtsEngine.cpp
+++ b/src/TtsEngine.cpp
@@ -16,10 +16,14 @@
 #include <QAudioDevice>
 #include <QCryptographicHash>
 #include <QDataStream>
+#include <QDebug>
+#include <QEvent>
 #include <QEventLoop>
 #include <QMediaDevices>
+#include <QMutex>
 #include <QPointer>
 #include <QTimer>
+#include <QWaitCondition>
 #endif
 
 namespace
@@ -28,6 +32,69 @@ namespace
 	constexpr int kMaxPendingChars      = 512 * 1024;
 
 #if QMUD_ENABLE_TEXT_TO_SPEECH
+	constexpr int kSpeechShutdownWaitMs = 1500;
+
+	struct SpeechShutdownState
+	{
+			QMutex         mutex;
+			QWaitCondition wake;
+			bool           completed{false};
+	};
+
+	class SpeechObjectCleanup final : public QObject
+	{
+		public:
+			SpeechObjectCleanup(std::unique_ptr<QTextToSpeech>       speechObject,
+			                    std::shared_ptr<SpeechShutdownState> shutdownState,
+			                    QPointer<QThread> ownerThread, const bool stopOwnerThread)
+			    : m_speechObject(std::move(speechObject)), m_shutdownState(std::move(shutdownState)),
+			      m_ownerThread(std::move(ownerThread)), m_stopOwnerThread(stopOwnerThread)
+			{
+			}
+
+			~SpeechObjectCleanup() override
+			{
+				destroySpeechObject();
+			}
+
+			void complete()
+			{
+				destroySpeechObject();
+				{
+					QMutexLocker locker(&m_shutdownState->mutex);
+					m_shutdownState->completed = true;
+					m_shutdownState->wake.wakeAll();
+				}
+				deleteLater();
+				if (m_stopOwnerThread && m_ownerThread)
+					m_ownerThread->quit();
+			}
+
+		private:
+			void destroySpeechObject()
+			{
+				if (!m_speechObject)
+					return;
+				m_speechObject->stop();
+				m_speechObject.reset();
+			}
+
+			std::unique_ptr<QTextToSpeech>       m_speechObject;
+			std::shared_ptr<SpeechShutdownState> m_shutdownState;
+			QPointer<QThread>                    m_ownerThread;
+			bool                                 m_stopOwnerThread{false};
+	};
+
+	[[nodiscard]] SpeechObjectCleanup *
+	releaseCleanupContextToOwnerThread(std::unique_ptr<SpeechObjectCleanup> &cleanupContext,
+	                                   const SpeechObjectCleanup            *expectedContext)
+	{
+		SpeechObjectCleanup *releasedContext = cleanupContext.release();
+		Q_ASSERT(releasedContext == expectedContext);
+		Q_UNUSED(expectedContext);
+		return releasedContext;
+	}
+
 	QString buildVoiceIdBase(const QVoice &voice)
 	{
 		const QString locale = voice.locale().name().trimmed();
@@ -113,6 +180,9 @@ namespace QMudTtsEngine
 		runtime->initializeAudioOutputs();
 
 #if QMUD_ENABLE_TEXT_TO_SPEECH
+		if (!QCoreApplication::instance())
+			return runtime;
+
 		const QStringList engines = QTextToSpeech::availableEngines();
 		if (engines.isEmpty())
 			return runtime;
@@ -146,12 +216,18 @@ namespace QMudTtsEngine
 	TtsEngine::~TtsEngine()
 	{
 #if QMUD_ENABLE_TEXT_TO_SPEECH
-		destroySpeechObject();
+		const bool speechDestroyed = destroySpeechObject(true);
 		if (speechThread && speechThread->isRunning())
 		{
-			speechThread->quit();
-			if (QThread::currentThread() != speechThread.get())
-				speechThread->wait();
+			if (speechDestroyed)
+				speechThread->quit();
+			if (QThread::currentThread() == speechThread.get())
+			{
+				releaseSpeechThreadAfterFailedShutdown("destructor is running on TTS worker thread");
+				return;
+			}
+			if (!speechThread->wait(kSpeechShutdownWaitMs))
+				releaseSpeechThreadAfterFailedShutdown("TTS worker did not stop during teardown");
 		}
 #endif
 	}
@@ -183,12 +259,15 @@ namespace QMudTtsEngine
 		if (!speech)
 			return;
 		QObject *callbackContext = callbackDispatcher ? callbackDispatcher.get() : speech.get();
-		const std::weak_ptr<TtsEngine> weakRuntime = shared_from_this();
+		const QPointer<QTextToSpeech>  speechSource = speech.get();
+		const std::weak_ptr<TtsEngine> weakRuntime  = shared_from_this();
 		QObject::connect(speech.get(), &QTextToSpeech::stateChanged, callbackContext,
-		                 [weakRuntime](const QTextToSpeech::State state)
+		                 [weakRuntime, speechSource](const QTextToSpeech::State state)
 		                 {
 			                 const auto runtime = weakRuntime.lock();
 			                 if (!runtime)
+				                 return;
+			                 if (!speechSource || runtime->speech.get() != speechSource)
 				                 return;
 			                 if (state == QTextToSpeech::Speaking || state == QTextToSpeech::Synthesizing)
 			                 {
@@ -217,22 +296,122 @@ namespace QMudTtsEngine
 		                 });
 	}
 
-	void TtsEngine::destroySpeechObject()
+	bool TtsEngine::destroySpeechObject(const bool stopOwnerThread)
 	{
 		if (!speech)
-			return;
-		QTextToSpeech *speechObject = speech.release();
+			return true;
+		std::unique_ptr<QTextToSpeech> speechObject = std::move(speech);
 		if (!speechObject)
-			return;
+			return true;
+		QObject::disconnect(speechObject.get(), nullptr, nullptr, nullptr);
+		QCoreApplication::removePostedEvents(speechObject.get(), QEvent::MetaCall);
 		if (speechObject->thread() == QThread::currentThread())
 		{
-			delete speechObject;
+			speechObject->stop();
+			speechObject.reset();
+			return true;
+		}
+		QPointer<QThread> ownerThread = speechObject->thread();
+		if (!ownerThread || !ownerThread->isRunning())
+		{
+			speechObject->stop();
+			speechObject.reset();
+			if (stopOwnerThread && ownerThread)
+				ownerThread->quit();
+			return true;
+		}
+
+		const auto shutdownState = std::make_shared<SpeechShutdownState>();
+		auto  cleanupContext = std::make_unique<SpeechObjectCleanup>(std::move(speechObject), shutdownState,
+		                                                             ownerThread, stopOwnerThread);
+		auto *cleanupContextPtr = cleanupContext.get();
+		cleanupContext->moveToThread(ownerThread);
+		QObject::connect(ownerThread, &QThread::finished, cleanupContextPtr, &QObject::deleteLater,
+		                 Qt::UniqueConnection);
+		[[maybe_unused]] SpeechObjectCleanup *releasedCleanupContext =
+		    releaseCleanupContextToOwnerThread(cleanupContext, cleanupContextPtr);
+		const bool invoked = QMetaObject::invokeMethod(
+		    cleanupContextPtr, [cleanupContextPtr] { cleanupContextPtr->complete(); }, Qt::QueuedConnection);
+		if (!invoked)
+		{
+			cleanupContextPtr->deleteLater();
+			if (stopOwnerThread && ownerThread)
+				ownerThread->quit();
+			return false;
+		}
+
+		bool completed = false;
+		{
+			QMutexLocker locker(&shutdownState->mutex);
+			if (!shutdownState->completed)
+				shutdownState->wake.wait(&shutdownState->mutex, kSpeechShutdownWaitMs);
+			completed = shutdownState->completed;
+		}
+		if (!completed && stopOwnerThread && ownerThread)
+			ownerThread->quit();
+		return completed;
+	}
+
+	bool TtsEngine::retireSpeechObject(std::unique_ptr<QTextToSpeech> &retiredSpeech)
+	{
+		if (!retiredSpeech)
+			return true;
+		QTextToSpeech *speechObject = retiredSpeech.get();
+		if (!speechObject)
+			return true;
+		if (speechObject->thread() == QThread::currentThread())
+		{
+			speechObject->stop();
+			retiredSpeech.reset();
+			return true;
+		}
+		const QPointer<QThread> ownerThread = speechObject->thread();
+		if (!ownerThread || !ownerThread->isRunning())
+		{
+			speechObject->stop();
+			retiredSpeech.reset();
+			return true;
+		}
+
+		if (!QMetaObject::invokeMethod(speechObject, [] {}, Qt::QueuedConnection))
+			return false;
+
+		QObject::disconnect(speechObject, nullptr, nullptr, nullptr);
+		QCoreApplication::removePostedEvents(speechObject, QEvent::MetaCall);
+
+		const bool cleanupQueued = QMetaObject::invokeMethod(
+		    speechObject,
+		    [speechObject]
+		    {
+			    speechObject->stop();
+			    speechObject->deleteLater();
+		    },
+		    Qt::QueuedConnection);
+		if (!cleanupQueued)
+			speechObject->deleteLater();
+
+		[[maybe_unused]] QTextToSpeech *releasedSpeech = retiredSpeech.release();
+		Q_ASSERT(releasedSpeech == speechObject);
+		return true;
+	}
+
+	void TtsEngine::releaseSpeechThreadAfterFailedShutdown(const char *context)
+	{
+		if (!speechThread)
+			return;
+		QThread *thread = speechThread.release();
+		if (!thread)
+			return;
+		if (!thread->isRunning())
+		{
+			delete thread;
 			return;
 		}
-		const bool invoked = QMetaObject::invokeMethod(
-		    speechObject, [speechObject]() { delete speechObject; }, Qt::BlockingQueuedConnection);
-		if (!invoked)
-			delete speechObject;
+		QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater, Qt::UniqueConnection);
+		thread->requestInterruption();
+		thread->quit();
+		qWarning().noquote() << QStringLiteral("[QMud][TTS] Releasing TTS worker during shutdown: %1")
+		                            .arg(QString::fromLatin1(context ? context : "unknown reason"));
 	}
 
 	void TtsEngine::enqueueBoundedUtterance(QString utterance)
@@ -299,10 +478,14 @@ namespace QMudTtsEngine
 		if (!replacementSpeech || replacementSpeech->errorReason() != QTextToSpeech::ErrorReason::NoError)
 			return false;
 
+		std::unique_ptr<QTextToSpeech> retiredSpeech = std::move(speech);
+		if (!retireSpeechObject(retiredSpeech))
+		{
+			speech = std::move(retiredSpeech);
+			return false;
+		}
 		if (speechThread && speechThread->isRunning())
 			replacementSpeech->moveToThread(speechThread.get());
-
-		destroySpeechObject();
 		speech = std::move(replacementSpeech);
 		invokeSpeechBlocking(
 		    [this](QTextToSpeech &speechObject)
@@ -340,7 +523,7 @@ namespace QMudTtsEngine
 				continue;
 			const QString idSuffix = QString::fromLatin1(rawId.toHex());
 			const QString tokenId  = QStringLiteral("QMUD\\TTS\\Audio\\Device\\%1")
-			                            .arg(idSuffix.isEmpty() ? QStringLiteral("unknown") : idSuffix);
+			                             .arg(idSuffix.isEmpty() ? QStringLiteral("unknown") : idSuffix);
 			const QString description =
 			    device.description().trimmed().isEmpty() ? tokenId : device.description().trimmed();
 			audioOutputIds.push_back(tokenId);

--- a/src/TtsEngine.h
+++ b/src/TtsEngine.h
@@ -67,8 +67,8 @@ namespace QMudTtsEngine
 			 * @param platform Platform policy. `Auto` uses build target platform.
 			 * @return Preferred engine id or empty string when no suitable engine exists.
 			 */
-			static QString                    preferredEngineIdFor(const QStringList   &engines,
-			                                                       EnginePlatformPolicy platform = EnginePlatformPolicy::Auto);
+			static QString preferredEngineIdFor(const QStringList   &engines,
+			                                    EnginePlatformPolicy platform = EnginePlatformPolicy::Auto);
 
 			/**
 			 * @brief Tears down the speech object and worker thread.
@@ -246,8 +246,8 @@ namespace QMudTtsEngine
 			TtsEngine() = default;
 
 			[[nodiscard]] virtual bool supportsSynthesizeCapability() const;
-			virtual bool               queueSynthesizeUtterance(QString                                utterance,
-			                                                    const std::function<void(QByteArray)> &onChunk);
+			virtual bool queueSynthesizeUtterance(QString                                utterance,
+			                                      const std::function<void(QByteArray)> &onChunk);
 
 #if QMUD_ENABLE_TEXT_TO_SPEECH
 			std::unique_ptr<QTextToSpeech> speech;
@@ -335,11 +335,13 @@ namespace QMudTtsEngine
 			virtual bool rebindSpeechForAudioOutput(int outputIndex);
 
 		private:
-			void initializeAudioOutputs();
-			void wireSpeechStateCallbacks();
-			void destroySpeechObject();
-			void resolveStopTransitionIfTerminal();
-			void enqueueBoundedUtterance(QString utterance);
+			void        initializeAudioOutputs();
+			void        wireSpeechStateCallbacks();
+			bool        destroySpeechObject(bool stopOwnerThread);
+			static bool retireSpeechObject(std::unique_ptr<QTextToSpeech> &retiredSpeech);
+			void        releaseSpeechThreadAfterFailedShutdown(const char *context);
+			void        resolveStopTransitionIfTerminal();
+			void        enqueueBoundedUtterance(QString utterance);
 #else
 			void initializeAudioOutputs();
 #endif

--- a/src/WorldCommandProcessor.cpp
+++ b/src/WorldCommandProcessor.cpp
@@ -2845,7 +2845,7 @@ bool WorldCommandProcessor::processOneAliasSequence(const QString &currentLine, 
 		// the previous non-note line.
 		if (m_runtime)
 		{
-			if (const QVector<WorldRuntime::LineEntry> &lines = m_runtime->lines();
+			if (const auto &lines = m_runtime->lines();
 			    !lines.isEmpty() && (lines.last().flags & WorldRuntime::LineNote) == 0)
 			{
 				m_runtime->outputText(QString(), true, true);

--- a/src/WorldCommandProcessor.cpp
+++ b/src/WorldCommandProcessor.cpp
@@ -1200,6 +1200,27 @@ int WorldCommandProcessor::executeCommand(const QString &text)
 	return eOK;
 }
 
+int WorldCommandProcessor::executeUserMacroSendNow(const QString &text, const bool history)
+{
+	m_omitFromHistoryForEnteredCommand = false;
+	m_enteredCommandSendFailed         = false;
+
+	QString commandText = text;
+	if (m_translateBackslashSequences)
+		commandText = fixupEscapeSequences(commandText);
+
+	const int result = executeCommand(commandText);
+	if (result == eOK && history && !m_omitFromHistoryForEnteredCommand && !m_enteredCommandSendFailed &&
+	    m_view)
+	{
+		m_view->addToHistoryForced(text);
+	}
+
+	m_omitFromHistoryForEnteredCommand = false;
+	m_enteredCommandSendFailed         = false;
+	return result;
+}
+
 int WorldCommandProcessor::executeCommandWithTriggerPriority(const QString &text)
 {
 	++m_triggerCommandPriorityDepth;
@@ -2003,7 +2024,9 @@ bool WorldCommandProcessor::evaluateCommand(const QString &input)
 	};
 
 	// ----------------------------- AUTO SAY ------------------------------
-	bool          autoSay = !m_processingAutoSay && isEnabled(attrs.value(QStringLiteral("enable_auto_say")));
+	const bool userMacroSource = m_runtime && m_runtime->currentActionSource() == WorldRuntime::eUserMacro;
+	bool       autoSay =
+	    !userMacroSource && !m_processingAutoSay && isEnabled(attrs.value(QStringLiteral("enable_auto_say")));
 	const QString autoSayString     = attrs.value(QStringLiteral("auto_say_string"));
 	const QString overridePrefix    = attrs.value(QStringLiteral("auto_say_override_prefix"));
 	const bool    excludeNonAlpha   = isEnabled(attrs.value(QStringLiteral("autosay_exclude_non_alpha")));

--- a/src/WorldCommandProcessor.h
+++ b/src/WorldCommandProcessor.h
@@ -78,6 +78,17 @@ class WorldCommandProcessor : public QObject
 		 */
 		int                executeCommand(const QString &text);
 		/**
+		 * @brief Executes one Send Now macro through alias/queue/send pipeline.
+		 *
+		 * The caller owns action-source setup; set the runtime source to
+		 * `WorldRuntime::eUserMacro` when macro source semantics are required.
+		 *
+		 * @param text Macro Send Now text.
+		 * @param history Add original macro text to history when `true`.
+		 * @return Execution status/result code.
+		 */
+		int                executeUserMacroSendNow(const QString &text, bool history);
+		/**
 		 * @brief Executes one direct trigger-script command with priority over queued movement.
 		 * @param text Command text.
 		 * @return Execution status/result code.

--- a/src/WorldOptionDefaultsNumeric.inc
+++ b/src/WorldOptionDefaultsNumeric.inc
@@ -49,7 +49,7 @@
     {"fade_output_buffer_after_seconds", 0, 0, 3600, OPT_UPDATE_VIEWS}, // seconds to wait before fading
     {"fade_output_opacity_percent", 20, 0, 100, OPT_UPDATE_VIEWS},      // percent to fade to
     {"fade_output_seconds", 8, 1, 60, OPT_UPDATE_VIEWS},                // how many seconds to take to fade
-    {"flash_taskbar_icon", false}, {"history_lines", 1000, 20, 5000},
+    {"flash_taskbar_icon", false}, {"history_lines", 1000, 20, 50000},
     {"hyperlink_adds_to_command_history", true}, {"persist_output_buffer", true},
     {"persist_command_history", true},
     {"hyperlink_colour", RGB(0, 128, 255), 0, 0xFFFFFF, OPT_RGB_COLOUR | OPT_UPDATE_VIEWS},

--- a/src/WorldOptionsDataNumeric.inc
+++ b/src/WorldOptionsDataNumeric.inc
@@ -51,7 +51,7 @@
     {"fade_output_buffer_after_seconds", 0, 0, 3600, OPT_UPDATE_VIEWS},
     {"fade_output_opacity_percent", 20, 0, 100, OPT_UPDATE_VIEWS},
     {"fade_output_seconds", 8, 1, 60, OPT_UPDATE_VIEWS}, {"flash_taskbar_icon", false, 0, 0, 0},
-    {"history_lines", 1000, 20, 5000, 0}, {"hyperlink_adds_to_command_history", true, 0, 0, 0},
+    {"history_lines", 1000, 20, 50000, 0}, {"hyperlink_adds_to_command_history", true, 0, 0, 0},
     {"persist_output_buffer", true, 0, 0, 0}, {"persist_command_history", true, 0, 0, 0},
     {"hyperlink_colour", RGB(0, 128, 255), 0, 0xFFFFFF, OPT_RGB_COLOUR | OPT_UPDATE_VIEWS},
     {"ignore_chat_colours", false, 0, 0, 0}, {"ignore_mxp_colour_changes", false, 0, 0, 0},

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -52,6 +52,7 @@
 #include "helpers/NoteColourUtils.h"
 #include "helpers/OutputWrapUtils.h"
 #include "helpers/PluginPathUtils.h"
+#include "helpers/SoundFileRoutingUtils.h"
 #include "scripting/ScriptingErrors.h"
 
 #include <QApplication>
@@ -98,6 +99,8 @@
 #include <QtSql/QSqlError>
 #include <QtSql/QSqlRecord>
 #if QMUD_ENABLE_SOUND
+#include <QAudioOutput>
+#include <QMediaPlayer>
 #include <QSoundEffect>
 #include <QTemporaryFile>
 #endif
@@ -4326,19 +4329,7 @@ WorldRuntime::~WorldRuntime()
 
 #if QMUD_ENABLE_SOUND
 	for (SoundBuffer &buffer : m_soundBuffers)
-	{
-		if (buffer.effect)
-		{
-			buffer.effect->stop();
-			delete buffer.effect;
-			buffer.effect = nullptr;
-		}
-		if (buffer.tempFile)
-		{
-			delete buffer.tempFile;
-			buffer.tempFile = nullptr;
-		}
-	}
+		clearSoundBuffer(buffer);
 #endif
 
 	for (int const fontId : std::as_const(m_specialFontIds))
@@ -10781,6 +10772,50 @@ static double normalizeSoundVolume(double volume)
 	return qBound(0.0, scaled, 1.0);
 }
 
+bool WorldRuntime::soundBufferHasBackend(const SoundBuffer &entry)
+{
+	return entry.effect || entry.player;
+}
+
+bool WorldRuntime::soundBufferIsPlaying(const SoundBuffer &entry)
+{
+	if (entry.effect)
+		return entry.effect->isPlaying();
+	if (entry.player)
+		return entry.player->playbackState() == QMediaPlayer::PlayingState;
+	return false;
+}
+
+void WorldRuntime::clearSoundBuffer(SoundBuffer &entry)
+{
+	if (entry.effect)
+	{
+		entry.effect->stop();
+		delete entry.effect;
+		entry.effect = nullptr;
+	}
+	if (entry.player)
+	{
+		entry.player->stop();
+		delete entry.player;
+		entry.player      = nullptr;
+		entry.audioOutput = nullptr;
+	}
+	if (entry.tempFile)
+	{
+		delete entry.tempFile;
+		entry.tempFile = nullptr;
+	}
+	entry.looping = false;
+	entry.volume  = 1.0;
+	entry.pan     = 0.0;
+}
+
+bool WorldRuntime::shouldUseMediaPlayerForSoundFile(const QString &fileName)
+{
+	return soundFilePlaybackBackendForFile(fileName) == SoundFilePlaybackBackend::QMediaPlayer;
+}
+
 int WorldRuntime::playSound(int buffer, const QString &fileName, bool loop, double volume, double pan)
 {
 	if (QThread::currentThread() != thread())
@@ -10817,15 +10852,22 @@ int WorldRuntime::playSoundBypassingPluginCallbacks(int buffer, const QString &f
 	if (buffer >= 1 && buffer <= kMaxSoundBuffers && fileName.isEmpty())
 	{
 		SoundBuffer &entry = m_soundBuffers[buffer - 1];
-		if (!entry.effect)
+		if (!soundBufferHasBackend(entry))
 			return eBadParameter;
-		if (!entry.effect->isPlaying())
+		if (!soundBufferIsPlaying(entry))
 			return eCannotPlaySound;
 		entry.looping = loop;
 		entry.volume  = normalizeSoundVolume(volume);
 		entry.pan     = pan;
-		entry.effect->setLoopCount(loop ? QSoundEffect::Infinite : 1);
-		entry.effect->setVolume(static_cast<float>(entry.volume));
+		if (entry.effect)
+		{
+			entry.effect->setLoopCount(loop ? QSoundEffect::Infinite : 1);
+			entry.effect->setVolume(static_cast<float>(entry.volume));
+		}
+		if (entry.player)
+			entry.player->setLoops(loop ? QMediaPlayer::Infinite : QMediaPlayer::Once);
+		if (entry.audioOutput)
+			entry.audioOutput->setVolume(static_cast<float>(entry.volume));
 		return eOK;
 	}
 
@@ -10837,7 +10879,7 @@ int WorldRuntime::playSoundBypassingPluginCallbacks(int buffer, const QString &f
 	{
 		for (int i = 0; i < (kMaxSoundBuffers / 2); ++i)
 		{
-			if (!m_soundBuffers[i].effect)
+			if (!soundBufferHasBackend(m_soundBuffers[i]))
 			{
 				targetBuffer = i + 1;
 				break;
@@ -10848,7 +10890,7 @@ int WorldRuntime::playSoundBypassingPluginCallbacks(int buffer, const QString &f
 	{
 		for (int i = 0; i < kMaxSoundBuffers; ++i)
 		{
-			if (!m_soundBuffers[i].effect || !m_soundBuffers[i].effect->isPlaying())
+			if (!soundBufferHasBackend(m_soundBuffers[i]) || !soundBufferIsPlaying(m_soundBuffers[i]))
 			{
 				targetBuffer = i + 1;
 				break;
@@ -10862,17 +10904,7 @@ int WorldRuntime::playSoundBypassingPluginCallbacks(int buffer, const QString &f
 		return eBadParameter;
 
 	SoundBuffer &entry = m_soundBuffers[targetBuffer - 1];
-	if (entry.effect)
-	{
-		entry.effect->stop();
-		delete entry.effect;
-		entry.effect = nullptr;
-	}
-	if (entry.tempFile)
-	{
-		delete entry.tempFile;
-		entry.tempFile = nullptr;
-	}
+	clearSoundBuffer(entry);
 
 	const QString relative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(fileName);
 	QString       resolved;
@@ -10903,26 +10935,104 @@ int WorldRuntime::playSoundBypassingPluginCallbacks(int buffer, const QString &f
 	    QMudNativePluginRegistry::luaAudioRuntimeBufferState(this, targetBuffer, luaAudioState)
 	        ? luaAudioState.generation
 	        : 0;
-	auto *effect = new QSoundEffect(this);
-	if (luaAudioGeneration != 0)
+	entry.looping = loop;
+	entry.volume  = normalizeSoundVolume(volume);
+	entry.pan     = pan;
+	if (shouldUseMediaPlayerForSoundFile(resolved))
 	{
-		connect(effect, &QSoundEffect::statusChanged, this,
-		        [this, effect, targetBuffer, luaAudioGeneration]
+		auto *player      = new QMediaPlayer(this);
+		auto *audioOutput = new QAudioOutput(player);
+		player->setAudioOutput(audioOutput);
+		player->setLoops(loop ? QMediaPlayer::Infinite : QMediaPlayer::Once);
+		audioOutput->setVolume(static_cast<float>(entry.volume));
+		connect(player, &QMediaPlayer::errorOccurred, this,
+		        [this, player, targetBuffer, luaAudioGeneration](QMediaPlayer::Error, const QString &)
 		        {
-			        if (effect->status() == QSoundEffect::Error)
+			        if (luaAudioGeneration != 0)
 				        QMudNativePluginRegistry::luaAudioReleaseRuntimeBufferIfGeneration(
 				            this, targetBuffer, luaAudioGeneration);
+			        if (targetBuffer < 1 || targetBuffer > kMaxSoundBuffers)
+				        return;
+
+			        SoundBuffer &current = m_soundBuffers[targetBuffer - 1];
+			        if (current.player != player)
+				        return;
+
+			        player->stop();
+			        player->setSource(QUrl());
+			        current.player      = nullptr;
+			        current.audioOutput = nullptr;
+			        if (current.tempFile)
+			        {
+				        delete current.tempFile;
+				        current.tempFile = nullptr;
+			        }
+			        current.looping = false;
+			        current.volume  = 1.0;
+			        current.pan     = 0.0;
+			        player->deleteLater();
 		        });
+		if (luaAudioGeneration != 0)
+		{
+			connect(player, &QMediaPlayer::playbackStateChanged, this,
+			        [this, loop, targetBuffer, luaAudioGeneration](const QMediaPlayer::PlaybackState state)
+			        {
+				        if (!loop && state == QMediaPlayer::StoppedState)
+					        QMudNativePluginRegistry::luaAudioReleaseRuntimeBufferIfGeneration(
+					            this, targetBuffer, luaAudioGeneration);
+			        });
+		}
+		player->setSource(QUrl::fromLocalFile(resolved));
+		if (player->error() != QMediaPlayer::NoError)
+		{
+			delete player;
+			entry.looping = false;
+			entry.volume  = 1.0;
+			entry.pan     = 0.0;
+			return eCannotPlaySound;
+		}
+		entry.player      = player;
+		entry.audioOutput = audioOutput;
+		player->play();
+		return eOK;
 	}
+
+	auto *effect = new QSoundEffect(this);
+	connect(effect, &QSoundEffect::statusChanged, this,
+	        [this, effect, targetBuffer, luaAudioGeneration]
+	        {
+		        if (effect->status() != QSoundEffect::Error)
+			        return;
+		        if (luaAudioGeneration != 0)
+			        QMudNativePluginRegistry::luaAudioReleaseRuntimeBufferIfGeneration(this, targetBuffer,
+			                                                                           luaAudioGeneration);
+		        if (targetBuffer < 1 || targetBuffer > kMaxSoundBuffers)
+			        return;
+
+		        SoundBuffer &current = m_soundBuffers[targetBuffer - 1];
+		        if (current.effect != effect)
+			        return;
+
+		        current.effect = nullptr;
+		        if (current.tempFile)
+		        {
+			        delete current.tempFile;
+			        current.tempFile = nullptr;
+		        }
+		        current.looping = false;
+		        current.volume  = 1.0;
+		        current.pan     = 0.0;
+		        effect->deleteLater();
+	        });
 	effect->setSource(QUrl::fromLocalFile(resolved));
 	if (effect->status() == QSoundEffect::Error)
 	{
 		delete effect;
+		entry.looping = false;
+		entry.volume  = 1.0;
+		entry.pan     = 0.0;
 		return eCannotPlaySound;
 	}
-	entry.looping = loop;
-	entry.volume  = normalizeSoundVolume(volume);
-	entry.pan     = pan;
 	effect->setLoopCount(loop ? QSoundEffect::Infinite : 1);
 	effect->setVolume(static_cast<float>(entry.volume));
 	if (luaAudioGeneration != 0)
@@ -10956,7 +11066,7 @@ int WorldRuntime::playSoundMemory(int buffer, const QByteArray &data, bool loop,
 	{
 		for (int i = 0; i < (kMaxSoundBuffers / 2); ++i)
 		{
-			if (!m_soundBuffers[i].effect)
+			if (!soundBufferHasBackend(m_soundBuffers[i]))
 			{
 				targetBuffer = i + 1;
 				break;
@@ -10967,7 +11077,7 @@ int WorldRuntime::playSoundMemory(int buffer, const QByteArray &data, bool loop,
 	{
 		for (int i = 0; i < kMaxSoundBuffers; ++i)
 		{
-			if (!m_soundBuffers[i].effect || !m_soundBuffers[i].effect->isPlaying())
+			if (!soundBufferHasBackend(m_soundBuffers[i]) || !soundBufferIsPlaying(m_soundBuffers[i]))
 			{
 				targetBuffer = i + 1;
 				break;
@@ -10981,17 +11091,7 @@ int WorldRuntime::playSoundMemory(int buffer, const QByteArray &data, bool loop,
 		return eBadParameter;
 
 	SoundBuffer &entry = m_soundBuffers[targetBuffer - 1];
-	if (entry.effect)
-	{
-		entry.effect->stop();
-		delete entry.effect;
-		entry.effect = nullptr;
-	}
-	if (entry.tempFile)
-	{
-		delete entry.tempFile;
-		entry.tempFile = nullptr;
-	}
+	clearSoundBuffer(entry);
 
 	auto *temp = new QTemporaryFile(this);
 	temp->setAutoRemove(true);
@@ -11009,7 +11109,36 @@ int WorldRuntime::playSoundMemory(int buffer, const QByteArray &data, bool loop,
 	entry.tempFile = temp;
 
 	auto *effect = new QSoundEffect(this);
+	connect(effect, &QSoundEffect::statusChanged, this,
+	        [this, effect, targetBuffer]
+	        {
+		        if (effect->status() != QSoundEffect::Error)
+			        return;
+		        if (targetBuffer < 1 || targetBuffer > kMaxSoundBuffers)
+			        return;
+
+		        SoundBuffer &current = m_soundBuffers[targetBuffer - 1];
+		        if (current.effect != effect)
+			        return;
+
+		        current.effect = nullptr;
+		        if (current.tempFile)
+		        {
+			        delete current.tempFile;
+			        current.tempFile = nullptr;
+		        }
+		        current.looping = false;
+		        current.volume  = 1.0;
+		        current.pan     = 0.0;
+		        effect->deleteLater();
+	        });
 	effect->setSource(QUrl::fromLocalFile(temp->fileName()));
+	if (effect->status() == QSoundEffect::Error)
+	{
+		delete effect;
+		clearSoundBuffer(entry);
+		return eCannotPlaySound;
+	}
 	entry.looping = loop;
 	entry.volume  = normalizeSoundVolume(volume);
 	entry.pan     = pan;
@@ -11049,19 +11178,7 @@ int WorldRuntime::stopSoundBypassingPluginCallbacks(int buffer)
 	if (buffer == 0)
 	{
 		for (SoundBuffer &entry : m_soundBuffers)
-		{
-			if (entry.effect)
-			{
-				entry.effect->stop();
-				delete entry.effect;
-				entry.effect = nullptr;
-			}
-			if (entry.tempFile)
-			{
-				delete entry.tempFile;
-				entry.tempFile = nullptr;
-			}
-		}
+			clearSoundBuffer(entry);
 		return eOK;
 	}
 
@@ -11069,17 +11186,7 @@ int WorldRuntime::stopSoundBypassingPluginCallbacks(int buffer)
 		return eBadParameter;
 
 	SoundBuffer &entry = m_soundBuffers[buffer - 1];
-	if (entry.effect)
-	{
-		entry.effect->stop();
-		delete entry.effect;
-		entry.effect = nullptr;
-	}
-	if (entry.tempFile)
-	{
-		delete entry.tempFile;
-		entry.tempFile = nullptr;
-	}
+	clearSoundBuffer(entry);
 	return eOK;
 }
 
@@ -11093,9 +11200,9 @@ int WorldRuntime::soundStatus(int buffer) const
 	if (buffer < 1 || buffer > kMaxSoundBuffers)
 		return -1;
 	const SoundBuffer &entry = m_soundBuffers[buffer - 1];
-	if (!entry.effect)
+	if (!soundBufferHasBackend(entry))
 		return -2;
-	if (!entry.effect->isPlaying())
+	if (!soundBufferIsPlaying(entry))
 		return 0;
 	return entry.looping ? 2 : 1;
 }

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -17132,6 +17132,18 @@ void WorldRuntime::notifyNativePluginStateChanged()
 	invalidateLuaCallbackDispatchSnapshot();
 }
 
+bool WorldRuntime::hasMushReaderLiveSpeechOwner() const
+{
+	if (QThread::currentThread() != thread())
+		return qmudInvokeMethodOr(const_cast<WorldRuntime *>(this), false,
+		                          [this] { return hasMushReaderLiveSpeechOwner(); });
+
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::hasMushReaderLiveSpeechOwner");
+	const QString mushReaderId = QMudNativePluginRegistry::mushReaderPluginId();
+	return findPluginIndex(m_plugins, mushReaderId) >= 0 ||
+	       QMudNativePluginRegistry::isMushReaderPluginEnabled(this);
+}
+
 void WorldRuntime::firePluginPartialLine(const QString &text)
 {
 	callPluginCallbacks(QStringLiteral("OnPluginPartialLine"), text, true);

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -9025,6 +9025,8 @@ void WorldRuntime::bookmarkLine(int lineNumber, bool set)
 	}
 
 	qmudAssertObjectThreadAffinity(this, "WorldRuntime::bookmarkLine");
+	if (m_sessionStateOutputBufferSealed)
+		return;
 	if (lineNumber <= 0 || lineNumber > m_lines.size())
 		return;
 
@@ -13087,12 +13089,14 @@ void WorldRuntime::deleteLines(int count)
 	}
 
 	qmudAssertObjectThreadAffinity(this, "WorldRuntime::deleteLines");
+	if (m_sessionStateOutputBufferSealed)
+		return;
 	if (count <= 0 || m_lines.isEmpty())
 		return;
 	if (count >= m_lines.size())
 		m_lines.clear();
 	else
-		m_lines.erase(m_lines.end() - count, m_lines.end());
+		m_lines.remove(m_lines.size() - count, count);
 	invalidateLuaCallbackLineBufferSnapshot();
 	if (m_view)
 		m_view->rebuildOutputFromLines(m_lines);
@@ -13107,6 +13111,8 @@ void WorldRuntime::deleteOutput()
 	}
 
 	qmudAssertObjectThreadAffinity(this, "WorldRuntime::deleteOutput");
+	if (m_sessionStateOutputBufferSealed)
+		return;
 	m_lines.clear();
 	invalidateLuaCallbackLineBufferSnapshot();
 	if (m_view)
@@ -22408,6 +22414,9 @@ QString WorldRuntime::comments() const
 
 void WorldRuntime::addLine(const QString &text, int flags, bool hardReturn, const QDateTime &time)
 {
+	if (m_sessionStateOutputBufferSealed)
+		return;
+
 	LineEntry entry;
 	entry.text       = text;
 	entry.flags      = flags;
@@ -22436,6 +22445,9 @@ void WorldRuntime::addLine(const QString &text, int flags, bool hardReturn, cons
 void WorldRuntime::addLine(const QString &text, int flags, const QVector<StyleSpan> &spans, bool hardReturn,
                            const QDateTime &time)
 {
+	if (m_sessionStateOutputBufferSealed)
+		return;
+
 	LineEntry entry;
 	entry.text       = text;
 	entry.flags      = flags;
@@ -22507,12 +22519,15 @@ int WorldRuntime::maxOutputLinesLimit() const
 
 int WorldRuntime::enforceOutputLineLimit()
 {
+	if (m_sessionStateOutputBufferSealed)
+		return 0;
+
 	const int maxLines = maxOutputLinesLimit();
 	if (maxLines <= 0 || m_lines.size() <= maxLines)
 		return 0;
 
 	const int removed = safeQSizeToInt(m_lines.size() - maxLines);
-	m_lines.erase(m_lines.begin(), m_lines.begin() + removed);
+	m_lines.remove(0, removed);
 	invalidateLuaCallbackLineBufferSnapshot();
 
 	if (m_lastGoTo > m_lines.size())
@@ -22545,13 +22560,33 @@ int WorldRuntime::enforceOutputLineLimit()
 	return removed;
 }
 
-const QVector<WorldRuntime::LineEntry> &WorldRuntime::lines() const
+const IndexedRingBuffer<WorldRuntime::LineEntry> &WorldRuntime::lines() const
 {
 	return m_lines;
 }
 
-void WorldRuntime::replaceOutputLines(const QVector<LineEntry> &lines)
+void WorldRuntime::setSessionStateOutputBufferSealed(const bool sealed)
 {
+	if (QThread::currentThread() != thread())
+	{
+		qmudInvokeMethodChecked(this, [this, sealed] { setSessionStateOutputBufferSealed(sealed); });
+		return;
+	}
+
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::setSessionStateOutputBufferSealed");
+	m_sessionStateOutputBufferSealed = sealed;
+}
+
+bool WorldRuntime::isSessionStateOutputBufferSealed() const
+{
+	return m_sessionStateOutputBufferSealed;
+}
+
+void WorldRuntime::replaceOutputLines(const IndexedRingBuffer<LineEntry> &lines)
+{
+	if (m_sessionStateOutputBufferSealed)
+		return;
+
 	m_lines = lines;
 	invalidateLuaCallbackLineBufferSnapshot();
 
@@ -22566,8 +22601,16 @@ void WorldRuntime::replaceOutputLines(const QVector<LineEntry> &lines)
 		m_view->restoreOutputFromPersistedLines(m_lines);
 }
 
+void WorldRuntime::replaceOutputLines(const QVector<LineEntry> &lines)
+{
+	replaceOutputLines(IndexedRingBuffer<LineEntry>(lines));
+}
+
 void WorldRuntime::finalizePendingInputLineHardReturn()
 {
+	if (m_sessionStateOutputBufferSealed)
+		return;
+
 	if (m_lines.isEmpty())
 		return;
 
@@ -22583,6 +22626,9 @@ void WorldRuntime::finalizePendingInputLineHardReturn()
 
 void WorldRuntime::clearLastLineHardReturn()
 {
+	if (m_sessionStateOutputBufferSealed)
+		return;
+
 	if (m_lines.isEmpty())
 		return;
 
@@ -22626,6 +22672,9 @@ void WorldRuntime::beginIncomingLineLuaContext(const QString &text, int flags,
 
 bool WorldRuntime::reserveIncomingLineLuaContextInBuffer()
 {
+	if (m_sessionStateOutputBufferSealed)
+		return false;
+
 	if (!m_luaContextLineActive)
 		return false;
 	if (m_luaContextLineBuffered)
@@ -22648,6 +22697,9 @@ bool WorldRuntime::reserveIncomingLineLuaContextInBuffer()
 bool WorldRuntime::updateBufferedIncomingLineLuaContext(const QString &text, int flags,
                                                         const QVector<StyleSpan> &spans, bool hardReturn)
 {
+	if (m_sessionStateOutputBufferSealed)
+		return false;
+
 	if (!m_luaContextLineActive || !m_luaContextLineBuffered)
 		return false;
 	if (m_luaContextLineBufferIndex <= 0 || m_luaContextLineBufferIndex > m_lines.size())
@@ -22667,6 +22719,9 @@ bool WorldRuntime::updateBufferedIncomingLineLuaContext(const QString &text, int
 
 bool WorldRuntime::removeBufferedIncomingLineLuaContext()
 {
+	if (m_sessionStateOutputBufferSealed)
+		return false;
+
 	if (!m_luaContextLineActive || !m_luaContextLineBuffered)
 		return false;
 	if (m_luaContextLineBufferIndex <= 0 || m_luaContextLineBufferIndex > m_lines.size())
@@ -22683,6 +22738,9 @@ bool WorldRuntime::removeBufferedIncomingLineLuaContext()
 
 bool WorldRuntime::hideBufferedIncomingLineLuaContextForReplacement()
 {
+	if (m_sessionStateOutputBufferSealed)
+		return false;
+
 	if (!m_luaContextLineActive || !m_luaContextLineBuffered)
 		return false;
 	if (m_luaContextLineBufferIndex <= 0 || m_luaContextLineBufferIndex > m_lines.size())
@@ -22707,6 +22765,9 @@ qint64 WorldRuntime::incomingLineLuaContextAbsoluteNumber() const
 
 bool WorldRuntime::removeHiddenLuaContextLineByAbsoluteNumber(const qint64 absoluteLineNumber)
 {
+	if (m_sessionStateOutputBufferSealed)
+		return false;
+
 	if (absoluteLineNumber <= 0)
 		return false;
 	for (int i = 0; i < m_lines.size(); ++i)
@@ -22842,6 +22903,9 @@ bool WorldRuntime::writeLuaCallbackOutputAtLineAnchor(const qint64 anchorLineNum
                                                       int flags, const QVector<StyleSpan> &spans,
                                                       const bool hardReturn)
 {
+	if (m_sessionStateOutputBufferSealed)
+		return false;
+
 	if (text.isEmpty() && spans.isEmpty() && !hardReturn)
 		return false;
 

--- a/src/WorldRuntime.cpp
+++ b/src/WorldRuntime.cpp
@@ -13182,6 +13182,18 @@ int WorldRuntime::executeCommand(const QString &text) const
 	return m_commandProcessor->executeCommand(text);
 }
 
+int WorldRuntime::executeUserMacroSendNow(const QString &text, const bool history) const
+{
+	if (QThread::currentThread() != thread())
+		return qmudInvokeMethodOr(const_cast<WorldRuntime *>(this), eWorldClosed,
+		                          [this, text, history] { return executeUserMacroSendNow(text, history); });
+
+	qmudAssertObjectThreadAffinity(this, "WorldRuntime::executeUserMacroSendNow");
+	if (!m_commandProcessor)
+		return eWorldClosed;
+	return m_commandProcessor->executeUserMacroSendNow(text, history);
+}
+
 int WorldRuntime::executeCommandWithTriggerPriority(const QString &text) const
 {
 	if (QThread::currentThread() != thread())

--- a/src/WorldRuntime.h
+++ b/src/WorldRuntime.h
@@ -1251,6 +1251,11 @@ class WorldRuntime : public QObject
 		 */
 		void                      notifyNativePluginStateChanged();
 		/**
+		 * @brief Returns whether MushReader owns live speech for this runtime.
+		 * @return `true` when the native MushReader shim is installed or currently enabled for the runtime.
+		 */
+		[[nodiscard]] bool        hasMushReaderLiveSpeechOwner() const;
+		/**
 		 * @brief Lists installed plugin ids in current order.
 		 * @return Plugin id list.
 		 */

--- a/src/WorldRuntime.h
+++ b/src/WorldRuntime.h
@@ -11,6 +11,7 @@
 #define QMUD_WORLDRUNTIME_H
 
 #include "AnsiSgrParseUtils.h"
+#include "IndexedRingBuffer.h"
 #include "LuaExecutor.h"
 #include "MemoryImageDecodeCacheUtils.h"
 #include "MiniWindow.h"
@@ -1447,12 +1448,31 @@ class WorldRuntime : public QObject
 		 * @brief Returns immutable output line buffer.
 		 * @return Immutable buffered line list.
 		 */
-		[[nodiscard]] const QVector<LineEntry> &lines() const;
+		[[nodiscard]] const IndexedRingBuffer<LineEntry> &lines() const;
+		/**
+		 * @brief Enables/disables the session-state output-buffer save seal.
+		 * @param sealed Seal state.
+		 *
+		 * While sealed, runtime line-buffer mutations are ignored so an async session-state
+		 * writer can serialize a shallow ring-buffer snapshot without detaching the backing
+		 * store.
+		 */
+		void                                              setSessionStateOutputBufferSealed(bool sealed);
+		/**
+		 * @brief Returns whether the output buffer is sealed for session-state persistence.
+		 * @return `true` when line-buffer mutations are currently ignored.
+		 */
+		[[nodiscard]] bool                                isSessionStateOutputBufferSealed() const;
 		/**
 		 * @brief Replaces buffered output lines and rebuilds the attached view.
 		 * @param lines Replacement buffered output lines.
 		 */
-		void                                    replaceOutputLines(const QVector<LineEntry> &lines);
+		void replaceOutputLines(const IndexedRingBuffer<LineEntry> &lines);
+		/**
+		 * @brief Replaces buffered output lines and rebuilds the attached view.
+		 * @param lines Replacement buffered output lines.
+		 */
+		void replaceOutputLines(const QVector<LineEntry> &lines);
 		/**
 		 * @brief Marks the last buffered input line as hard-return terminated when pending.
 		 *
@@ -1460,14 +1480,14 @@ class WorldRuntime : public QObject
 		 * keeping echoed commands on the same line) so runtime line state remains consistent
 		 * with the rendered document after rebuilds.
 		 */
-		void                                    finalizePendingInputLineHardReturn();
+		void finalizePendingInputLineHardReturn();
 		/**
 		 * @brief Clears hard-return termination flag on the last buffered line when set.
 		 *
 		 * Used by keep-on-same-line echo flow when the view consumes a trailing
 		 * line break from the existing rendered output.
 		 */
-		void                                    clearLastLineHardReturn();
+		void clearLastLineHardReturn();
 		/**
 		 * @brief Begins temporary incoming-line context for Lua callbacks.
 		 * @param text Incoming line text.
@@ -5613,7 +5633,8 @@ class WorldRuntime : public QObject
 		QList<Include>                                  m_includes;
 		QList<Script>                                   m_scripts;
 		QString                                         m_comments;
-		QVector<LineEntry>                              m_lines;
+		IndexedRingBuffer<LineEntry>                    m_lines;
+		bool                                            m_sessionStateOutputBufferSealed{false};
 		QMap<qint64, int>                               m_acceleratorKeyToCommand;
 		QMap<int, AcceleratorEntry>                     m_commandToAcceleratorEntry;
 		int                                             m_nextAcceleratorCommand{kAcceleratorFirstCommand};

--- a/src/WorldRuntime.h
+++ b/src/WorldRuntime.h
@@ -2757,6 +2757,17 @@ class WorldRuntime : public QObject
 		 */
 		[[nodiscard]] int            executeCommand(const QString &text) const;
 		/**
+		 * @brief Executes one Send Now macro via command processor.
+		 *
+		 * The caller owns action-source setup; set the runtime source to
+		 * `WorldRuntime::eUserMacro` when macro source semantics are required.
+		 *
+		 * @param text Macro Send Now text.
+		 * @param history Add original macro text to history when `true`.
+		 * @return API status code.
+		 */
+		[[nodiscard]] int            executeUserMacroSendNow(const QString &text, bool history) const;
+		/**
 		 * @brief Executes one direct trigger-script command with priority over queued movement.
 		 * @param text Command text.
 		 * @return API status code.

--- a/src/WorldRuntime.h
+++ b/src/WorldRuntime.h
@@ -49,6 +49,8 @@ class ILuaExecutor;
 class WorldCommandProcessor;
 class WorldView;
 class QUdpSocket;
+class QAudioOutput;
+class QMediaPlayer;
 class QSoundEffect;
 class QTemporaryFile;
 class QTcpServer;
@@ -530,6 +532,8 @@ class WorldRuntime : public QObject
 		struct SoundBuffer
 		{
 				QSoundEffect   *effect{nullptr};
+				QMediaPlayer   *player{nullptr};
+				QAudioOutput   *audioOutput{nullptr};
 				QTemporaryFile *tempFile{nullptr};
 				bool            looping{false};
 				double          volume{1.0};
@@ -5702,6 +5706,10 @@ class WorldRuntime : public QObject
 		bool                                    m_outputFrozen{false};
 		TextRectangleSettings                   m_textRectangle;
 		QMap<int, UdpListener>                  m_udpListeners;
+		[[nodiscard]] static bool               soundBufferHasBackend(const SoundBuffer &entry);
+		[[nodiscard]] static bool               soundBufferIsPlaying(const SoundBuffer &entry);
+		static void                             clearSoundBuffer(SoundBuffer &entry);
+		[[nodiscard]] static bool               shouldUseMediaPlayerForSoundFile(const QString &fileName);
 		QVector<SoundBuffer>                    m_soundBuffers;
 		int                                     m_outputFontHeight{0};
 		int                                     m_outputFontWidth{0};

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -83,7 +83,8 @@
 
 namespace
 {
-	constexpr const char *kWorldOutputAccessibleProperty = "qmud_world_output_widget";
+	constexpr const char *kWorldOutputAccessibleProperty                  = "qmud_world_output_widget";
+	constexpr qreal       kNativeLayoutCumulativeOriginNormalizeThreshold = 1.0e12;
 
 	int                   sizeToInt(const qsizetype value)
 	{
@@ -227,7 +228,7 @@ namespace
 		return true;
 	}
 
-	bool runtimeLineNumbersAreContiguous(const QVector<WorldRuntime::LineEntry> &lines)
+	template <typename Lines> bool runtimeLineNumbersAreContiguous(const Lines &lines)
 	{
 		if (lines.isEmpty())
 			return true;
@@ -242,9 +243,9 @@ namespace
 		return true;
 	}
 
-	int findRuntimeLineIndexByNumberNear(const QVector<WorldRuntime::LineEntry> &runtimeLines,
-	                                     const qint64 lineNumber, const int preferredIndex,
-	                                     const bool searchBackwardFirst)
+	template <typename Lines>
+	int findRuntimeLineIndexByNumberNear(const Lines &runtimeLines, const qint64 lineNumber,
+	                                     const int preferredIndex, const bool searchBackwardFirst)
 	{
 		if (runtimeLines.isEmpty())
 			return -1;
@@ -1560,7 +1561,7 @@ class WorldOutputAccessible final : public QAccessibleWidget, public QAccessible
 			if (!view)
 				return {};
 
-			const QVector<WorldView::NativeOutputRenderLine> &renderLines = view->nativeOutputRenderLines();
+			const WorldView::NativeOutputRenderLines &renderLines = view->nativeOutputRenderLines();
 			return WorldView::accessibleNativeOutputTextMap(renderLines);
 		}
 };
@@ -2469,8 +2470,8 @@ void WorldView::syncOutputScrollSingleStep() const
 		m_outputScrollBar->setSingleStep(singleStep);
 }
 
-void WorldView::syncNativeOutputScrollBarsFromLayout(const QVector<NativeOutputRenderLine> &lines,
-                                                     const bool allowLayoutBuild) const
+void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLines &lines,
+                                                     const bool                     allowLayoutBuild) const
 {
 	if (!m_output || !m_nativeOutputCanvas)
 		return;
@@ -2524,7 +2525,7 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const QVector<NativeOutputR
 	                                       : m_nativeLayoutCachedLineAdvance;
 	const qreal docY          = (lines.isEmpty() || m_nativeLayoutCumulativeHeights.size() <= lines.size())
 	                                ? 0.0
-	                                : m_nativeLayoutCumulativeHeights.at(lines.size());
+	                                : nativeLayoutCumulativeHeightAt(lines.size());
 	const int   contentHeight = qMax(0, static_cast<int>(std::ceil(docY)));
 	const int   lineStep      = qMax(1, static_cast<int>(std::round(effectiveLineAdvance)));
 
@@ -2635,7 +2636,7 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const QVector<NativeOutputR
 						continue;
 
 					const int anchoredValue =
-					    static_cast<int>(std::round(m_nativeLayoutCumulativeHeights.at(newLineIndex))) -
+					    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(newLineIndex))) -
 					    anchorTopOffset;
 					targetValue           = qBound(0, anchoredValue, maxScroll);
 					splitTopAnchorApplied = true;
@@ -2780,8 +2781,7 @@ void WorldView::requestNativeOutputTailRepaint() const
 		requestNativeOutputRepaint();
 }
 
-bool WorldView::nativeOutputDeltaRepaintRect(const QVector<NativeOutputRenderLine> &lines,
-                                             QRect                                 &repaintRect) const
+bool WorldView::nativeOutputDeltaRepaintRect(const NativeOutputRenderLines &lines, QRect &repaintRect) const
 {
 	repaintRect = {};
 	if (!m_nativeOutputCanvas || !m_output || lines.isEmpty())
@@ -2823,7 +2823,7 @@ bool WorldView::nativeOutputDeltaRepaintRect(const QVector<NativeOutputRenderLin
 	if (firstDirtyLine < 0 || firstDirtyLine >= lineCount)
 		return false;
 
-	const qreal documentHeight      = m_nativeLayoutCumulativeHeights.at(lines.size());
+	const qreal documentHeight      = nativeLayoutCumulativeHeightAt(lines.size());
 	auto        appendPaneDirtyRect = [&](const WrapTextBrowser *view)
 	{
 		if (!view || !view->isVisible())
@@ -2836,8 +2836,7 @@ bool WorldView::nativeOutputDeltaRepaintRect(const QVector<NativeOutputRenderLin
 		const int scrollY =
 		    view->verticalScrollBar() ? qBound(0, view->verticalScrollBar()->value(), nativeMaxScroll) : 0;
 		const qreal dirtyTop = static_cast<qreal>(paneRect.top()) +
-		                       m_nativeLayoutCumulativeHeights.at(firstDirtyLine) -
-		                       static_cast<qreal>(scrollY);
+		                       nativeLayoutCumulativeHeightAt(firstDirtyLine) - static_cast<qreal>(scrollY);
 		const qreal dirtyBottom =
 		    static_cast<qreal>(paneRect.top()) + documentHeight - static_cast<qreal>(scrollY);
 		const int   dirtyY      = static_cast<int>(std::floor(dirtyTop)) - 2;
@@ -2976,12 +2975,12 @@ bool WorldView::requestNativeOutputScrollAwarePresentationRepaint(
 		auto       firstVisibleIt =
 		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
 		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleTop);
+		                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
 		firstLine = qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 		auto lastVisibleIt =
 		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
 		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleBottom);
+		                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
 		lastLine = qMin(sizeToInt(lines.size()) - 1,
 		                sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 		return firstLine <= lastLine;
@@ -3017,9 +3016,9 @@ bool WorldView::requestNativeOutputScrollAwarePresentationRepaint(
 			return false;
 		currentLineKeys.push_back(nativeRuntimeLineKey(lines.at(i)));
 		currentLineTops.push_back(
-		    static_cast<int>(std::round(m_nativeLayoutCumulativeHeights.at(i) - currentScrollY)));
+		    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i) - currentScrollY)));
 		currentLineBottoms.push_back(
-		    static_cast<int>(std::round(m_nativeLayoutCumulativeHeights.at(i + 1) - currentScrollY)));
+		    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i + 1) - currentScrollY)));
 	}
 
 	int mappedLineCount = 0;
@@ -3104,7 +3103,7 @@ void WorldView::requestNativeOutputPresentationRepaint(const bool repaintVisible
 }
 
 QMudAccessibleTextUtils::LineOffsetMap
-WorldView::accessibleNativeOutputTextMap(const QVector<NativeOutputRenderLine> &lines)
+WorldView::accessibleNativeOutputTextMap(const NativeOutputRenderLines &lines)
 {
 	QVector<QString> textLines;
 	textLines.reserve(lines.size());
@@ -3122,7 +3121,7 @@ void WorldView::primeAccessibleOutputTextState() const
 	m_accessibleOutputText           = map.text(0, map.characterCount());
 }
 
-void WorldView::notifyAccessibleOutputPresented(const QVector<NativeOutputRenderLine> &lines) const
+void WorldView::notifyAccessibleOutputPresented(const NativeOutputRenderLines &lines) const
 {
 	if (!QAccessible::isActive())
 	{
@@ -3205,9 +3204,10 @@ WorldView::nativeOutputPanePaintStateForView(const WrapTextBrowser *view) const
 	return nullptr;
 }
 
-void WorldView::refreshNativeOutputPanePaintStateFromLayout(
-    const WrapTextBrowser *view, const QRect &paneRect, const int scrollY, const int scrollMax,
-    const QVector<NativeOutputRenderLine> &lines) const
+void WorldView::refreshNativeOutputPanePaintStateFromLayout(const WrapTextBrowser *view,
+                                                            const QRect &paneRect, const int scrollY,
+                                                            const int                      scrollMax,
+                                                            const NativeOutputRenderLines &lines) const
 {
 	NativeOutputPanePaintState *const state = nativeOutputPanePaintStateForView(view);
 	if (!state || paneRect.isEmpty())
@@ -3227,13 +3227,13 @@ void WorldView::refreshNativeOutputPanePaintStateFromLayout(
 		auto       firstVisibleIt =
 		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
 		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleTop);
+		                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
 		int firstVisibleLine =
 		    qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 		auto lastVisibleIt =
 		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
 		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleBottom);
+		                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
 		int lastVisibleLine = qMin(sizeToInt(lines.size()) - 1,
 		                           sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 		if (firstVisibleLine <= lastVisibleLine)
@@ -3252,9 +3252,9 @@ void WorldView::refreshNativeOutputPanePaintStateFromLayout(
 				visibleFirstRuntimeLineNumbers.push_back(line.firstRuntimeLineNumber);
 				visibleLastRuntimeLineNumbers.push_back(line.lastRuntimeLineNumber);
 				visibleLineTops.push_back(
-				    static_cast<int>(std::round(m_nativeLayoutCumulativeHeights.at(i) - visibleTop)));
+				    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i) - visibleTop)));
 				visibleLineBottoms.push_back(
-				    static_cast<int>(std::round(m_nativeLayoutCumulativeHeights.at(i + 1) - visibleTop)));
+				    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i + 1) - visibleTop)));
 			}
 		}
 	}
@@ -3274,8 +3274,8 @@ void WorldView::refreshNativeOutputPanePaintStateFromLayout(
 
 void WorldView::updateNativeOutputPanePaintState(const WrapTextBrowser *view, const QRect &paneRect,
                                                  const QRegion &paintedRegion, const int scrollY,
-                                                 const int                              scrollMax,
-                                                 const QVector<NativeOutputRenderLine> &lines) const
+                                                 const int                      scrollMax,
+                                                 const NativeOutputRenderLines &lines) const
 {
 	NativeOutputPanePaintState *const state = nativeOutputPanePaintStateForView(view);
 	if (!state || paneRect.isEmpty())
@@ -3305,7 +3305,7 @@ void WorldView::primeNativeOutputCaches() const
 	if (viewportRect.width() <= 0 || viewportRect.height() <= 0)
 		return;
 
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return;
 
@@ -3742,7 +3742,7 @@ bool WorldView::nativeRenderBaseCacheMatchesCurrentSource() const
 	if (!m_runtime)
 		return !m_nativeRenderLineCacheFromRuntime;
 
-	const QVector<WorldRuntime::LineEntry> &runtimeLines = m_runtime->lines();
+	const auto &runtimeLines = m_runtime->lines();
 	if (!m_nativeRenderLineCacheFromRuntime)
 		return false;
 	if (runtimeLines.isEmpty())
@@ -3869,7 +3869,7 @@ void WorldView::applyNativePartialRenderLineOverlay() const
 	m_nativePartialRenderLineEffectiveRevision = m_nativeRenderLineCacheRevision;
 }
 
-const QVector<WorldView::NativeOutputRenderLine> &WorldView::finalizeNativeOutputRenderLines() const
+const WorldView::NativeOutputRenderLines &WorldView::finalizeNativeOutputRenderLines() const
 {
 	if (!m_nativeHasPartialOutput || m_nativePartialOutputText.isEmpty())
 	{
@@ -3996,9 +3996,9 @@ QVector<QTextLayout::FormatRange> WorldView::buildNativeFormatRanges(const Nativ
 	return ranges;
 }
 
-bool WorldView::nativeLayoutCacheReadyFor(const QVector<NativeOutputRenderLine> &lines,
-                                          const int wrapWidthPixels, const int localWrapWidthPixels,
-                                          const int lineSpacingSetting, const QFont &layoutFont) const
+bool WorldView::nativeLayoutCacheReadyFor(const NativeOutputRenderLines &lines, const int wrapWidthPixels,
+                                          const int localWrapWidthPixels, const int lineSpacingSetting,
+                                          const QFont &layoutFont) const
 {
 	const qreal lineSpacingFactor = (100.0 + static_cast<qreal>(lineSpacingSetting)) / 100.0;
 	const qreal lineAdvance =
@@ -4098,10 +4098,9 @@ int WorldView::estimateNativeLineRows(const NativeOutputRenderLine &line, const 
 	return qMax(1, rows);
 }
 
-bool WorldView::ensureNativeLayoutRange(const QVector<NativeOutputRenderLine> &lines, int firstLine,
-                                        int lastLine, const int wrapWidthPixels,
-                                        const int localWrapWidthPixels, const int lineSpacingSetting,
-                                        const QFont &layoutFont) const
+bool WorldView::ensureNativeLayoutRange(const NativeOutputRenderLines &lines, int firstLine, int lastLine,
+                                        const int wrapWidthPixels, const int localWrapWidthPixels,
+                                        const int lineSpacingSetting, const QFont &layoutFont) const
 {
 	if (lines.isEmpty())
 		return false;
@@ -4137,10 +4136,9 @@ bool WorldView::ensureNativeLayoutRange(const QVector<NativeOutputRenderLine> &l
 	if (firstHeightChangedLine < 0)
 		return false;
 
-	qreal docY =
-	    firstHeightChangedLine > 0 ? m_nativeLayoutCumulativeHeights.at(firstHeightChangedLine) : 0.0;
+	qreal docY = firstHeightChangedLine > 0 ? nativeLayoutCumulativeHeightAt(firstHeightChangedLine) : 0.0;
 	if (firstHeightChangedLine == 0 && !m_nativeLayoutCumulativeHeights.isEmpty())
-		m_nativeLayoutCumulativeHeights[0] = 0.0;
+		setNativeLayoutCumulativeHeightAt(0, 0.0);
 	for (int i = firstHeightChangedLine; i < lines.size(); ++i)
 	{
 		const int rows = (i < m_nativeLayoutVisualRows.size() && m_nativeLayoutVisualRows.at(i) > 0)
@@ -4148,13 +4146,13 @@ bool WorldView::ensureNativeLayoutRange(const QVector<NativeOutputRenderLine> &l
 		                     : 1;
 		docY += static_cast<qreal>(rows) * defaultLineAdvance;
 		if (i + 1 < m_nativeLayoutCumulativeHeights.size())
-			m_nativeLayoutCumulativeHeights[i + 1] = docY;
+			setNativeLayoutCumulativeHeightAt(i + 1, docY);
 	}
 	m_nativeLayoutCumulativeDirtyFrom = sizeToInt(lines.size());
 	return true;
 }
 
-int WorldView::ensureNativeLineLayout(const QVector<NativeOutputRenderLine> &lines, const int index,
+int WorldView::ensureNativeLineLayout(const NativeOutputRenderLines &lines, const int index,
                                       const int wrapWidthPixels, const int localWrapWidthPixels,
                                       const qreal defaultLineAdvance, const QFont &layoutFont) const
 {
@@ -4246,9 +4244,9 @@ int WorldView::ensureNativeLineLayout(const QVector<NativeOutputRenderLine> &lin
 	return rowCount;
 }
 
-void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &lines,
-                                         const int wrapWidthPixels, const int localWrapWidthPixels,
-                                         const int lineSpacingSetting, const QFont &layoutFont) const
+void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, const int wrapWidthPixels,
+                                         const int localWrapWidthPixels, const int lineSpacingSetting,
+                                         const QFont &layoutFont) const
 {
 	const qreal lineSpacingFactor = (100.0 + static_cast<qreal>(lineSpacingSetting)) / 100.0;
 	const qreal defaultLineAdvance =
@@ -4292,7 +4290,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 			    headTrimCount < m_nativeLayoutCumulativeHeights.size() &&
 			    m_nativeLayoutCumulativeDirtyFrom >= headTrimCount)
 			{
-				trimmedHeadDocY = qMax<qreal>(0.0, m_nativeLayoutCumulativeHeights.at(headTrimCount));
+				trimmedHeadDocY = qMax<qreal>(0.0, nativeLayoutCumulativeHeightAt(headTrimCount));
 			}
 			else
 			{
@@ -4351,7 +4349,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 		qreal trimmedDocY = 0.0;
 		if (m_nativeLayoutCumulativeHeights.size() > headTrimCount)
-			trimmedDocY = qMax<qreal>(0.0, m_nativeLayoutCumulativeHeights.at(headTrimCount));
+			trimmedDocY = qMax<qreal>(0.0, nativeLayoutCumulativeHeightAt(headTrimCount));
 
 		m_nativeLayoutVisualRows.remove(0, headTrimCount);
 		m_nativeLayoutLineLayouts.remove(0, headTrimCount);
@@ -4362,14 +4360,16 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 		if (m_nativeLayoutCumulativeHeights.size() > headTrimCount)
 		{
 			m_nativeLayoutCumulativeHeights.remove(0, headTrimCount);
-			for (qreal &height : m_nativeLayoutCumulativeHeights)
-				height = qMax<qreal>(0.0, height - trimmedDocY);
-			if (!m_nativeLayoutCumulativeHeights.isEmpty())
-				m_nativeLayoutCumulativeHeights[0] = 0.0;
+			m_nativeLayoutCumulativeHeightOrigin += trimmedDocY;
+			if (m_nativeLayoutCumulativeHeightOrigin >= kNativeLayoutCumulativeOriginNormalizeThreshold)
+			{
+				resetNativeLayoutCumulativeHeightOrigin();
+			}
 		}
 		else
 		{
-			m_nativeLayoutCumulativeHeights = QVector<qreal>(1, 0.0);
+			m_nativeLayoutCumulativeHeights.assign(1, 0.0);
+			m_nativeLayoutCumulativeHeightOrigin = 0.0;
 		}
 
 		m_nativeLayoutCumulativeDirtyFrom = qMax(0, m_nativeLayoutCumulativeDirtyFrom - headTrimCount);
@@ -4454,7 +4454,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 		m_nativeLayoutCumulativeHeights.resize(newSize + 1);
 		if (!m_nativeLayoutCumulativeHeights.isEmpty())
-			m_nativeLayoutCumulativeHeights[0] = 0.0;
+			setNativeLayoutCumulativeHeightAt(0, 0.0);
 		if (cumulativePrefixPreserved)
 		{
 			m_nativeLayoutCumulativeDirtyFrom =
@@ -4466,7 +4466,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 			for (int i = 0; i < reusablePrefix; ++i)
 			{
 				prefixDocY += static_cast<qreal>(m_nativeLayoutVisualRows.at(i)) * defaultLineAdvance;
-				m_nativeLayoutCumulativeHeights[i + 1] = prefixDocY;
+				setNativeLayoutCumulativeHeightAt(i + 1, prefixDocY);
 			}
 			m_nativeLayoutCumulativeDirtyFrom = qBound(0, reusablePrefix, newSize);
 		}
@@ -4507,7 +4507,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 			m_nativeLayoutCumulativeHeights.resize(lines.size() + 1);
 			if (stablePrefix == 0 && !m_nativeLayoutCumulativeHeights.isEmpty())
-				m_nativeLayoutCumulativeHeights[0] = 0.0;
+				setNativeLayoutCumulativeHeightAt(0, 0.0);
 			m_nativeLayoutCumulativeDirtyFrom =
 			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, stablePrefix), newSize);
 			renderDeltaFastPathApplied = true;
@@ -4552,7 +4552,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 			m_nativeLayoutCumulativeHeights.resize(newSize + 1);
 			if (stablePrefix == 0 && !m_nativeLayoutCumulativeHeights.isEmpty())
-				m_nativeLayoutCumulativeHeights[0] = 0.0;
+				setNativeLayoutCumulativeHeightAt(0, 0.0);
 			m_nativeLayoutCumulativeDirtyFrom =
 			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, stablePrefix), newSize);
 			renderDeltaFastPathApplied = true;
@@ -4596,7 +4596,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 			m_nativeLayoutCumulativeHeights.resize(newSize + 1);
 			if (!m_nativeLayoutCumulativeHeights.isEmpty())
-				m_nativeLayoutCumulativeHeights[0] = 0.0;
+				setNativeLayoutCumulativeHeightAt(0, 0.0);
 			m_nativeLayoutCumulativeDirtyFrom =
 			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, preservedCount), newSize);
 			renderDeltaFastPathApplied = true;
@@ -4676,7 +4676,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 			m_nativeLayoutCumulativeHeights.resize(newSize + 1);
 			if (!m_nativeLayoutCumulativeHeights.isEmpty())
-				m_nativeLayoutCumulativeHeights[0] = 0.0;
+				setNativeLayoutCumulativeHeightAt(0, 0.0);
 			m_nativeLayoutCumulativeDirtyFrom =
 			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, stablePrefix), newSize);
 			renderDeltaFastPathApplied = true;
@@ -4722,34 +4722,35 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 		    preserveLineLayouts)
 		{
 			if (m_nativeLayoutVisualRows.size() != lines.size())
-				m_nativeLayoutVisualRows = QVector<int>(lines.size(), -1);
+				m_nativeLayoutVisualRows.assign(lines.size(), -1);
 			else if (wrapChanged)
 				std::ranges::fill(m_nativeLayoutVisualRows, -1);
 
 			if (m_nativeLayoutLineLayouts.size() != lines.size())
-				m_nativeLayoutLineLayouts = QVector<QSharedPointer<QTextLayout>>(lines.size());
+				m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
 			if (m_nativeLayoutLineContentHashes.size() != lines.size())
-				m_nativeLayoutLineContentHashes = QVector<quint64>(lines.size(), 0);
+				m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
 			if (m_nativeLayoutRowsExact.size() != lines.size())
-				m_nativeLayoutRowsExact = QVector<uchar>(lines.size(), 0);
+				m_nativeLayoutRowsExact.assign(lines.size(), 0);
 		}
 		else
 		{
-			m_nativeLayoutVisualRows        = QVector<int>(lines.size(), -1);
-			m_nativeLayoutLineLayouts       = QVector<QSharedPointer<QTextLayout>>(lines.size());
-			m_nativeLayoutLineContentHashes = QVector<quint64>(lines.size(), 0);
-			m_nativeLayoutRowsExact         = QVector<uchar>(lines.size(), 0);
+			m_nativeLayoutVisualRows.assign(lines.size(), -1);
+			m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
+			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
+			m_nativeLayoutRowsExact.assign(lines.size(), 0);
 		}
-		m_nativeLayoutCumulativeHeights    = QVector<qreal>(lines.size() + 1, 0.0);
-		m_nativeLayoutCumulativeDirtyFrom  = 0;
-		m_nativeLayoutCacheValid           = true;
-		m_nativeLayoutCachedWrapWidth      = wrapWidthPixels;
-		m_nativeLayoutCachedLocalWrapWidth = localWrapWidthPixels;
-		m_nativeLayoutCachedLineSpacing    = lineSpacingSetting;
-		m_nativeLayoutCachedStyleKey       = styleKey;
-		m_nativeLayoutCachedLineAdvance    = defaultLineAdvance;
-		m_nativeLayoutCachedFont           = layoutFont;
-		m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
+		m_nativeLayoutCumulativeHeights.assign(lines.size() + 1, 0.0);
+		m_nativeLayoutCumulativeHeightOrigin = 0.0;
+		m_nativeLayoutCumulativeDirtyFrom    = 0;
+		m_nativeLayoutCacheValid             = true;
+		m_nativeLayoutCachedWrapWidth        = wrapWidthPixels;
+		m_nativeLayoutCachedLocalWrapWidth   = localWrapWidthPixels;
+		m_nativeLayoutCachedLineSpacing      = lineSpacingSetting;
+		m_nativeLayoutCachedStyleKey         = styleKey;
+		m_nativeLayoutCachedLineAdvance      = defaultLineAdvance;
+		m_nativeLayoutCachedFont             = layoutFont;
+		m_nativeLayoutCachedRenderRevision   = m_nativeRenderLineCacheRevision;
 		refreshLayoutRuntimeLineKeys();
 		++m_nativeLayoutCacheResets;
 	}
@@ -4829,9 +4830,9 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 					}
 					else
 					{
-						m_nativeLayoutCumulativeHeights[0] = 0.0;
-						qreal prefixDocY                   = 0.0;
-						int   firstChangedVisualLine       = mappedCount;
+						setNativeLayoutCumulativeHeightAt(0, 0.0);
+						qreal prefixDocY             = 0.0;
+						int   firstChangedVisualLine = mappedCount;
 						for (int i = 0; i < mappedCount; ++i)
 						{
 							const NativeOutputRenderLine &line = lines.at(i);
@@ -4847,7 +4848,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 							prefixDocY +=
 							    static_cast<qreal>(m_nativeLayoutVisualRows.at(i)) * defaultLineAdvance;
-							m_nativeLayoutCumulativeHeights[i + 1] = prefixDocY;
+							setNativeLayoutCumulativeHeightAt(i + 1, prefixDocY);
 						}
 						m_nativeLayoutCumulativeDirtyFrom =
 						    qBound(0, firstChangedVisualLine, sizeToInt(lines.size()));
@@ -4860,21 +4861,21 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 		if (!remappedFastPath)
 		{
-			QVector<int>                         oldRows;
-			QVector<quint64>                     oldLineKeys;
-			QVector<QSharedPointer<QTextLayout>> oldLayouts;
-			QVector<quint64>                     oldHashes;
-			QVector<uchar>                       oldExactRows;
+			IndexedRingBuffer<int>                         oldRows;
+			IndexedRingBuffer<quint64>                     oldLineKeys;
+			IndexedRingBuffer<QSharedPointer<QTextLayout>> oldLayouts;
+			IndexedRingBuffer<quint64>                     oldHashes;
+			IndexedRingBuffer<uchar>                       oldExactRows;
 			oldRows.swap(m_nativeLayoutVisualRows);
 			oldLineKeys.swap(m_nativeLayoutRuntimeLineKeys);
 			oldLayouts.swap(m_nativeLayoutLineLayouts);
 			oldHashes.swap(m_nativeLayoutLineContentHashes);
 			oldExactRows.swap(m_nativeLayoutRowsExact);
 
-			m_nativeLayoutVisualRows        = QVector<int>(lines.size(), -1);
-			m_nativeLayoutLineLayouts       = QVector<QSharedPointer<QTextLayout>>(lines.size());
-			m_nativeLayoutLineContentHashes = QVector<quint64>(lines.size(), 0);
-			m_nativeLayoutRowsExact         = QVector<uchar>(lines.size(), 0);
+			m_nativeLayoutVisualRows.assign(lines.size(), -1);
+			m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
+			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
+			m_nativeLayoutRowsExact.assign(lines.size(), 0);
 			QVector<int> remappedOldIndexes(lines.size(), -1);
 
 			const bool   oldDimensionsStillMatch =
@@ -4913,8 +4914,8 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 			refreshLayoutRuntimeLineKeys();
 			m_nativeLayoutCumulativeHeights.resize(lines.size() + 1);
-			m_nativeLayoutCumulativeHeights[0] = 0.0;
-			auto lineCanReuseMappedLayout      = [&](const int i)
+			setNativeLayoutCumulativeHeightAt(0, 0.0);
+			auto lineCanReuseMappedLayout = [&](const int i)
 			{
 				if (i < 0 || i >= lines.size())
 					return false;
@@ -4939,7 +4940,7 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 				}
 				prefixDocY += static_cast<qreal>(m_nativeLayoutVisualRows.at(firstChangedVisualLine)) *
 				              defaultLineAdvance;
-				m_nativeLayoutCumulativeHeights[firstChangedVisualLine + 1] = prefixDocY;
+				setNativeLayoutCumulativeHeightAt(firstChangedVisualLine + 1, prefixDocY);
 				++firstChangedVisualLine;
 			}
 			m_nativeLayoutCumulativeDirtyFrom = qBound(0, firstChangedVisualLine, sizeToInt(lines.size()));
@@ -4949,12 +4950,12 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 	{
 		if (m_nativeLayoutVisualRows.size() != lines.size())
 		{
-			m_nativeLayoutVisualRows          = QVector<int>(lines.size(), -1);
+			m_nativeLayoutVisualRows.assign(lines.size(), -1);
 			m_nativeLayoutCumulativeDirtyFrom = 0;
 		}
 		if (m_nativeLayoutRowsExact.size() != lines.size())
 		{
-			m_nativeLayoutRowsExact           = QVector<uchar>(lines.size(), 0);
+			m_nativeLayoutRowsExact.assign(lines.size(), 0);
 			m_nativeLayoutCumulativeDirtyFrom = 0;
 		}
 		if (m_nativeLayoutRuntimeLineKeys.size() != lines.size())
@@ -4966,13 +4967,13 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 		}
 		if (m_nativeLayoutLineLayouts.size() != lines.size())
 		{
-			m_nativeLayoutLineLayouts         = QVector<QSharedPointer<QTextLayout>>(lines.size());
-			m_nativeLayoutLineContentHashes   = QVector<quint64>(lines.size(), 0);
+			m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
+			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
 			m_nativeLayoutCumulativeDirtyFrom = 0;
 		}
 		else if (m_nativeLayoutLineContentHashes.size() != lines.size())
 		{
-			m_nativeLayoutLineContentHashes   = QVector<quint64>(lines.size(), 0);
+			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
 			m_nativeLayoutCumulativeDirtyFrom = 0;
 		}
 	}
@@ -4991,10 +4992,10 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 
 	const int dirtyFrom = qBound(0, m_nativeLayoutCumulativeDirtyFrom, sizeToInt(lines.size()));
 	if (dirtyFrom == 0)
-		m_nativeLayoutCumulativeHeights[0] = 0.0;
+		setNativeLayoutCumulativeHeightAt(0, 0.0);
 
 	qreal              docY = (dirtyFrom > 0 && dirtyFrom < m_nativeLayoutCumulativeHeights.size())
-	                              ? m_nativeLayoutCumulativeHeights.at(dirtyFrom)
+	                              ? nativeLayoutCumulativeHeightAt(dirtyFrom)
 	                              : 0.0;
 	const QFontMetrics layoutFontMetrics(layoutFont);
 	for (int i = dirtyFrom; i < lines.size(); ++i)
@@ -5020,10 +5021,34 @@ void WorldView::ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &
 		const int visualRowsForLine = qMax(1, m_nativeLayoutVisualRows.at(i));
 		docY += static_cast<qreal>(visualRowsForLine) * defaultLineAdvance;
 		if (i + 1 < m_nativeLayoutCumulativeHeights.size())
-			m_nativeLayoutCumulativeHeights[i + 1] = docY;
+			setNativeLayoutCumulativeHeightAt(i + 1, docY);
 	}
 	m_nativeLayoutCumulativeDirtyFrom  = sizeToInt(lines.size());
 	m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
+}
+
+qreal WorldView::nativeLayoutCumulativeHeightAt(const int index) const
+{
+	if (index < 0 || index >= m_nativeLayoutCumulativeHeights.size())
+		return 0.0;
+	return m_nativeLayoutCumulativeHeights.at(index) - m_nativeLayoutCumulativeHeightOrigin;
+}
+
+void WorldView::setNativeLayoutCumulativeHeightAt(const int index, const qreal value) const
+{
+	if (index < 0 || index >= m_nativeLayoutCumulativeHeights.size())
+		return;
+	m_nativeLayoutCumulativeHeights[index] = value + m_nativeLayoutCumulativeHeightOrigin;
+}
+
+void WorldView::resetNativeLayoutCumulativeHeightOrigin() const
+{
+	if (qFuzzyIsNull(m_nativeLayoutCumulativeHeightOrigin))
+		return;
+	for (qsizetype i = 0; i < m_nativeLayoutCumulativeHeights.size(); ++i)
+		m_nativeLayoutCumulativeHeights[i] =
+		    qMax<qreal>(0.0, m_nativeLayoutCumulativeHeights.at(i) - m_nativeLayoutCumulativeHeightOrigin);
+	m_nativeLayoutCumulativeHeightOrigin = 0.0;
 }
 
 const QTextLayout *WorldView::nativeLayoutForLine(const int index) const
@@ -5087,8 +5112,8 @@ void WorldView::markNativeRuntimeLineRestitchPending(const int runtimeLineIndex)
 	}
 }
 
-void WorldView::rebuildNativeRenderCacheFromLineEntries(const QVector<WorldRuntime::LineEntry> &lines,
-                                                        const bool fromRuntimeSource) const
+void WorldView::rebuildNativeRenderCacheFromLineEntries(
+    const IndexedRingBuffer<WorldRuntime::LineEntry> &lines, const bool fromRuntimeSource) const
 {
 	removeNativePartialRenderLineOverlay(false);
 	const int oldLineCount = sizeToInt(m_nativeRenderLineCache.size());
@@ -5210,7 +5235,7 @@ void WorldView::rebuildNativeRenderCacheFromLineEntries(const QVector<WorldRunti
 	bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::FullReset, oldLineCount);
 }
 
-const QVector<WorldView::NativeOutputRenderLine> &WorldView::nativeOutputRenderLines() const
+const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() const
 {
 	enum class RuntimeRebuildReason
 	{
@@ -5272,7 +5297,7 @@ const QVector<WorldView::NativeOutputRenderLine> &WorldView::nativeOutputRenderL
 		rebuildNativeRenderCacheFromLineEntries(m_nativeStandaloneOutputLines, false);
 	};
 
-	auto fullRebuildFromRuntime = [this](const QVector<WorldRuntime::LineEntry> &runtimeLines)
+	auto fullRebuildFromRuntime = [this](const auto &runtimeLines)
 	{
 		m_nativeRuntimeTailRestitchPending     = false;
 		m_nativeRuntimeLineRestitchIndex       = -1;
@@ -5292,7 +5317,7 @@ const QVector<WorldView::NativeOutputRenderLine> &WorldView::nativeOutputRenderL
 			fullRebuildFromStandalone();
 		return finalizeNativeOutputRenderLines();
 	}
-	const QVector<WorldRuntime::LineEntry> &runtimeLines = m_runtime->lines();
+	const auto &runtimeLines = m_runtime->lines();
 	if (m_nativeRenderLineCacheValid && !m_nativeRenderLineCacheFromRuntime)
 	{
 		// Recover from stale pinned state: if runtime lines exist but the pinned
@@ -6031,7 +6056,7 @@ const QVector<WorldView::NativeOutputRenderLine> &WorldView::nativeOutputRenderL
 		m_nativeRangeRestitchDiagDroppedMax = qMax(m_nativeRangeRestitchDiagDroppedMax, droppedNativeCount);
 #endif
 
-		QVector<NativeOutputRenderLine> preservedSuffix;
+		NativeOutputRenderLines preservedSuffix;
 		if (preserveSuffix && suffixRenderIndex < m_nativeRenderLineCache.size())
 		{
 			preservedSuffix.reserve(m_nativeRenderLineCache.size() - suffixRenderIndex);
@@ -6488,7 +6513,7 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	if (!nativeOutputInteractionActive() || !view || !view->viewport())
 		return false;
 
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return false;
 
@@ -6515,7 +6540,7 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	const qreal effectiveLineAdvance =
 	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : lineAdvance;
 	qreal     docY = m_nativeLayoutCumulativeHeights.size() > lines.size()
-	                     ? m_nativeLayoutCumulativeHeights.at(lines.size())
+	                     ? nativeLayoutCumulativeHeightAt(lines.size())
 	                     : 0.0;
 
 	const int nativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
@@ -6539,23 +6564,24 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 			effectiveScrollY = qBound(0, scrollY, nativeMaxScroll);
 	}
 
-	const qreal yDoc       = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
-	int         lineIndex  = sizeToInt(lines.size()) - 1;
-	qreal       lineY      = 0.0;
-	qreal       lineYEnd   = docY;
-	const auto  firstAbove = std::upper_bound(m_nativeLayoutCumulativeHeights.cbegin() + 1,
-	                                          m_nativeLayoutCumulativeHeights.cend(), yDoc);
+	const qreal yDoc      = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
+	int         lineIndex = sizeToInt(lines.size()) - 1;
+	qreal       lineY     = 0.0;
+	qreal       lineYEnd  = docY;
+	const auto  firstAbove =
+	    std::upper_bound(m_nativeLayoutCumulativeHeights.cbegin() + 1, m_nativeLayoutCumulativeHeights.cend(),
+	                     yDoc + m_nativeLayoutCumulativeHeightOrigin);
 	lineIndex = qBound(0, static_cast<int>(firstAbove - m_nativeLayoutCumulativeHeights.cbegin()) - 1,
 	                   sizeToInt(lines.size()) - 1);
-	lineY     = m_nativeLayoutCumulativeHeights.at(lineIndex);
-	lineYEnd  = m_nativeLayoutCumulativeHeights.at(lineIndex + 1);
+	lineY     = nativeLayoutCumulativeHeightAt(lineIndex);
+	lineYEnd  = nativeLayoutCumulativeHeightAt(lineIndex + 1);
 	if (allowCacheBuild &&
 	    ensureNativeLayoutRange(lines, qMax(0, lineIndex - 2),
 	                            qMin(sizeToInt(lines.size()) - 1, lineIndex + 2), wrapWidthPixels,
 	                            localWrapWidthPixels, lineSpacing, layoutFont))
 	{
 		docY                             = m_nativeLayoutCumulativeHeights.size() > lines.size()
-		                                       ? m_nativeLayoutCumulativeHeights.at(lines.size())
+		                                       ? nativeLayoutCumulativeHeightAt(lines.size())
 		                                       : 0.0;
 		const int updatedNativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
 		if (updatedNativeMaxScroll > 0)
@@ -6571,12 +6597,13 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 		}
 		const qreal updatedYDoc       = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
 		const auto  updatedFirstAbove = std::upper_bound(m_nativeLayoutCumulativeHeights.cbegin() + 1,
-		                                                 m_nativeLayoutCumulativeHeights.cend(), updatedYDoc);
+		                                                 m_nativeLayoutCumulativeHeights.cend(),
+		                                                 updatedYDoc + m_nativeLayoutCumulativeHeightOrigin);
 		lineIndex =
 		    qBound(0, static_cast<int>(updatedFirstAbove - m_nativeLayoutCumulativeHeights.cbegin()) - 1,
 		           sizeToInt(lines.size()) - 1);
-		lineY    = m_nativeLayoutCumulativeHeights.at(lineIndex);
-		lineYEnd = m_nativeLayoutCumulativeHeights.at(lineIndex + 1);
+		lineY    = nativeLayoutCumulativeHeightAt(lineIndex);
+		lineYEnd = nativeLayoutCumulativeHeightAt(lineIndex + 1);
 	}
 
 	const NativeOutputRenderLine &line = lines.at(lineIndex);
@@ -6680,7 +6707,7 @@ bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const Nat
 	if (!nativeOutputInteractionActive() || !view || !view->viewport())
 		return false;
 
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return false;
 
@@ -6713,7 +6740,7 @@ bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const Nat
 	const qreal effectiveLineAdvance =
 	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : fallbackLineAdvance;
 	const qreal docY            = m_nativeLayoutCumulativeHeights.size() > lines.size()
-	                                  ? m_nativeLayoutCumulativeHeights.at(lines.size())
+	                                  ? nativeLayoutCumulativeHeightAt(lines.size())
 	                                  : 0.0;
 	const int   nativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
 	int         scrollY         = 0;
@@ -6737,8 +6764,8 @@ bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const Nat
 			effectiveScrollY = qBound(0, scrollY, nativeMaxScroll);
 	}
 
-	const qreal                   lineTop    = m_nativeLayoutCumulativeHeights.at(lineIndex);
-	const qreal                   lineBottom = m_nativeLayoutCumulativeHeights.at(lineIndex + 1);
+	const qreal                   lineTop    = nativeLayoutCumulativeHeightAt(lineIndex);
+	const qreal                   lineBottom = nativeLayoutCumulativeHeightAt(lineIndex + 1);
 	const qreal                   lineHeight = qMax<qreal>(1.0, lineBottom - lineTop);
 	const NativeOutputRenderLine &line       = lines.at(lineIndex);
 
@@ -6796,7 +6823,7 @@ bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const Nat
 void WorldView::scrollNativeOutputRangeIntoView(const WrapTextBrowser *view, int firstLine,
                                                 int lastLine) const
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty() || !view || !view->viewport())
 		return;
 
@@ -6827,9 +6854,9 @@ void WorldView::scrollNativeOutputRangeIntoView(const WrapTextBrowser *view, int
 	if (lastLine + 1 >= m_nativeLayoutCumulativeHeights.size())
 		return;
 
-	const int rangeTop = qMax(0, static_cast<int>(std::floor(m_nativeLayoutCumulativeHeights.at(firstLine))));
+	const int rangeTop = qMax(0, static_cast<int>(std::floor(nativeLayoutCumulativeHeightAt(firstLine))));
 	const int rangeBottom =
-	    qMax(rangeTop + 1, static_cast<int>(std::ceil(m_nativeLayoutCumulativeHeights.at(lastLine + 1))));
+	    qMax(rangeTop + 1, static_cast<int>(std::ceil(nativeLayoutCumulativeHeightAt(lastLine + 1))));
 
 	const int currentTop    = bar->value();
 	const int pageStep      = qMax(1, bar->pageStep());
@@ -6972,7 +6999,7 @@ void WorldView::clearNativeOutputSelection(const bool notify)
 		applyResolvedOutputSelection(false, 0, 0, 0, 0);
 }
 
-void WorldView::applyPendingNativeSelectionHeadTrim(const QVector<NativeOutputRenderLine> &lines)
+void WorldView::applyPendingNativeSelectionHeadTrim(const NativeOutputRenderLines &lines)
 {
 	const int trimCount = m_nativeSelectionPendingHeadTrimLines;
 	if (trimCount <= 0)
@@ -7038,7 +7065,7 @@ void WorldView::clearNativeSelectionIfOutsideVisibleViewport(const WrapTextBrows
 		return;
 	}
 
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 	{
 		clearNativeOutputSelection(true);
@@ -7054,7 +7081,7 @@ void WorldView::setNativeOutputSelection(const WrapTextBrowser      *sourceView,
                                          const NativeOutputPosition &anchor,
                                          const NativeOutputPosition &cursor, const bool dragging)
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty() || !sourceView)
 	{
 		clearNativeOutputSelection(true);
@@ -7129,7 +7156,7 @@ bool WorldView::nativeOutputSelectionBounds(int &startLine, int &startColumn, in
 	    (!m_scrollbackSplitActive || !m_liveOutput || !m_liveOutput->isVisible()))
 		return false;
 
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return false;
 	const_cast<WorldView *>(this)->applyPendingNativeSelectionHeadTrim(lines);
@@ -7168,7 +7195,7 @@ QString WorldView::nativeOutputSelectionText() const
 	if (!nativeOutputSelectionBounds(startLine, startColumn, endLine, endColumn))
 		return {};
 
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return {};
 
@@ -7196,7 +7223,7 @@ QString WorldView::nativeOutputSelectionHtml() const
 	if (!nativeOutputSelectionBounds(startLine, startColumn, endLine, endColumn))
 		return {};
 
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return {};
 
@@ -7387,7 +7414,7 @@ bool WorldView::handleNativeOutputMouseEvent(const QEvent *event, const QWidget 
 			return false;
 		cacheWordUnderMouse(hit, textHit);
 
-		const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+		const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 		if (hit.line < 0 || hit.line >= lines.size())
 			return false;
 		const QString text = lines.at(hit.line).text;
@@ -7521,7 +7548,7 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 	if (renderCacheNeedsSync)
 		const_cast<WorldView *>(this)->requestNativeRuntimeOutputPresentationSync(false, false);
 
-	const QVector<NativeOutputRenderLine> &lines =
+	const NativeOutputRenderLines &lines =
 	    renderCacheNeedsSync ? m_nativeRenderLineCache : finalizeNativeOutputRenderLines();
 	const bool diagnosticsEnabled = nativeCanvasDiagnosticsEnabled();
 	if (diagnosticsEnabled)
@@ -7631,7 +7658,7 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 	const qreal effectiveLineAdvance =
 	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : fallbackLineAdvance;
 	qreal     docY = m_nativeLayoutCumulativeHeights.size() > lines.size()
-	                     ? m_nativeLayoutCumulativeHeights.at(lines.size())
+	                     ? nativeLayoutCumulativeHeightAt(lines.size())
 	                     : 0.0;
 	const int totalVisualRows =
 	    effectiveLineAdvance > 0.0 ? qMax(0, static_cast<int>(std::round(docY / effectiveLineAdvance))) : 0;
@@ -7682,13 +7709,13 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 		auto firstVisibleIt =
 		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
 		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleTop);
+		                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
 		int firstVisibleLine =
 		    qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 		auto lastVisibleIt =
 		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
 		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleBottom);
+		                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
 		int lastVisibleLine = qMin(sizeToInt(lines.size()) - 1,
 		                           sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 		if (firstVisibleLine > lastVisibleLine)
@@ -7703,7 +7730,7 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 		                            localWrapWidthPixels, lineSpacingSetting, layoutFont))
 		{
 			docY             = m_nativeLayoutCumulativeHeights.size() > lines.size()
-			                       ? m_nativeLayoutCumulativeHeights.at(lines.size())
+			                       ? nativeLayoutCumulativeHeightAt(lines.size())
 			                       : 0.0;
 			nativeMaxScroll  = qMax(0, static_cast<int>(std::ceil(docY)) - pane.textRect.height());
 			effectiveScrollY = nativeMaxScroll > 0 ? qBound(0, pane.scrollY, nativeMaxScroll) : 0;
@@ -7714,21 +7741,21 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 			firstVisibleIt =
 			    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
 			                                                   m_nativeLayoutCumulativeHeights.cend()),
-			                             visibleTop);
+			                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
 			firstVisibleLine =
 			    qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 			lastVisibleIt =
 			    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
 			                                                   m_nativeLayoutCumulativeHeights.cend()),
-			                             visibleBottom);
+			                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
 			lastVisibleLine = qMin(sizeToInt(lines.size()) - 1,
 			                       sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
 		}
 		for (int i = firstVisibleLine; i <= lastVisibleLine; ++i)
 		{
 			const NativeOutputRenderLine &line        = lines.at(i);
-			const qreal                   lineTop     = m_nativeLayoutCumulativeHeights.at(i);
-			const qreal                   lineBottom  = m_nativeLayoutCumulativeHeights.at(i + 1);
+			const qreal                   lineTop     = nativeLayoutCumulativeHeightAt(i);
+			const qreal                   lineBottom  = nativeLayoutCumulativeHeightAt(i + 1);
 			const qreal                   lineOpacity = qBound(0.0, line.opacity, 1.0);
 			const int                     lineY       = static_cast<int>(
 			    std::floor(static_cast<qreal>(pane.textRect.top() - effectiveScrollY) + lineTop));
@@ -7991,7 +8018,7 @@ void WorldView::markNativeRuntimeRangeRestitchPending(const int runtimeLineIndex
 const WorldView::NativeOutputRenderLines &
 WorldView::synchronizeNativeRuntimeOutputPresentation(const bool allowLayoutBuild, const bool followTail)
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	syncNativeOutputScrollBarsFromLayout(lines, allowLayoutBuild);
 	if (followTail && !m_frozen)
 	{
@@ -8027,7 +8054,7 @@ void WorldView::requestNativeRuntimeOutputPresentationSync(const bool allowLayou
 		    that->m_nativeRuntimeOutputPresentationQueued          = false;
 		    that->m_nativeRuntimeOutputPresentationNeedsLayoutSync = false;
 		    that->m_nativeRuntimeOutputPresentationFollowTail      = false;
-		    const QVector<NativeOutputRenderLine> &lines =
+		    const NativeOutputRenderLines &lines =
 		        that->synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, followTail);
 #ifndef NDEBUG
 		    if (that->m_nativeRangeRestitchDiagCount > 0)
@@ -8055,7 +8082,7 @@ void WorldView::requestNativeRuntimeOutputPresentationSync(const bool allowLayou
 		m_nativeRuntimeOutputPresentationQueued          = false;
 		m_nativeRuntimeOutputPresentationNeedsLayoutSync = false;
 		m_nativeRuntimeOutputPresentationFollowTail      = false;
-		const QVector<NativeOutputRenderLine> &lines =
+		const NativeOutputRenderLines &lines =
 		    synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, followTail);
 #ifndef NDEBUG
 		if (m_nativeRangeRestitchDiagCount > 0)
@@ -8131,7 +8158,7 @@ void WorldView::requestOutputScrollToEnd(const bool allowLayoutBuild)
 			                             .arg(that->m_scrollbackSplitActive ? QStringLiteral("1")
 			                                                                : QStringLiteral("0"));
 		    }
-		    const QVector<NativeOutputRenderLine> &lines =
+		    const NativeOutputRenderLines &lines =
 		        that->synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, true);
 		    that->requestNativeOutputPresentationRepaint(true, lines);
 	    },
@@ -8140,7 +8167,7 @@ void WorldView::requestOutputScrollToEnd(const bool allowLayoutBuild)
 	{
 		m_scrollToEndQueued          = false;
 		m_scrollToEndNeedsLayoutSync = false;
-		const QVector<NativeOutputRenderLine> &lines =
+		const NativeOutputRenderLines &lines =
 		    synchronizeNativeRuntimeOutputPresentation(allowLayoutBuild, true);
 		requestNativeOutputPresentationRepaint(true, lines);
 	}
@@ -8490,8 +8517,8 @@ void WorldView::echoInputText(const QString &text)
 
 QStringList WorldView::outputLines() const
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
-	QStringList                            result;
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
+	QStringList                    result;
 	result.reserve(lines.size());
 	for (const NativeOutputRenderLine &line : lines)
 		result.push_back(line.text);
@@ -8603,7 +8630,7 @@ bool WorldView::isAtBufferEnd() const
 
 void WorldView::selectOutputLine(int zeroBasedLine) const
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return;
 
@@ -8615,7 +8642,7 @@ void WorldView::selectOutputLine(int zeroBasedLine) const
 
 void WorldView::selectOutputRange(int zeroBasedLine, int startColumn, int endColumn) const
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return;
 
@@ -8652,10 +8679,9 @@ void WorldView::selectOutputRange(int zeroBasedLine, int startColumn, int endCol
 	if (zeroBasedLine + 1 >= m_nativeLayoutCumulativeHeights.size())
 		return;
 
-	const int lineTop =
-	    qMax(0, static_cast<int>(std::floor(m_nativeLayoutCumulativeHeights.at(zeroBasedLine))));
+	const int lineTop = qMax(0, static_cast<int>(std::floor(nativeLayoutCumulativeHeightAt(zeroBasedLine))));
 	const int lineBottom =
-	    qMax(lineTop + 1, static_cast<int>(std::ceil(m_nativeLayoutCumulativeHeights.at(zeroBasedLine + 1))));
+	    qMax(lineTop + 1, static_cast<int>(std::ceil(nativeLayoutCumulativeHeightAt(zeroBasedLine + 1))));
 
 	const int currentTop    = bar->value();
 	const int pageStep      = qMax(1, bar->pageStep());
@@ -8680,7 +8706,7 @@ void WorldView::selectOutputRange(int zeroBasedLine, int startColumn, int endCol
 
 void WorldView::setOutputSelection(int startLine, int endLine, int startColumn, int endColumn) const
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return;
 
@@ -8745,10 +8771,10 @@ bool WorldView::doOutputFind(bool again)
 	if (!m_outputFind)
 		m_outputFind.reset(new OutputFindState());
 
-	OutputFindState                       &state      = *m_outputFind;
-	const QVector<NativeOutputRenderLine> &lines      = nativeOutputRenderLines();
-	const int                              totalLines = sizeToInt(lines.size());
-	auto                                   lineTextAt = [&lines](const int zeroBasedLine)
+	OutputFindState               &state      = *m_outputFind;
+	const NativeOutputRenderLines &lines      = nativeOutputRenderLines();
+	const int                      totalLines = sizeToInt(lines.size());
+	auto                           lineTextAt = [&lines](const int zeroBasedLine)
 	{
 		if (zeroBasedLine < 0 || zeroBasedLine >= lines.size())
 			return QString{};
@@ -9039,7 +9065,7 @@ QString WorldView::wordUnderCursor() const
 
 QString WorldView::wordAtNativeOutputPosition(const NativeOutputPosition &position) const
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (position.line < 0 || position.line >= lines.size())
 		return {};
 	const QString text = lines.at(position.line).text;
@@ -9369,8 +9395,8 @@ QString WorldView::inputSelectionText() const
 
 QString WorldView::outputPlainText() const
 {
-	const QVector<NativeOutputRenderLine> &lines = nativeOutputRenderLines();
-	QStringList                            joined;
+	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
+	QStringList                    joined;
 	joined.reserve(lines.size());
 	for (const NativeOutputRenderLine &line : lines)
 		joined.push_back(line.text);
@@ -9515,7 +9541,7 @@ void WorldView::appendOutputTextInternal(const QString &text, bool newLine, bool
 		else
 			m_runtime->addLine(text, recordedFlags, displaySpans, newLine);
 
-		const QVector<WorldRuntime::LineEntry> &lines = m_runtime->lines();
+		const auto &lines = m_runtime->lines();
 		if (!lines.isEmpty())
 		{
 			displayEntry = lines.last();
@@ -9767,7 +9793,7 @@ void WorldView::clearOutputBuffer()
 	requestDrawOutputWindowNotification();
 }
 
-void WorldView::restoreOutputFromPersistedLines(const QVector<WorldRuntime::LineEntry> &lines)
+void WorldView::restoreOutputFromPersistedLines(const IndexedRingBuffer<WorldRuntime::LineEntry> &lines)
 {
 	stopIncrementalHyperlinkRestyle();
 	m_pendingOutput.clear();
@@ -9817,6 +9843,16 @@ void WorldView::restoreOutputFromPersistedLines(const QVector<WorldRuntime::Line
 	primeNativeOutputCaches();
 	requestDrawOutputWindowNotification();
 	requestNativeOutputRepaint();
+}
+
+void WorldView::restoreOutputFromPersistedLines(const QVector<WorldRuntime::LineEntry> &lines)
+{
+	restoreOutputFromPersistedLines(IndexedRingBuffer<WorldRuntime::LineEntry>(lines));
+}
+
+void WorldView::rebuildOutputFromLines(const IndexedRingBuffer<WorldRuntime::LineEntry> &lines)
+{
+	restoreOutputFromPersistedLines(lines);
 }
 
 void WorldView::rebuildOutputFromLines(const QVector<WorldRuntime::LineEntry> &lines)
@@ -11686,7 +11722,7 @@ bool WorldView::fadeRebuildNeededNow() const
 	if (!m_runtime || m_fadeOutputBufferAfterSeconds <= 0 || m_fadeOutputSeconds <= 0 || m_frozen)
 		return false;
 
-	const QVector<WorldRuntime::LineEntry> &lines = m_runtime->lines();
+	const auto &lines = m_runtime->lines();
 	if (lines.isEmpty())
 		return false;
 
@@ -11785,16 +11821,16 @@ void WorldView::updateLineInformationTooltip(const QWidget *watched, const QMous
 		return;
 	}
 
-	const QVector<NativeOutputRenderLine> &renderLines = nativeOutputRenderLines();
+	const NativeOutputRenderLines &renderLines = nativeOutputRenderLines();
 	if (hit.line < 0 || hit.line >= renderLines.size())
 	{
 		hideLineInfoTooltip();
 		return;
 	}
 
-	const NativeOutputRenderLine           &renderLine   = renderLines.at(hit.line);
-	const QVector<WorldRuntime::LineEntry> &runtimeLines = m_runtime->lines();
-	const WorldRuntime::LineEntry          *resolvedLine = nullptr;
+	const NativeOutputRenderLine  &renderLine   = renderLines.at(hit.line);
+	const auto                    &runtimeLines = m_runtime->lines();
+	const WorldRuntime::LineEntry *resolvedLine = nullptr;
 	if (renderLine.firstRuntimeLineNumber > 0)
 	{
 		const int runtimeIndex = findRuntimeLineIndexByNumberNear(
@@ -13544,8 +13580,8 @@ bool WorldView::handleTabCompletionKeyPress()
 			return false;
 		}
 
-		const QVector<WorldRuntime::LineEntry> &lines     = m_runtime->lines();
-		int                                     startLine = sizeToInt(lines.size()) - 1;
+		const auto &lines     = m_runtime->lines();
+		int         startLine = sizeToInt(lines.size()) - 1;
 		if (continueCycle)
 		{
 			if (lastSource >= 0)

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -83,8 +83,7 @@
 
 namespace
 {
-	constexpr const char *kWorldOutputAccessibleProperty                  = "qmud_world_output_widget";
-	constexpr qreal       kNativeLayoutCumulativeOriginNormalizeThreshold = 1.0e12;
+	constexpr const char *kWorldOutputAccessibleProperty = "qmud_world_output_widget";
 
 	int                   sizeToInt(const qsizetype value)
 	{
@@ -311,6 +310,22 @@ namespace
 			seed *= 1099511628211ULL;
 		}
 		return hashCombine(seed, static_cast<quint64>(text.size()));
+	}
+
+	quint64 nativeLayoutContentSalt(const quint64 styleKey, const int lineSpacingSetting,
+	                                const QFont &layoutFont)
+	{
+		quint64 salt = styleKey;
+		salt         = hashCombine(salt, hashStringContent(layoutFont.toString()));
+		salt         = hashCombine(salt, static_cast<quint64>(lineSpacingSetting));
+		return salt;
+	}
+
+	quint64 nativeLayoutLineCacheHash(const quint64 visualHash, const int effectiveWrapWidth,
+	                                  const quint64 layoutContentSalt)
+	{
+		return hashCombine(hashCombine(visualHash, static_cast<quint64>(effectiveWrapWidth)),
+		                   layoutContentSalt);
 	}
 
 	bool isActionLinkType(const int actionType)
@@ -2523,11 +2538,11 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLin
 	const qreal effectiveLineAdvance = (lines.isEmpty() || m_nativeLayoutCachedLineAdvance <= 0.0)
 	                                       ? fallbackLineAdvance
 	                                       : m_nativeLayoutCachedLineAdvance;
-	const qreal docY          = (lines.isEmpty() || m_nativeLayoutCumulativeHeights.size() <= lines.size())
-	                                ? 0.0
-	                                : nativeLayoutCumulativeHeightAt(lines.size());
-	const int   contentHeight = qMax(0, static_cast<int>(std::ceil(docY)));
-	const int   lineStep      = qMax(1, static_cast<int>(std::round(effectiveLineAdvance)));
+	const qreal docY                 = (lines.isEmpty() || m_nativeLayoutHeightIndex.size() != lines.size())
+	                                       ? 0.0
+	                                       : m_nativeLayoutHeightIndex.totalHeight();
+	const int   contentHeight        = qMax(0, static_cast<int>(std::ceil(docY)));
+	const int   lineStep             = qMax(1, static_cast<int>(std::round(effectiveLineAdvance)));
 
 	{
 		QScopedValueRollback<bool> scrollSyncGuard(m_nativeScrollSyncInPaint, true);
@@ -2559,8 +2574,8 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLin
 			        m_nativePrimaryPaintState.visibleLineTops.size() &&
 			    m_nativePrimaryPaintState.visibleLineKeys.size() ==
 			        m_nativePrimaryPaintState.visibleFirstRuntimeLineNumbers.size() &&
-			    m_nativeLayoutRuntimeLineKeys.size() == lines.size() &&
-			    m_nativeLayoutCumulativeHeights.size() == lines.size() + 1)
+			    m_nativeLayoutSlots.size() == lines.size() &&
+			    m_nativeLayoutHeightIndex.size() == lines.size())
 			{
 				const int headTrimCount =
 				    (m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision)
@@ -2570,14 +2585,13 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLin
 				                                                         const quint64 anchorKey,
 				                                                         const qint64 anchorRuntimeLineNumber)
 				{
-					if (m_nativeLayoutRuntimeLineKeys.isEmpty())
+					if (m_nativeLayoutSlots.isEmpty())
 						return -1;
 
 					auto matchesAnchor = [this, anchorKey](const int lineIndex)
 					{
-						return anchorKey != 0 && lineIndex >= 0 &&
-						       lineIndex < m_nativeLayoutRuntimeLineKeys.size() &&
-						       m_nativeLayoutRuntimeLineKeys.at(lineIndex) == anchorKey;
+						return anchorKey != 0 && lineIndex >= 0 && lineIndex < m_nativeLayoutSlots.size() &&
+						       m_nativeLayoutSlots.at(lineIndex).runtimeLineKey == anchorKey;
 					};
 					auto containsAnchorRuntimeLine = [&lines, anchorRuntimeLineNumber](const int lineIndex)
 					{
@@ -2586,14 +2600,14 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLin
 						                                                 anchorRuntimeLineNumber);
 					};
 
-					const int expectedIndex = qBound(0, oldLineIndex - headTrimCount,
-					                                 sizeToInt(m_nativeLayoutRuntimeLineKeys.size()) - 1);
+					const int expectedIndex =
+					    qBound(0, oldLineIndex - headTrimCount, sizeToInt(m_nativeLayoutSlots.size()) - 1);
 					if (matchesAnchor(expectedIndex))
 						return expectedIndex;
 					if (matchesAnchor(oldLineIndex))
 						return oldLineIndex;
 
-					const int searchRadius = qMin(256, sizeToInt(m_nativeLayoutRuntimeLineKeys.size()) - 1);
+					const int searchRadius = qMin(256, sizeToInt(m_nativeLayoutSlots.size()) - 1);
 					for (int distance = 1; distance <= searchRadius; ++distance)
 					{
 						const int beforeIndex = expectedIndex - distance;
@@ -2791,12 +2805,11 @@ bool WorldView::nativeOutputDeltaRepaintRect(const NativeOutputRenderLines &line
 	{
 		return false;
 	}
-	if (!m_nativeLayoutCacheValid || m_nativeLayoutCachedRenderRevision != m_nativeRenderLineCacheRevision ||
-	    m_nativeLayoutCumulativeDirtyFrom < sizeToInt(lines.size()))
+	if (!m_nativeLayoutCacheValid || m_nativeLayoutCachedRenderRevision != m_nativeRenderLineCacheRevision)
 	{
 		return false;
 	}
-	if (m_nativeLayoutCumulativeHeights.size() <= lines.size())
+	if (m_nativeLayoutHeightIndex.size() != lines.size())
 		return false;
 
 	int       firstDirtyLine = -1;
@@ -2807,7 +2820,9 @@ bool WorldView::nativeOutputDeltaRepaintRect(const NativeOutputRenderLines &line
 	case NativeRenderCacheDeltaKind::TailRemove:
 	{
 		const int oldLineCount = qBound(0, m_nativeRenderCacheDelta.oldLineCount, lineCount);
-		firstDirtyLine         = qMax(0, oldLineCount - (m_nativeRenderCacheDelta.tailLineMutated ? 1 : 0));
+		firstDirtyLine = m_nativeRenderCacheDelta.headLineMutated
+		                     ? 0
+		                     : qMax(0, oldLineCount - (m_nativeRenderCacheDelta.tailLineMutated ? 1 : 0));
 		break;
 	}
 	case NativeRenderCacheDeltaKind::HeadTrimTailAppend:
@@ -2823,7 +2838,7 @@ bool WorldView::nativeOutputDeltaRepaintRect(const NativeOutputRenderLines &line
 	if (firstDirtyLine < 0 || firstDirtyLine >= lineCount)
 		return false;
 
-	const qreal documentHeight      = nativeLayoutCumulativeHeightAt(lines.size());
+	const qreal documentHeight      = m_nativeLayoutHeightIndex.totalHeight();
 	auto        appendPaneDirtyRect = [&](const WrapTextBrowser *view)
 	{
 		if (!view || !view->isVisible())
@@ -2835,12 +2850,18 @@ bool WorldView::nativeOutputDeltaRepaintRect(const NativeOutputRenderLines &line
 		const int nativeMaxScroll = qMax(0, static_cast<int>(std::ceil(documentHeight)) - paneRect.height());
 		const int scrollY =
 		    view->verticalScrollBar() ? qBound(0, view->verticalScrollBar()->value(), nativeMaxScroll) : 0;
-		const qreal dirtyTop = static_cast<qreal>(paneRect.top()) +
-		                       nativeLayoutCumulativeHeightAt(firstDirtyLine) - static_cast<qreal>(scrollY);
-		const qreal dirtyBottom =
-		    static_cast<qreal>(paneRect.top()) + documentHeight - static_cast<qreal>(scrollY);
-		const int   dirtyY      = static_cast<int>(std::floor(dirtyTop)) - 2;
-		const int   dirtyHeight = qMax(1, static_cast<int>(std::ceil(dirtyBottom)) - dirtyY + 3);
+		const bool  dirtyTopExact = firstDirtyLine <= m_nativeLayoutExactPrefixCount;
+		const qreal dirtyTop      = dirtyTopExact ? static_cast<qreal>(paneRect.top()) +
+		                                                nativeLayoutCumulativeHeightAt(firstDirtyLine) -
+		                                                static_cast<qreal>(scrollY)
+		                                          : static_cast<qreal>(paneRect.top());
+		const auto  paneTop       = static_cast<qreal>(paneRect.top());
+		const auto  paneBottom    = static_cast<qreal>(paneRect.bottom() + 1);
+		if (dirtyTopExact && dirtyTop >= paneBottom)
+			return;
+		const qreal dirtyBottom = paneBottom;
+		const int dirtyY = dirtyTop <= paneTop ? paneRect.top() : static_cast<int>(std::floor(dirtyTop)) - 2;
+		const int dirtyHeight = qMax(1, static_cast<int>(std::ceil(dirtyBottom)) - dirtyY + 3);
 		const QRect paneDirtyRect =
 		    QRect(paneRect.left(), dirtyY, paneRect.width(), dirtyHeight).intersected(paneRect);
 		if (!paneDirtyRect.isEmpty())
@@ -2876,6 +2897,11 @@ bool WorldView::requestNativeOutputScrollAwarePresentationRepaint(
 {
 	if (!m_nativeOutputCanvas || !m_output || !m_output->isVisible() || lines.isEmpty())
 		return false;
+	if (m_nativeRenderCacheDelta.kind != NativeRenderCacheDeltaKind::TailAppend ||
+	    m_nativeRenderCacheDelta.headTrimCount > 0 || m_nativeRenderCacheDelta.headLineMutated)
+	{
+		return false;
+	}
 	if (m_scrollbackSplitActive || m_nativeOutputRepaintQueued || m_nativeOutputScrollBlitPending)
 		return false;
 	if (m_nativeRenderCacheDelta.revision != m_nativeRenderLineCacheRevision ||
@@ -2961,8 +2987,7 @@ bool WorldView::requestNativeOutputScrollAwarePresentationRepaint(
 	const QFont layoutFont           = m_output->font();
 	if (!nativeLayoutCacheReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting,
 	                               layoutFont) ||
-	    m_nativeLayoutCumulativeHeights.size() <= lines.size() ||
-	    m_nativeLayoutRowsExact.size() != lines.size())
+	    m_nativeLayoutHeightIndex.size() != lines.size() || m_nativeLayoutSlots.size() != lines.size())
 	{
 		return false;
 	}
@@ -2972,17 +2997,8 @@ bool WorldView::requestNativeOutputScrollAwarePresentationRepaint(
 	{
 		const auto visibleTop    = static_cast<qreal>(scrollY);
 		const auto visibleBottom = static_cast<qreal>(scrollY + paneHeight - 1);
-		auto       firstVisibleIt =
-		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
-		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
-		firstLine = qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
-		auto lastVisibleIt =
-		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
-		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
-		lastLine = qMin(sizeToInt(lines.size()) - 1,
-		                sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
+		firstLine                = nativeLayoutLineAtY(visibleTop);
+		lastLine                 = qMin(sizeToInt(lines.size()) - 1, nativeLayoutLineAtY(visibleBottom));
 		return firstLine <= lastLine;
 	};
 
@@ -3010,15 +3026,16 @@ bool WorldView::requestNativeOutputScrollAwarePresentationRepaint(
 	currentLineKeys.reserve(currentLastVisibleLine - currentFirstVisibleLine + 1);
 	currentLineTops.reserve(currentLastVisibleLine - currentFirstVisibleLine + 1);
 	currentLineBottoms.reserve(currentLastVisibleLine - currentFirstVisibleLine + 1);
+	qreal currentLineTop = nativeLayoutCumulativeHeightAt(currentFirstVisibleLine);
 	for (int i = currentFirstVisibleLine; i <= currentLastVisibleLine; ++i)
 	{
-		if (m_nativeLayoutRowsExact.at(i) == 0)
+		if (m_nativeLayoutSlots.at(i).rowsExact == 0)
 			return false;
-		currentLineKeys.push_back(nativeRuntimeLineKey(lines.at(i)));
-		currentLineTops.push_back(
-		    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i) - currentScrollY)));
-		currentLineBottoms.push_back(
-		    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i + 1) - currentScrollY)));
+		const qreal currentLineBottom = currentLineTop + m_nativeLayoutHeightIndex.heightAt(i);
+		currentLineKeys.push_back(m_nativeLayoutSlots.at(i).runtimeLineKey);
+		currentLineTops.push_back(static_cast<int>(std::round(currentLineTop - currentScrollY)));
+		currentLineBottoms.push_back(static_cast<int>(std::round(currentLineBottom - currentScrollY)));
+		currentLineTop = currentLineBottom;
 	}
 
 	int mappedLineCount = 0;
@@ -3152,6 +3169,7 @@ void WorldView::notifyAccessibleOutputPresented(const NativeOutputRenderLines &l
 	}
 
 	const bool exactTailAppend = m_accessibleOutputPendingTailAppend &&
+	                             !m_nativeRenderCacheDelta.headLineMutated &&
 	                             (m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::TailAppend ||
 	                              !m_nativeRenderLineCacheFromRuntime);
 	const bool suppressLiveAccessibilityEvents = m_runtime && m_runtime->hasMushReaderLiveSpeechOwner();
@@ -3219,23 +3237,13 @@ void WorldView::refreshNativeOutputPanePaintStateFromLayout(const WrapTextBrowse
 	QVector<qint64>  visibleLastRuntimeLineNumbers;
 	QVector<int>     visibleLineTops;
 	QVector<int>     visibleLineBottoms;
-	if (!lines.isEmpty() && m_nativeLayoutCumulativeHeights.size() > lines.size() &&
-	    m_nativeLayoutRowsExact.size() == lines.size())
+	if (!lines.isEmpty() && m_nativeLayoutHeightIndex.size() == lines.size() &&
+	    m_nativeLayoutSlots.size() == lines.size())
 	{
-		const auto visibleTop    = static_cast<qreal>(scrollY);
-		const auto visibleBottom = static_cast<qreal>(scrollY + paneRect.height() - 1);
-		auto       firstVisibleIt =
-		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
-		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
-		int firstVisibleLine =
-		    qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
-		auto lastVisibleIt =
-		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
-		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
-		int lastVisibleLine = qMin(sizeToInt(lines.size()) - 1,
-		                           sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
+		const auto visibleTop       = static_cast<qreal>(scrollY);
+		const auto visibleBottom    = static_cast<qreal>(scrollY + paneRect.height() - 1);
+		int        firstVisibleLine = nativeLayoutLineAtY(visibleTop);
+		int        lastVisibleLine  = qMin(sizeToInt(lines.size()) - 1, nativeLayoutLineAtY(visibleBottom));
 		if (firstVisibleLine <= lastVisibleLine)
 		{
 			visibleLineIndexes.reserve(lastVisibleLine - firstVisibleLine + 1);
@@ -3244,17 +3252,18 @@ void WorldView::refreshNativeOutputPanePaintStateFromLayout(const WrapTextBrowse
 			visibleLastRuntimeLineNumbers.reserve(lastVisibleLine - firstVisibleLine + 1);
 			visibleLineTops.reserve(lastVisibleLine - firstVisibleLine + 1);
 			visibleLineBottoms.reserve(lastVisibleLine - firstVisibleLine + 1);
+			qreal visibleLineTop = nativeLayoutCumulativeHeightAt(firstVisibleLine);
 			for (int i = firstVisibleLine; i <= lastVisibleLine; ++i)
 			{
 				const NativeOutputRenderLine &line = lines.at(i);
+				const qreal visibleLineBottom      = visibleLineTop + m_nativeLayoutHeightIndex.heightAt(i);
 				visibleLineIndexes.push_back(i);
-				visibleLineKeys.push_back(nativeRuntimeLineKey(line));
+				visibleLineKeys.push_back(m_nativeLayoutSlots.at(i).runtimeLineKey);
 				visibleFirstRuntimeLineNumbers.push_back(line.firstRuntimeLineNumber);
 				visibleLastRuntimeLineNumbers.push_back(line.lastRuntimeLineNumber);
-				visibleLineTops.push_back(
-				    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i) - visibleTop)));
-				visibleLineBottoms.push_back(
-				    static_cast<int>(std::round(nativeLayoutCumulativeHeightAt(i + 1) - visibleTop)));
+				visibleLineTops.push_back(static_cast<int>(std::round(visibleLineTop - visibleTop)));
+				visibleLineBottoms.push_back(static_cast<int>(std::round(visibleLineBottom - visibleTop)));
+				visibleLineTop = visibleLineBottom;
 			}
 		}
 	}
@@ -3569,7 +3578,8 @@ void WorldView::logAndResetNativeAppendDiagnostics() const
 #endif
 }
 
-void WorldView::extendNativeRuntimeLineRange(NativeOutputRenderLine &line, const qint64 lineNumber)
+void WorldView::extendNativeRuntimeLineRange(NativeOutputRenderLine &line, const qint64 lineNumber,
+                                             const qint64 runtimeLineIndex)
 {
 	if (lineNumber <= 0)
 		return;
@@ -3593,6 +3603,11 @@ void WorldView::extendNativeRuntimeLineRange(NativeOutputRenderLine &line, const
 		line.sourceRuntimeLineNumbers.push_back(lineNumber);
 	line.sourceRuntimeLineKey = nativeRuntimeLineKey(line.sourceRuntimeLineNumbers,
 	                                                 line.firstRuntimeLineNumber, line.lastRuntimeLineNumber);
+	if (runtimeLineIndex >= 0)
+	{
+		if (line.firstRuntimeLineIndex < 0)
+			line.firstRuntimeLineIndex = runtimeLineIndex;
+	}
 }
 
 bool WorldView::nativeRuntimeLineRangeContains(const NativeOutputRenderLine &line, const qint64 lineNumber)
@@ -3996,6 +4011,477 @@ QVector<QTextLayout::FormatRange> WorldView::buildNativeFormatRanges(const Nativ
 	return ranges;
 }
 
+qsizetype WorldView::NativeLayoutHeightIndex::size() const
+{
+	return m_heights.size();
+}
+
+bool WorldView::NativeLayoutHeightIndex::isEmpty() const
+{
+	return m_heights.isEmpty();
+}
+
+qreal WorldView::NativeLayoutHeightIndex::heightAt(const int index) const
+{
+	if (index < 0 || index >= sizeToInt(m_heights.size()))
+		return 0.0;
+	return m_heights.at(index);
+}
+
+qreal WorldView::NativeLayoutHeightIndex::prefixHeightAt(const int index) const
+{
+	const int heightCount  = sizeToInt(m_heights.size());
+	const int boundedIndex = qBound(0, index, heightCount);
+	if (boundedIndex <= 0)
+		return 0.0;
+	if (boundedIndex >= heightCount)
+		return totalHeight();
+
+	int       prefixLines = 0;
+	const int blockIndex  = blockForLine(boundedIndex - 1, &prefixLines);
+	qreal     height      = blockSumPrefix(blockIndex);
+	for (int i = prefixLines; i < boundedIndex; ++i)
+		height += m_heights.at(i);
+	return height;
+}
+
+qreal WorldView::NativeLayoutHeightIndex::totalHeight() const
+{
+	return blockSumPrefix(sizeToInt(m_blockSums.size()));
+}
+
+int WorldView::NativeLayoutHeightIndex::lineAtY(const qreal y) const
+{
+	if (m_heights.isEmpty())
+		return 0;
+
+	const int   heightCount = sizeToInt(m_heights.size());
+	const qreal boundedY    = qBound<qreal>(0.0, y, totalHeight());
+	qreal       prefix      = 0.0;
+	const int   block       = blockForY(boundedY, &prefix);
+	int         line        = blockLengthPrefix(block);
+	const int   blockEnd    = qMin(heightCount, line + m_blockLengths.at(block));
+	for (; line < blockEnd; ++line)
+	{
+		prefix += m_heights.at(line);
+		if (boundedY < prefix)
+			return line;
+	}
+	return heightCount - 1;
+}
+
+void WorldView::NativeLayoutHeightIndex::clear()
+{
+	m_heights.clear();
+	m_blockLengths.clear();
+	m_blockSums.clear();
+	m_lengthFenwick.clear();
+	m_sumFenwick.clear();
+}
+
+void WorldView::NativeLayoutHeightIndex::reserve(const qsizetype count)
+{
+	m_heights.reserve(count);
+}
+
+void WorldView::NativeLayoutHeightIndex::append(const qreal height)
+{
+	const qreal boundedHeight = qMax<qreal>(0.0, height);
+	m_heights.push_back(boundedHeight);
+	if (m_blockLengths.isEmpty() || m_blockLengths.constLast() >= kBlockSize)
+	{
+		m_blockLengths.push_back(1);
+		m_blockSums.push_back(boundedHeight);
+		const int blockCount = sizeToInt(m_blockLengths.size());
+		const int span       = blockCount & -blockCount;
+		int       lineSum    = 0;
+		qreal     heightSum  = 0.0;
+		for (int i = blockCount - span; i < blockCount; ++i)
+		{
+			lineSum += m_blockLengths.at(i);
+			heightSum += m_blockSums.at(i);
+		}
+		m_lengthFenwick.push_back(lineSum);
+		m_sumFenwick.push_back(heightSum);
+		return;
+	}
+
+	const int blockIndex = sizeToInt(m_blockLengths.size()) - 1;
+	++m_blockLengths[blockIndex];
+	m_blockSums[blockIndex] += boundedHeight;
+	addBlockLengthDelta(blockIndex, 1);
+	addBlockSumDelta(blockIndex, boundedHeight);
+}
+
+void WorldView::NativeLayoutHeightIndex::resize(const qsizetype count, const qreal defaultHeight)
+{
+	const qsizetype oldSize = m_heights.size();
+	if (count == oldSize)
+		return;
+
+	const qreal boundedDefaultHeight = qMax<qreal>(0.0, defaultHeight);
+	if (count < oldSize)
+	{
+		qsizetype remaining        = oldSize - count;
+		qsizetype currentSize      = oldSize;
+		bool      structureChanged = false;
+		while (remaining > 0 && !m_blockLengths.isEmpty())
+		{
+			const int  blockIndex  = sizeToInt(m_blockLengths.size()) - 1;
+			const int  blockLength = m_blockLengths.constLast();
+			const auto blockSize   = static_cast<qsizetype>(blockLength);
+			if (remaining >= blockSize)
+			{
+				remaining -= blockSize;
+				currentSize -= blockSize;
+				m_blockLengths.removeLast();
+				m_blockSums.removeLast();
+				structureChanged = true;
+				continue;
+			}
+
+			const int removeFromBlock = sizeToInt(remaining);
+			qreal     removedHeight   = 0.0;
+			for (int i = 0; i < removeFromBlock; ++i)
+				removedHeight += m_heights.at(currentSize - removeFromBlock + i);
+
+			m_blockLengths[blockIndex] -= removeFromBlock;
+			m_blockSums[blockIndex] -= removedHeight;
+			remaining = 0;
+			if (!structureChanged)
+			{
+				addBlockLengthDelta(blockIndex, -removeFromBlock);
+				addBlockSumDelta(blockIndex, -removedHeight);
+			}
+		}
+		m_heights.truncateBack(count);
+		if (structureChanged)
+			rebuildFenwick();
+		return;
+	}
+
+	m_heights.resize(count);
+	for (qsizetype i = oldSize; i < count; ++i)
+		m_heights[i] = boundedDefaultHeight;
+
+	qsizetype remaining        = count - oldSize;
+	bool      structureChanged = false;
+	while (remaining > 0)
+	{
+		if (m_blockLengths.isEmpty() || m_blockLengths.constLast() >= kBlockSize)
+		{
+			const int appendCount = sizeToInt(qMin<qsizetype>(remaining, kBlockSize));
+			m_blockLengths.push_back(appendCount);
+			m_blockSums.push_back(static_cast<qreal>(appendCount) * boundedDefaultHeight);
+			structureChanged = true;
+			remaining -= appendCount;
+		}
+		else
+		{
+			const int blockIndex = sizeToInt(m_blockLengths.size()) - 1;
+			const int appendCount =
+			    sizeToInt(qMin<qsizetype>(remaining, kBlockSize - m_blockLengths.constLast()));
+			const qreal addedHeight = static_cast<qreal>(appendCount) * boundedDefaultHeight;
+			m_blockLengths[blockIndex] += appendCount;
+			m_blockSums[blockIndex] += addedHeight;
+			if (!structureChanged)
+			{
+				addBlockLengthDelta(blockIndex, appendCount);
+				addBlockSumDelta(blockIndex, addedHeight);
+			}
+			remaining -= appendCount;
+		}
+	}
+	if (structureChanged)
+		rebuildFenwick();
+}
+
+void WorldView::NativeLayoutHeightIndex::assign(const qsizetype count, const qreal defaultHeight)
+{
+	m_heights.assign(count, qMax<qreal>(0.0, defaultHeight));
+	rebuildBlockSums();
+}
+
+void WorldView::NativeLayoutHeightIndex::removeFront(const qsizetype count)
+{
+	const qsizetype boundedCount = qBound<qsizetype>(0, count, m_heights.size());
+	if (boundedCount <= 0)
+		return;
+
+	qsizetype remaining        = boundedCount;
+	int       consumedLines    = 0;
+	bool      structureChanged = false;
+	int       fullBlockCount   = 0;
+	while (remaining > 0 && fullBlockCount < sizeToInt(m_blockLengths.size()))
+	{
+		const int firstBlockLength = m_blockLengths.at(fullBlockCount);
+		if (remaining < static_cast<qsizetype>(firstBlockLength))
+			break;
+		remaining -= firstBlockLength;
+		consumedLines += firstBlockLength;
+		++fullBlockCount;
+	}
+	if (fullBlockCount > 0)
+	{
+		m_blockLengths.remove(0, fullBlockCount);
+		m_blockSums.remove(0, fullBlockCount);
+		structureChanged = true;
+	}
+
+	if (remaining > 0 && !m_blockLengths.isEmpty())
+	{
+		const int removeFromBlock = sizeToInt(remaining);
+		qreal     removedHeight   = 0.0;
+		for (int i = 0; i < removeFromBlock; ++i)
+			removedHeight += m_heights.at(consumedLines + i);
+
+		m_blockLengths[0] -= removeFromBlock;
+		m_blockSums[0] -= removedHeight;
+		remaining = 0;
+
+		if (!structureChanged)
+		{
+			addBlockLengthDelta(0, -removeFromBlock);
+			addBlockSumDelta(0, -removedHeight);
+		}
+	}
+	m_heights.remove(0, boundedCount);
+	if (structureChanged)
+		rebuildFenwick();
+}
+
+void WorldView::NativeLayoutHeightIndex::replace(const int index, const int removeCount,
+                                                 const int insertCount, const qreal defaultHeight)
+{
+	const int oldSize            = sizeToInt(m_heights.size());
+	const int boundedIndex       = qBound(0, index, oldSize);
+	const int boundedRemoveCount = qBound(0, removeCount, oldSize - boundedIndex);
+	const int boundedInsertCount = qMax(0, insertCount);
+	if (boundedRemoveCount == 0 && boundedInsertCount == 0)
+		return;
+
+	int rebuildBlock = 0;
+	int rebuildLine  = 0;
+	if (!m_blockLengths.isEmpty() && oldSize > 0)
+	{
+		const int rebuildProbeLine = boundedIndex < oldSize ? boundedIndex : oldSize - 1;
+		rebuildBlock               = blockForLine(rebuildProbeLine, &rebuildLine);
+	}
+
+	m_heights.replace(boundedIndex, boundedRemoveCount, boundedInsertCount, qMax<qreal>(0.0, defaultHeight));
+	rebuildBlockSumsFromBlock(rebuildBlock, rebuildLine);
+}
+
+void WorldView::NativeLayoutHeightIndex::setHeight(const int index, const qreal height)
+{
+	if (index < 0 || index >= sizeToInt(m_heights.size()))
+		return;
+	const qreal boundedHeight = qMax<qreal>(0.0, height);
+	if (qFuzzyCompare(m_heights.at(index) + 1.0, boundedHeight + 1.0))
+		return;
+	const qreal delta    = boundedHeight - m_heights.at(index);
+	m_heights[index]     = boundedHeight;
+	int       prefix     = 0;
+	const int blockIndex = blockForLine(index, &prefix);
+	if (blockIndex >= 0 && blockIndex < sizeToInt(m_blockSums.size()))
+	{
+		m_blockSums[blockIndex] += delta;
+		addBlockSumDelta(blockIndex, delta);
+	}
+}
+
+void WorldView::NativeLayoutHeightIndex::setLayoutSlotHeightRange(
+    const int firstLine, const int lastLineExclusive, const IndexedRingBuffer<NativeLayoutSlot> &layoutSlots,
+    const qreal lineAdvance)
+{
+	const int lineCount = std::min(sizeToInt(m_heights.size()), sizeToInt(layoutSlots.size()));
+	if (lineCount <= 0 || m_blockLengths.isEmpty())
+		return;
+	const int boundedFirst = qBound(0, firstLine, lineCount);
+	const int boundedLast  = qBound(boundedFirst, lastLineExclusive, lineCount);
+	if (boundedLast <= boundedFirst)
+		return;
+
+	const qreal boundedLineAdvance = qMax<qreal>(0.0, lineAdvance);
+	int         blockFirstLine     = 0;
+	int         blockIndex         = blockForLine(boundedFirst, &blockFirstLine);
+	int         line               = boundedFirst;
+	while (line < boundedLast && blockIndex < sizeToInt(m_blockLengths.size()))
+	{
+		const int blockEnd   = qMin(boundedLast, blockFirstLine + m_blockLengths.at(blockIndex));
+		qreal     blockDelta = 0.0;
+		for (; line < blockEnd; ++line)
+		{
+			const qreal height =
+			    static_cast<qreal>(qMax(1, layoutSlots.at(line).visualRows)) * boundedLineAdvance;
+			const qreal boundedHeight = qMax<qreal>(0.0, height);
+			if (qFuzzyCompare(m_heights.at(line) + 1.0, boundedHeight + 1.0))
+				continue;
+			blockDelta += boundedHeight - m_heights.at(line);
+			m_heights[line] = boundedHeight;
+		}
+		if (!qFuzzyIsNull(blockDelta))
+		{
+			m_blockSums[blockIndex] += blockDelta;
+			addBlockSumDelta(blockIndex, blockDelta);
+		}
+		blockFirstLine = blockEnd;
+		++blockIndex;
+	}
+}
+
+void WorldView::NativeLayoutHeightIndex::swap(NativeLayoutHeightIndex &other) noexcept
+{
+	m_heights.swap(other.m_heights);
+	m_blockLengths.swap(other.m_blockLengths);
+	m_blockSums.swap(other.m_blockSums);
+	m_lengthFenwick.swap(other.m_lengthFenwick);
+	m_sumFenwick.swap(other.m_sumFenwick);
+}
+
+void WorldView::NativeLayoutHeightIndex::rebuildBlockSums()
+{
+	m_blockLengths.clear();
+	m_blockSums.clear();
+	const int heightCount = sizeToInt(m_heights.size());
+	int       line        = 0;
+	while (line < heightCount)
+	{
+		const int blockLength = qMin(kBlockSize, heightCount - line);
+		qreal     sum         = 0.0;
+		for (int i = line; i < line + blockLength; ++i)
+			sum += m_heights.at(i);
+		m_blockLengths.push_back(blockLength);
+		m_blockSums.push_back(sum);
+		line += blockLength;
+	}
+	rebuildFenwick();
+}
+
+void WorldView::NativeLayoutHeightIndex::rebuildBlockSumsFromBlock(const int firstBlock, const int firstLine)
+{
+	const int heightCount       = sizeToInt(m_heights.size());
+	const int boundedFirstBlock = qBound(0, firstBlock, sizeToInt(m_blockLengths.size()));
+	const int boundedFirstLine  = qBound(0, firstLine, heightCount);
+	m_blockLengths.resize(boundedFirstBlock);
+	m_blockSums.resize(boundedFirstBlock);
+
+	int line = boundedFirstLine;
+	while (line < heightCount)
+	{
+		const int blockLength = qMin(kBlockSize, heightCount - line);
+		qreal     sum         = 0.0;
+		for (int i = line; i < line + blockLength; ++i)
+			sum += m_heights.at(i);
+		m_blockLengths.push_back(blockLength);
+		m_blockSums.push_back(sum);
+		line += blockLength;
+	}
+	rebuildFenwick();
+}
+
+void WorldView::NativeLayoutHeightIndex::rebuildFenwick()
+{
+	m_lengthFenwick.assign(m_blockLengths.size(), 0);
+	m_sumFenwick.assign(m_blockSums.size(), 0.0);
+	const int blockCount = sizeToInt(m_blockLengths.size());
+	for (int blockIndex = 0; blockIndex < blockCount; ++blockIndex)
+	{
+		addBlockLengthDelta(blockIndex, m_blockLengths.at(blockIndex));
+		addBlockSumDelta(blockIndex, m_blockSums.at(blockIndex));
+	}
+}
+
+void WorldView::NativeLayoutHeightIndex::addBlockLengthDelta(const int blockIndex, const int delta)
+{
+	const int fenwickSize = sizeToInt(m_lengthFenwick.size());
+	for (int i = blockIndex + 1; i <= fenwickSize; i += i & -i)
+		m_lengthFenwick[i - 1] += delta;
+}
+
+void WorldView::NativeLayoutHeightIndex::addBlockSumDelta(const int blockIndex, const qreal delta)
+{
+	const int fenwickSize = sizeToInt(m_sumFenwick.size());
+	for (int i = blockIndex + 1; i <= fenwickSize; i += i & -i)
+		m_sumFenwick[i - 1] += delta;
+}
+
+int WorldView::NativeLayoutHeightIndex::blockLengthPrefix(const int blockCount) const
+{
+	int sum = 0;
+	for (int i = qBound(0, blockCount, sizeToInt(m_lengthFenwick.size())); i > 0; i -= i & -i)
+		sum += m_lengthFenwick.at(i - 1);
+	return sum;
+}
+
+qreal WorldView::NativeLayoutHeightIndex::blockSumPrefix(const int blockCount) const
+{
+	qreal sum = 0.0;
+	for (int i = qBound(0, blockCount, sizeToInt(m_sumFenwick.size())); i > 0; i -= i & -i)
+		sum += m_sumFenwick.at(i - 1);
+	return sum;
+}
+
+int WorldView::NativeLayoutHeightIndex::blockForLine(const int lineIndex, int *prefixLines) const
+{
+	if (prefixLines)
+		*prefixLines = 0;
+	if (m_blockLengths.isEmpty())
+		return 0;
+
+	const int boundedLine = qBound(0, lineIndex, sizeToInt(m_heights.size()) - 1);
+	int       block       = 0;
+	int       prefix      = 0;
+	int       bit         = 1;
+	const int fenwickSize = sizeToInt(m_lengthFenwick.size());
+	while ((bit << 1) <= fenwickSize)
+		bit <<= 1;
+	for (; bit > 0; bit >>= 1)
+	{
+		const int next = block + bit;
+		if (next <= fenwickSize && prefix + m_lengthFenwick.at(next - 1) <= boundedLine)
+		{
+			block = next;
+			prefix += m_lengthFenwick.at(next - 1);
+		}
+	}
+
+	const int boundedBlock = qMin(block, sizeToInt(m_blockLengths.size()) - 1);
+	if (prefixLines)
+		*prefixLines = blockLengthPrefix(boundedBlock);
+	return boundedBlock;
+}
+
+int WorldView::NativeLayoutHeightIndex::blockForY(const qreal y, qreal *prefixHeight) const
+{
+	if (prefixHeight)
+		*prefixHeight = 0.0;
+	if (m_blockSums.isEmpty())
+		return 0;
+
+	const qreal boundedY    = qMax<qreal>(0.0, y);
+	int         block       = 0;
+	qreal       prefix      = 0.0;
+	int         bit         = 1;
+	const int   fenwickSize = sizeToInt(m_sumFenwick.size());
+	while ((bit << 1) <= fenwickSize)
+		bit <<= 1;
+	for (; bit > 0; bit >>= 1)
+	{
+		const int next = block + bit;
+		if (next <= fenwickSize && prefix + m_sumFenwick.at(next - 1) <= boundedY)
+		{
+			block = next;
+			prefix += m_sumFenwick.at(next - 1);
+		}
+	}
+
+	const int boundedBlock = qMin(block, sizeToInt(m_blockSums.size()) - 1);
+	if (prefixHeight)
+		*prefixHeight = blockSumPrefix(boundedBlock);
+	return boundedBlock;
+}
+
 bool WorldView::nativeLayoutCacheReadyFor(const NativeOutputRenderLines &lines, const int wrapWidthPixels,
                                           const int localWrapWidthPixels, const int lineSpacingSetting,
                                           const QFont &layoutFont) const
@@ -4003,20 +4489,16 @@ bool WorldView::nativeLayoutCacheReadyFor(const NativeOutputRenderLines &lines, 
 	const qreal lineSpacingFactor = (100.0 + static_cast<qreal>(lineSpacingSetting)) / 100.0;
 	const qreal lineAdvance =
 	    static_cast<qreal>(qMax(1, QFontMetrics(layoutFont).lineSpacing())) * lineSpacingFactor;
-	const quint64 styleKey             = nativeLayoutStyleKey();
-	const bool    cacheDimensionsMatch = m_nativeLayoutCumulativeHeights.size() == lines.size() + 1 &&
-	                                     m_nativeLayoutVisualRows.size() == lines.size() &&
-	                                     m_nativeLayoutLineLayouts.size() == lines.size() &&
-	                                     m_nativeLayoutLineContentHashes.size() == lines.size() &&
-	                                     m_nativeLayoutRowsExact.size() == lines.size();
+	const quint64 styleKey = nativeLayoutStyleKey();
+	const bool    cacheDimensionsMatch =
+	    m_nativeLayoutHeightIndex.size() == lines.size() && m_nativeLayoutSlots.size() == lines.size();
 	return m_nativeLayoutCacheValid && cacheDimensionsMatch &&
 	       m_nativeLayoutCachedRenderRevision == m_nativeRenderLineCacheRevision &&
 	       m_nativeLayoutCachedWrapWidth == wrapWidthPixels &&
 	       m_nativeLayoutCachedLocalWrapWidth == localWrapWidthPixels &&
 	       m_nativeLayoutCachedLineSpacing == lineSpacingSetting &&
 	       m_nativeLayoutCachedStyleKey == styleKey && m_nativeLayoutCachedFont == layoutFont &&
-	       qFuzzyCompare(m_nativeLayoutCachedLineAdvance + 1.0, lineAdvance + 1.0) &&
-	       m_nativeLayoutCumulativeDirtyFrom >= sizeToInt(lines.size());
+	       qFuzzyCompare(m_nativeLayoutCachedLineAdvance + 1.0, lineAdvance + 1.0);
 }
 
 int WorldView::estimateNativeLineRows(const NativeOutputRenderLine &line, const int effectiveWrapWidth,
@@ -4118,62 +4600,75 @@ bool WorldView::ensureNativeLayoutRange(const NativeOutputRenderLines &lines, in
 	const qreal lineSpacingFactor = (100.0 + static_cast<qreal>(lineSpacingSetting)) / 100.0;
 	const qreal defaultLineAdvance =
 	    static_cast<qreal>(qMax(1, QFontMetrics(layoutFont).lineSpacing())) * lineSpacingFactor;
+	const quint64 layoutContentSalt =
+	    nativeLayoutContentSalt(nativeLayoutStyleKey(), lineSpacingSetting, layoutFont);
 
-	int firstHeightChangedLine = -1;
+	bool heightChanged = false;
 	for (int i = firstLine; i <= lastLine; ++i)
 	{
-		const int   previousRows = (i < m_nativeLayoutVisualRows.size()) ? m_nativeLayoutVisualRows.at(i) : 0;
-		const uchar previousExact = (i < m_nativeLayoutRowsExact.size()) ? m_nativeLayoutRowsExact.at(i) : 0;
-		const int   exactRows     = ensureNativeLineLayout(lines, i, wrapWidthPixels, localWrapWidthPixels,
-		                                                   defaultLineAdvance, layoutFont);
-		if (firstHeightChangedLine < 0 &&
-		    (previousRows != exactRows || (previousExact == 0 && previousRows <= 0)))
+		const bool  hasPreviousSlot = i < sizeToInt(m_nativeLayoutSlots.size());
+		const int   previousRows    = hasPreviousSlot ? m_nativeLayoutSlots.at(i).visualRows : 0;
+		const uchar previousExact   = hasPreviousSlot ? m_nativeLayoutSlots.at(i).rowsExact : 0;
+		const int   exactRows   = ensureNativeLineLayout(lines, i, wrapWidthPixels, localWrapWidthPixels,
+		                                                 defaultLineAdvance, layoutFont, layoutContentSalt);
+		const qreal exactHeight = static_cast<qreal>(qMax(1, exactRows)) * defaultLineAdvance;
+		if (!qFuzzyCompare(m_nativeLayoutHeightIndex.heightAt(i) + 1.0, exactHeight + 1.0))
 		{
-			firstHeightChangedLine = i;
+			m_nativeLayoutHeightIndex.setHeight(i, exactHeight);
+			heightChanged = true;
+		}
+		else if (previousRows != exactRows || (previousExact == 0 && previousRows <= 0))
+		{
+			heightChanged = true;
 		}
 	}
+	refreshNativeLayoutExactPrefixFrom(firstLine);
 
-	if (firstHeightChangedLine < 0)
-		return false;
+	return heightChanged;
+}
 
-	qreal docY = firstHeightChangedLine > 0 ? nativeLayoutCumulativeHeightAt(firstHeightChangedLine) : 0.0;
-	if (firstHeightChangedLine == 0 && !m_nativeLayoutCumulativeHeights.isEmpty())
-		setNativeLayoutCumulativeHeightAt(0, 0.0);
-	for (int i = firstHeightChangedLine; i < lines.size(); ++i)
+void WorldView::refreshNativeLayoutExactPrefixFrom(const int firstLine) const
+{
+	const int lineCount = sizeToInt(m_nativeLayoutSlots.size());
+	if (lineCount <= 0)
 	{
-		const int rows = (i < m_nativeLayoutVisualRows.size() && m_nativeLayoutVisualRows.at(i) > 0)
-		                     ? m_nativeLayoutVisualRows.at(i)
-		                     : 1;
-		docY += static_cast<qreal>(rows) * defaultLineAdvance;
-		if (i + 1 < m_nativeLayoutCumulativeHeights.size())
-			setNativeLayoutCumulativeHeightAt(i + 1, docY);
+		m_nativeLayoutExactPrefixCount = 0;
+		return;
 	}
-	m_nativeLayoutCumulativeDirtyFrom = sizeToInt(lines.size());
-	return true;
+
+	int exactPrefix = qBound(0, m_nativeLayoutExactPrefixCount, lineCount);
+	if (firstLine > exactPrefix)
+	{
+		m_nativeLayoutExactPrefixCount = exactPrefix;
+		return;
+	}
+
+	exactPrefix = qBound(0, firstLine, lineCount);
+	while (exactPrefix < lineCount && m_nativeLayoutSlots.at(exactPrefix).rowsExact != 0)
+		++exactPrefix;
+	m_nativeLayoutExactPrefixCount = exactPrefix;
 }
 
 int WorldView::ensureNativeLineLayout(const NativeOutputRenderLines &lines, const int index,
                                       const int wrapWidthPixels, const int localWrapWidthPixels,
-                                      const qreal defaultLineAdvance, const QFont &layoutFont) const
+                                      const qreal defaultLineAdvance, const QFont &layoutFont,
+                                      const quint64 layoutContentSalt) const
 {
-	if (index < 0 || index >= lines.size())
+	if (index < 0 || index >= sizeToInt(lines.size()))
 		return 1;
-	if (index >= m_nativeLayoutLineLayouts.size() || index >= m_nativeLayoutLineContentHashes.size() ||
-	    index >= m_nativeLayoutVisualRows.size() || index >= m_nativeLayoutRowsExact.size())
-	{
+	if (index >= sizeToInt(m_nativeLayoutSlots.size()))
 		return 1;
-	}
 
 	const NativeOutputRenderLine &line = lines.at(index);
 	const bool    hasLocalContent    = (line.flags & (WorldRuntime::LineNote | WorldRuntime::LineInput)) != 0;
 	const int     effectiveWrapWidth = hasLocalContent ? localWrapWidthPixels : wrapWidthPixels;
 	const quint64 visualHash         = line.visualHash != 0 ? line.visualHash : nativeLineContentHash(line);
-	const quint64 contentHash        = hashCombine(visualHash, static_cast<quint64>(effectiveWrapWidth));
-	if (const auto &cachedLayout = m_nativeLayoutLineLayouts.at(index);
-	    cachedLayout && m_nativeLayoutLineContentHashes.at(index) == contentHash)
+	const quint64 contentHash = nativeLayoutLineCacheHash(visualHash, effectiveWrapWidth, layoutContentSalt);
+	NativeLayoutSlot &slot    = m_nativeLayoutSlots[index];
+	if (const auto &cachedLayout = slot.lineLayout; cachedLayout && slot.lineContentHash == contentHash)
 	{
-		if (m_nativeLayoutRowsExact.at(index) != 0 && m_nativeLayoutVisualRows.at(index) > 0)
-			return m_nativeLayoutVisualRows.at(index);
+		if (slot.rowsExact != 0 && slot.visualRows > 0)
+			return slot.visualRows;
 
 		if (!cachedLayout->cacheEnabled())
 			cachedLayout->setCacheEnabled(true);
@@ -4194,19 +4689,19 @@ int WorldView::ensureNativeLineLayout(const NativeOutputRenderLines &lines, cons
 			++rowCount;
 		}
 		cachedLayout->endLayout();
-		rowCount                        = qMax(1, rowCount);
-		m_nativeLayoutVisualRows[index] = rowCount;
-		m_nativeLayoutRowsExact[index]  = 1;
+		rowCount        = qMax(1, rowCount);
+		slot.visualRows = rowCount;
+		slot.rowsExact  = 1;
 		++m_nativeLayoutRowMeasurements;
 		return rowCount;
 	}
 
 	if (line.text.isEmpty())
 	{
-		m_nativeLayoutLineLayouts[index].clear();
-		m_nativeLayoutLineContentHashes[index] = contentHash;
-		m_nativeLayoutVisualRows[index]        = 1;
-		m_nativeLayoutRowsExact[index]         = 1;
+		slot.lineLayout.clear();
+		slot.lineContentHash = contentHash;
+		slot.visualRows      = 1;
+		slot.rowsExact       = 1;
 		return 1;
 	}
 
@@ -4236,10 +4731,10 @@ int WorldView::ensureNativeLineLayout(const NativeOutputRenderLines &lines, cons
 	layout->endLayout();
 	rowCount = qMax(1, rowCount);
 
-	m_nativeLayoutLineLayouts[index]       = layout;
-	m_nativeLayoutLineContentHashes[index] = contentHash;
-	m_nativeLayoutVisualRows[index]        = rowCount;
-	m_nativeLayoutRowsExact[index]         = 1;
+	slot.lineLayout      = layout;
+	slot.lineContentHash = contentHash;
+	slot.visualRows      = rowCount;
+	slot.rowsExact       = 1;
 	++m_nativeLayoutRowMeasurements;
 	return rowCount;
 }
@@ -4266,13 +4761,10 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 	const bool layoutCacheKeyChanged = !cacheWasValid || wrapChanged || lineSpacingChanged || fontChanged ||
 	                                   styleChanged || lineAdvanceChanged;
 
-	const bool cacheDimensionsMatch = m_nativeLayoutCumulativeHeights.size() == lines.size() + 1 &&
-	                                  m_nativeLayoutVisualRows.size() == lines.size() &&
-	                                  m_nativeLayoutLineLayouts.size() == lines.size() &&
-	                                  m_nativeLayoutLineContentHashes.size() == lines.size() &&
-	                                  m_nativeLayoutRowsExact.size() == lines.size();
+	const bool cacheDimensionsMatch =
+	    m_nativeLayoutHeightIndex.size() == lines.size() && m_nativeLayoutSlots.size() == lines.size();
 	if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && !renderRevisionChanged &&
-	    cacheDimensionsMatch && m_nativeLayoutCumulativeDirtyFrom >= sizeToInt(lines.size()))
+	    cacheDimensionsMatch)
 	{
 		return;
 	}
@@ -4283,12 +4775,11 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 	{
 		const int oldSize       = qMax(0, m_nativeRenderCacheDelta.oldLineCount);
 		const int headTrimCount = qBound(0, m_nativeRenderCacheDelta.headTrimCount, oldSize);
-		if (headTrimCount > 0 && m_nativeLayoutVisualRows.size() == oldSize)
+		if (headTrimCount > 0 && sizeToInt(m_nativeLayoutSlots.size()) == oldSize)
 		{
 			qreal trimmedHeadDocY = -1.0;
-			if (m_nativeLayoutCumulativeHeights.size() == oldSize + 1 &&
-			    headTrimCount < m_nativeLayoutCumulativeHeights.size() &&
-			    m_nativeLayoutCumulativeDirtyFrom >= headTrimCount)
+			if (sizeToInt(m_nativeLayoutHeightIndex.size()) == oldSize &&
+			    headTrimCount <= sizeToInt(m_nativeLayoutHeightIndex.size()))
 			{
 				trimmedHeadDocY = qMax<qreal>(0.0, nativeLayoutCumulativeHeightAt(headTrimCount));
 			}
@@ -4301,7 +4792,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 				bool        haveExactRows  = true;
 				for (int i = 0; i < headTrimCount; ++i)
 				{
-					const int visualRows = m_nativeLayoutVisualRows.at(i);
+					const int visualRows = m_nativeLayoutSlots.at(i).visualRows;
 					if (visualRows <= 0)
 					{
 						haveExactRows = false;
@@ -4323,396 +4814,408 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 	auto runtimeLineKeyForLine = [](const NativeOutputRenderLine &line)
 	{ return nativeRuntimeLineKey(line); };
 
-	auto lineContentHashForWidth = [&](const NativeOutputRenderLine &line)
+	const quint64 layoutContentSalt       = nativeLayoutContentSalt(styleKey, lineSpacingSetting, layoutFont);
+	auto          lineContentHashForWidth = [&](const NativeOutputRenderLine &line)
 	{
 		const bool hasLocalContent = (line.flags & (WorldRuntime::LineNote | WorldRuntime::LineInput)) != 0;
 		const int  effectiveWrapWidth = hasLocalContent ? localWrapWidthPixels : wrapWidthPixels;
 		const quint64 visualHash      = line.visualHash != 0 ? line.visualHash : nativeLineContentHash(line);
-		return hashCombine(visualHash, static_cast<quint64>(effectiveWrapWidth));
+		return nativeLayoutLineCacheHash(visualHash, effectiveWrapWidth, layoutContentSalt);
 	};
 
-	auto refreshLayoutRuntimeLineKeys = [this, &lines, &runtimeLineKeyForLine]
+	auto resetLayoutLineCaches = [this](const qsizetype count)
 	{
-		m_nativeLayoutRuntimeLineKeys.resize(lines.size());
-		for (int i = 0; i < lines.size(); ++i)
+		m_nativeLayoutSlots.assign(count, NativeLayoutSlot{});
+		m_nativeLayoutExactPrefixCount = 0;
+	};
+
+	QVector<QPair<int, int>> dirtyHeightRanges;
+	QVector<QPair<int, int>> layoutInvalidationRanges;
+	auto                     mergeRanges = [](QVector<QPair<int, int>> &ranges)
+	{
+		if (ranges.size() < 2)
+			return;
+		std::ranges::sort(ranges, {}, &QPair<int, int>::first);
+		const int rangeCount = sizeToInt(ranges.size());
+		int       writeIndex = 0;
+		for (int readIndex = 1; readIndex < rangeCount; ++readIndex)
 		{
-			m_nativeLayoutRuntimeLineKeys[i] = runtimeLineKeyForLine(lines.at(i));
+			QPair<int, int>       &current = ranges[writeIndex];
+			const QPair<int, int> &next    = ranges.at(readIndex);
+			if (next.first <= current.second)
+			{
+				current.second = qMax(current.second, next.second);
+				continue;
+			}
+			++writeIndex;
+			if (writeIndex != readIndex)
+				ranges[writeIndex] = next;
+		}
+		ranges.resize(writeIndex + 1);
+	};
+	auto markHeightRangeDirty = [&dirtyHeightRanges](const int first, const int lastExclusive)
+	{
+		if (lastExclusive <= first)
+			return;
+		dirtyHeightRanges.push_back({first, lastExclusive});
+	};
+
+	auto invalidateLayoutSlots =
+	    [this, &layoutInvalidationRanges, &markHeightRangeDirty](const int first, const int lastExclusive)
+	{
+		const int boundedFirst = qBound(0, first, sizeToInt(m_nativeLayoutSlots.size()));
+		const int boundedLast  = qBound(boundedFirst, lastExclusive, sizeToInt(m_nativeLayoutSlots.size()));
+		if (boundedLast <= boundedFirst)
+			return;
+		layoutInvalidationRanges.push_back({boundedFirst, boundedLast});
+		markHeightRangeDirty(boundedFirst, boundedLast);
+		if (boundedFirst < m_nativeLayoutExactPrefixCount)
+			m_nativeLayoutExactPrefixCount = boundedFirst;
+	};
+
+	auto applyLayoutInvalidationRanges = [this, &dirtyHeightRanges, &layoutInvalidationRanges, &mergeRanges]
+	{
+		if (layoutInvalidationRanges.isEmpty())
+			return;
+		mergeRanges(layoutInvalidationRanges);
+		const int lineCount = sizeToInt(m_nativeLayoutSlots.size());
+		for (const QPair<int, int> &range : layoutInvalidationRanges)
+		{
+			const int boundedFirst = qBound(0, range.first, lineCount);
+			const int boundedLast  = qBound(boundedFirst, range.second, lineCount);
+			if (boundedLast > boundedFirst)
+				dirtyHeightRanges.push_back({boundedFirst, boundedLast});
 		}
 	};
 
-	auto dropLayoutHead = [this](const int requestedHeadTrimCount)
+	auto mergeDirtyHeightRanges = [&dirtyHeightRanges, &mergeRanges] { mergeRanges(dirtyHeightRanges); };
+
+	auto layoutDimensionsMatch = [this](const int expectedSize)
 	{
-		const int headTrimCount =
-		    qBound(0, requestedHeadTrimCount, sizeToInt(m_nativeLayoutVisualRows.size()));
+		return sizeToInt(m_nativeLayoutSlots.size()) == expectedSize &&
+		       sizeToInt(m_nativeLayoutHeightIndex.size()) == expectedSize;
+	};
+
+	auto lineCanReuseCachedLayout = [this, &lines, &lineContentHashForWidth](const int i)
+	{
+		if (i < 0 || i >= sizeToInt(lines.size()) || i >= sizeToInt(m_nativeLayoutSlots.size()) ||
+		    i >= sizeToInt(m_nativeLayoutHeightIndex.size()))
+		{
+			return false;
+		}
+
+		const NativeOutputRenderLine &line = lines.at(i);
+		const NativeLayoutSlot       &slot = m_nativeLayoutSlots.at(i);
+		const bool                    exactLineHasLayout =
+		    slot.rowsExact == 0 || line.text.isEmpty() || static_cast<bool>(slot.lineLayout);
+		if (slot.visualRows <= 0 || !exactLineHasLayout)
+			return false;
+
+		return slot.runtimeLineKey == nativeRuntimeLineKey(line) &&
+		       slot.lineContentHash == lineContentHashForWidth(line);
+	};
+
+	auto reusableAlignedPrefix =
+	    [this, &lines, &runtimeLineKeyForLine, &lineCanReuseCachedLayout](const int requestedPrefix)
+	{
+		const int lineCount      = sizeToInt(lines.size());
+		const int prefixLimit    = qBound(0, requestedPrefix,
+		                                  std::min({lineCount, sizeToInt(m_nativeLayoutSlots.size()),
+		                                            sizeToInt(m_nativeLayoutHeightIndex.size())}));
+		int       reusablePrefix = 0;
+		while (reusablePrefix < prefixLimit)
+		{
+			if (m_nativeLayoutSlots.at(reusablePrefix).runtimeLineKey !=
+			        runtimeLineKeyForLine(lines.at(reusablePrefix)) ||
+			    !lineCanReuseCachedLayout(reusablePrefix))
+			{
+				break;
+			}
+			++reusablePrefix;
+		}
+		return reusablePrefix;
+	};
+
+	auto resetAllLayoutCachesForCurrentLines = [&]
+	{
+		resetLayoutLineCaches(lines.size());
+		m_nativeLayoutHeightIndex.assign(lines.size(), defaultLineAdvance);
+		markHeightRangeDirty(0, sizeToInt(lines.size()));
+	};
+
+	auto invalidateUnreusableAlignedRanges = [&](const int first, const int lastExclusive)
+	{
+		const int newSize = sizeToInt(lines.size());
+		if (m_nativeLayoutSlots.size() != lines.size())
+			m_nativeLayoutSlots.resize(lines.size());
+		const int boundedFirst    = qBound(0, first, newSize);
+		const int boundedLast     = qBound(boundedFirst, lastExclusive, newSize);
+		int       dirtyStart      = -1;
+		auto      flushDirtyRange = [&](const int end)
+		{
+			if (dirtyStart < 0)
+				return;
+			invalidateLayoutSlots(dirtyStart, end);
+			dirtyStart = -1;
+		};
+		for (int i = boundedFirst; i < boundedLast; ++i)
+		{
+			const quint64 currentRuntimeKey = runtimeLineKeyForLine(lines.at(i));
+			if (m_nativeLayoutSlots.at(i).runtimeLineKey != currentRuntimeKey)
+				m_nativeLayoutSlots[i].runtimeLineKey = currentRuntimeKey;
+			if (!lineCanReuseCachedLayout(i))
+			{
+				if (dirtyStart < 0)
+					dirtyStart = i;
+				continue;
+			}
+			flushDirtyRange(i);
+		}
+		flushDirtyRange(boundedLast);
+	};
+
+	auto transformDirtyRangesForReplace =
+	    [&dirtyHeightRanges](const int first, const int removeCount, const int insertCount)
+	{
+		if (dirtyHeightRanges.isEmpty() || (removeCount <= 0 && insertCount <= 0))
+			return;
+
+		const int replaceFirst = qMax(0, first);
+		const int removeLast   = replaceFirst + qMax(0, removeCount);
+		const int deltaCount   = qMax(0, insertCount) - qMax(0, removeCount);
+		for (QPair<int, int> &range : dirtyHeightRanges)
+		{
+			if (range.second <= replaceFirst)
+				continue;
+			if (range.first >= removeLast)
+			{
+				range.first += deltaCount;
+				range.second += deltaCount;
+				continue;
+			}
+
+			const int oldRightDirtyCount = qMax(0, range.second - removeLast);
+			range.first                  = qMin(range.first, replaceFirst);
+			range.second                 = replaceFirst + qMax(0, insertCount) + oldRightDirtyCount;
+		}
+	};
+
+	auto replaceLayoutRange =
+	    [&](const int first, const int removeCount, const int insertCount, const bool markInsertedDirty)
+	{
+		const int lineCount      = sizeToInt(m_nativeLayoutSlots.size());
+		const int boundedFirst   = qBound(0, first, lineCount);
+		const int boundedRemove  = qBound(0, removeCount, lineCount - boundedFirst);
+		const int boundedInsert  = qMax(0, insertCount);
+		const int oldExactPrefix = m_nativeLayoutExactPrefixCount;
+
+		transformDirtyRangesForReplace(boundedFirst, boundedRemove, boundedInsert);
+		m_nativeLayoutSlots.replace(boundedFirst, boundedRemove, boundedInsert, NativeLayoutSlot{});
+		m_nativeLayoutHeightIndex.replace(boundedFirst, boundedRemove, boundedInsert, defaultLineAdvance);
+
+		const int removeLast = boundedFirst + boundedRemove;
+		if (boundedFirst >= oldExactPrefix)
+		{
+			m_nativeLayoutExactPrefixCount = qBound(0, oldExactPrefix, sizeToInt(m_nativeLayoutSlots.size()));
+		}
+		else if (boundedInsert == 0 && removeLast <= oldExactPrefix)
+		{
+			m_nativeLayoutExactPrefixCount =
+			    qBound(0, oldExactPrefix - boundedRemove, sizeToInt(m_nativeLayoutSlots.size()));
+		}
+		else
+		{
+			m_nativeLayoutExactPrefixCount = boundedFirst;
+		}
+
+		if (markInsertedDirty && boundedInsert > 0)
+			markHeightRangeDirty(boundedFirst, boundedFirst + boundedInsert);
+	};
+
+	auto dropLayoutHead = [&](const int requestedHeadTrimCount)
+	{
+		const int headTrimCount = qBound(0, requestedHeadTrimCount, sizeToInt(m_nativeLayoutSlots.size()));
 		if (headTrimCount <= 0)
 			return;
 
-		qreal trimmedDocY = 0.0;
-		if (m_nativeLayoutCumulativeHeights.size() > headTrimCount)
-			trimmedDocY = qMax<qreal>(0.0, nativeLayoutCumulativeHeightAt(headTrimCount));
-
-		m_nativeLayoutVisualRows.remove(0, headTrimCount);
-		m_nativeLayoutLineLayouts.remove(0, headTrimCount);
-		m_nativeLayoutLineContentHashes.remove(0, headTrimCount);
-		m_nativeLayoutRuntimeLineKeys.remove(0, headTrimCount);
-		m_nativeLayoutRowsExact.remove(0, headTrimCount);
-
-		if (m_nativeLayoutCumulativeHeights.size() > headTrimCount)
-		{
-			m_nativeLayoutCumulativeHeights.remove(0, headTrimCount);
-			m_nativeLayoutCumulativeHeightOrigin += trimmedDocY;
-			if (m_nativeLayoutCumulativeHeightOrigin >= kNativeLayoutCumulativeOriginNormalizeThreshold)
-			{
-				resetNativeLayoutCumulativeHeightOrigin();
-			}
-		}
-		else
-		{
-			m_nativeLayoutCumulativeHeights.assign(1, 0.0);
-			m_nativeLayoutCumulativeHeightOrigin = 0.0;
-		}
-
-		m_nativeLayoutCumulativeDirtyFrom = qMax(0, m_nativeLayoutCumulativeDirtyFrom - headTrimCount);
+		transformDirtyRangesForReplace(0, headTrimCount, 0);
+		m_nativeLayoutSlots.remove(0, headTrimCount);
+		m_nativeLayoutHeightIndex.removeFront(headTrimCount);
+		m_nativeLayoutExactPrefixCount = qMax(0, m_nativeLayoutExactPrefixCount - headTrimCount);
 	};
 
-	auto preserveVerifiedLayoutPrefix =
-	    [this, &lines, &runtimeLineKeyForLine, &lineContentHashForWidth, &dropLayoutHead,
-	     defaultLineAdvance](const int newSize, const int headTrimCount, const int requestedStablePrefix)
+	auto dropLayoutHeadForReplay = [&](const int requestedHeadTrimCount)
 	{
-		if (newSize < 0 || headTrimCount < 0 || requestedStablePrefix < 0)
-			return false;
+		const int headTrimCount = qBound(0, requestedHeadTrimCount, sizeToInt(m_nativeLayoutSlots.size()));
+		if (headTrimCount <= 0)
+			return;
+		dropLayoutHead(headTrimCount);
+	};
 
-		const int       sourceOffset = qMax(0, headTrimCount);
-		const qsizetype availableSourceSize =
-		    std::min({m_nativeLayoutVisualRows.size(), m_nativeLayoutLineLayouts.size(),
-		              m_nativeLayoutLineContentHashes.size(), m_nativeLayoutRuntimeLineKeys.size(),
-		              m_nativeLayoutRowsExact.size()});
-		const int availableSourceCount =
-		    sizeToInt(qMax<qsizetype>(0, availableSourceSize - static_cast<qsizetype>(sourceOffset)));
-		const int prefixLimit = qBound(0, requestedStablePrefix, qMin(newSize, availableSourceCount));
-		if (prefixLimit <= 0 && newSize > 0)
-			return false;
-
-		int reusablePrefix = 0;
-		for (; reusablePrefix < prefixLimit; ++reusablePrefix)
+	auto collectLayoutReplayDeltas = [&]
+	{
+		QVector<NativeRenderCacheDelta> replayDeltas;
+		quint64                         expectedRevision = m_nativeLayoutCachedRenderRevision;
+		for (const NativeRenderCacheDelta &delta : std::as_const(m_nativeRenderCacheDeltas))
 		{
-			const int sourceIndex = sourceOffset + reusablePrefix;
-			if (m_nativeLayoutRuntimeLineKeys.at(sourceIndex) !=
-			    runtimeLineKeyForLine(lines.at(reusablePrefix)))
-			{
+			if (delta.revision <= expectedRevision)
+				continue;
+			if (delta.fromRevision != expectedRevision)
+				return QVector<NativeRenderCacheDelta>{};
+			replayDeltas.push_back(delta);
+			expectedRevision = delta.revision;
+			if (expectedRevision == m_nativeRenderLineCacheRevision)
 				break;
-			}
-
-			const NativeOutputRenderLine &line = lines.at(reusablePrefix);
-			const bool exactLineHasLayout      = m_nativeLayoutRowsExact.at(sourceIndex) == 0 ||
-			                                     line.text.isEmpty() ||
-			                                     static_cast<bool>(m_nativeLayoutLineLayouts.at(sourceIndex));
-			if (m_nativeLayoutVisualRows.at(sourceIndex) <= 0 || !exactLineHasLayout ||
-			    m_nativeLayoutLineContentHashes.at(sourceIndex) != lineContentHashForWidth(line))
-			{
-				break;
-			}
 		}
-		if (reusablePrefix <= 0 && newSize > 0)
+		if (expectedRevision != m_nativeRenderLineCacheRevision)
+			replayDeltas.clear();
+		return replayDeltas;
+	};
+
+	auto applyExactRenderDelta = [&](const NativeRenderCacheDelta &delta)
+	{
+		const int oldSize = qMax(0, delta.oldLineCount);
+		const int newSize = qMax(0, delta.newLineCount);
+		if (delta.kind != NativeRenderCacheDeltaKind::FullReset && !layoutDimensionsMatch(oldSize))
 			return false;
 
-		bool cumulativePrefixPreserved = false;
-		if (sourceOffset > 0)
+		switch (delta.kind)
 		{
-			if (reusablePrefix == availableSourceCount)
-			{
-				dropLayoutHead(sourceOffset);
-				cumulativePrefixPreserved = true;
-			}
-			else
-			{
-				for (int i = 0; i < reusablePrefix; ++i)
-				{
-					const int sourceIndex              = sourceOffset + i;
-					m_nativeLayoutVisualRows[i]        = m_nativeLayoutVisualRows.at(sourceIndex);
-					m_nativeLayoutLineLayouts[i]       = std::move(m_nativeLayoutLineLayouts[sourceIndex]);
-					m_nativeLayoutLineContentHashes[i] = m_nativeLayoutLineContentHashes.at(sourceIndex);
-					m_nativeLayoutRuntimeLineKeys[i]   = m_nativeLayoutRuntimeLineKeys.at(sourceIndex);
-					m_nativeLayoutRowsExact[i]         = m_nativeLayoutRowsExact.at(sourceIndex);
-				}
-			}
-		}
-
-		m_nativeLayoutVisualRows.resize(newSize);
-		m_nativeLayoutLineLayouts.resize(newSize);
-		m_nativeLayoutLineContentHashes.resize(newSize);
-		m_nativeLayoutRuntimeLineKeys.resize(newSize);
-		m_nativeLayoutRowsExact.resize(newSize);
-		for (int i = reusablePrefix; i < newSize; ++i)
+		case NativeRenderCacheDeltaKind::FullReset:
+			resetLayoutLineCaches(newSize);
+			m_nativeLayoutHeightIndex.assign(newSize, defaultLineAdvance);
+			markHeightRangeDirty(0, newSize);
+			return true;
+		case NativeRenderCacheDeltaKind::TailAppend:
 		{
-			m_nativeLayoutVisualRows[i] = -1;
-			m_nativeLayoutLineLayouts[i].clear();
-			m_nativeLayoutLineContentHashes[i] = 0;
-			m_nativeLayoutRuntimeLineKeys[i]   = runtimeLineKeyForLine(lines.at(i));
-			m_nativeLayoutRowsExact[i]         = 0;
+			if (newSize < oldSize)
+				return false;
+			const int  insertCount     = newSize - oldSize;
+			const bool tailLineMutated = delta.tailLineMutated && oldSize > 0;
+			const bool headLineMutated = delta.headLineMutated && newSize > 0;
+			replaceLayoutRange(oldSize, 0, insertCount, true);
+			const int stablePrefix =
+			    headLineMutated ? 0 : qBound(0, oldSize - (tailLineMutated ? 1 : 0), newSize);
+			markHeightRangeDirty(stablePrefix, newSize);
+			return layoutDimensionsMatch(newSize);
 		}
-
-		m_nativeLayoutCumulativeHeights.resize(newSize + 1);
-		if (!m_nativeLayoutCumulativeHeights.isEmpty())
-			setNativeLayoutCumulativeHeightAt(0, 0.0);
-		if (cumulativePrefixPreserved)
+		case NativeRenderCacheDeltaKind::TailRemove:
 		{
-			m_nativeLayoutCumulativeDirtyFrom =
-			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, reusablePrefix), newSize);
+			if (newSize > oldSize)
+				return false;
+			replaceLayoutRange(newSize, oldSize - newSize, 0, false);
+			const bool tailLineMutated = delta.tailLineMutated && newSize > 0;
+			const int  stablePrefix    = qBound(0, newSize - (tailLineMutated ? 1 : 0), newSize);
+			markHeightRangeDirty(stablePrefix, newSize);
+			return layoutDimensionsMatch(newSize);
 		}
-		else
+		case NativeRenderCacheDeltaKind::HeadTrimTailAppend:
 		{
-			qreal prefixDocY = 0.0;
-			for (int i = 0; i < reusablePrefix; ++i)
-			{
-				prefixDocY += static_cast<qreal>(m_nativeLayoutVisualRows.at(i)) * defaultLineAdvance;
-				setNativeLayoutCumulativeHeightAt(i + 1, prefixDocY);
-			}
-			m_nativeLayoutCumulativeDirtyFrom = qBound(0, reusablePrefix, newSize);
+			const int headTrimCount = qBound(0, delta.headTrimCount, oldSize);
+			if (headTrimCount <= 0 || oldSize < headTrimCount)
+				return false;
+			dropLayoutHeadForReplay(headTrimCount);
+			const int preservedCount = qBound(0, oldSize - headTrimCount, newSize);
+			const int insertCount    = newSize - preservedCount;
+			if (insertCount < 0)
+				return false;
+			replaceLayoutRange(preservedCount, 0, insertCount, true);
+			if (delta.headLineMutated && newSize > 0)
+				markHeightRangeDirty(0, 1);
+			const bool tailLineMutated = delta.tailLineMutated && preservedCount > 0;
+			const int  tailDirtyFirst  = qBound(0, preservedCount - (tailLineMutated ? 1 : 0), newSize);
+			markHeightRangeDirty(tailDirtyFirst, newSize);
+			return layoutDimensionsMatch(newSize);
 		}
-		return true;
+		case NativeRenderCacheDeltaKind::RuntimeLineRestitch:
+		{
+			if (oldSize != newSize || newSize <= 0)
+				return false;
+			const int changedIndex = qBound(0, delta.stablePrefixCount, newSize - 1);
+			replaceLayoutRange(changedIndex, 1, 1, true);
+			return layoutDimensionsMatch(newSize);
+		}
+		case NativeRenderCacheDeltaKind::RuntimeRangeRestitch:
+		{
+			const int headTrimCount = qBound(0, delta.headTrimCount, oldSize);
+			dropLayoutHeadForReplay(headTrimCount);
+			const int  postTrimOldSize = oldSize - headTrimCount;
+			const int  replaceFirst    = qBound(0, delta.replaceFirstLine, postTrimOldSize);
+			const int  removeCount     = qBound(0, delta.removedLineCount, postTrimOldSize - replaceFirst);
+			const int  insertCount     = qBound(0, delta.insertedLineCount, newSize);
+			const bool structuralRemap = postTrimOldSize - removeCount + insertCount == newSize;
+			if (!structuralRemap)
+				return false;
+			replaceLayoutRange(replaceFirst, removeCount, insertCount, insertCount > 0);
+			if (insertCount > 0)
+				markHeightRangeDirty(replaceFirst, replaceFirst + insertCount);
+			if (delta.headLineMutated && newSize > 0)
+				markHeightRangeDirty(0, 1);
+			return layoutDimensionsMatch(newSize);
+		}
+		case NativeRenderCacheDeltaKind::HeadMutation:
+		{
+			const int headTrimCount = qBound(0, delta.headTrimCount, oldSize);
+			dropLayoutHeadForReplay(headTrimCount);
+			if (!layoutDimensionsMatch(newSize))
+				return false;
+			if ((delta.headLineMutated || headTrimCount <= 0) && newSize > 0)
+				markHeightRangeDirty(0, 1);
+			return true;
+		}
+		case NativeRenderCacheDeltaKind::Unknown:
+			return false;
+		}
+		return false;
 	};
 
 	bool renderDeltaFastPathApplied = false;
-	if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged &&
-	    m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-	    m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::TailAppend &&
-	    m_nativeRenderCacheDelta.newLineCount == sizeToInt(lines.size()))
+	if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged)
 	{
-		const int  oldSize = qBound(0, m_nativeRenderCacheDelta.oldLineCount, sizeToInt(lines.size()));
-		const bool oldDimensionsMatch =
-		    m_nativeLayoutVisualRows.size() == oldSize && m_nativeLayoutLineLayouts.size() == oldSize &&
-		    m_nativeLayoutLineContentHashes.size() == oldSize &&
-		    m_nativeLayoutRuntimeLineKeys.size() == oldSize && m_nativeLayoutRowsExact.size() == oldSize &&
-		    m_nativeLayoutCumulativeHeights.size() == oldSize + 1;
-		if (oldDimensionsMatch)
+		const QVector<NativeRenderCacheDelta> replayDeltas  = collectLayoutReplayDeltas();
+		bool                                  replayApplied = !replayDeltas.isEmpty();
+		for (const NativeRenderCacheDelta &delta : replayDeltas)
 		{
-			const int  newSize         = sizeToInt(lines.size());
-			const bool tailLineMutated = m_nativeRenderCacheDelta.tailLineMutated && oldSize > 0;
-			const int  stablePrefix    = qBound(0, oldSize - (tailLineMutated ? 1 : 0), newSize);
-
-			m_nativeLayoutVisualRows.resize(lines.size());
-			m_nativeLayoutLineLayouts.resize(lines.size());
-			m_nativeLayoutLineContentHashes.resize(lines.size());
-			m_nativeLayoutRuntimeLineKeys.resize(lines.size());
-			m_nativeLayoutRowsExact.resize(lines.size());
-			for (int i = stablePrefix; i < newSize; ++i)
+			if (!applyExactRenderDelta(delta))
 			{
-				m_nativeLayoutVisualRows[i] = -1;
-				m_nativeLayoutLineLayouts[i].clear();
-				m_nativeLayoutLineContentHashes[i] = 0;
-				m_nativeLayoutRuntimeLineKeys[i]   = runtimeLineKeyForLine(lines.at(i));
-				m_nativeLayoutRowsExact[i]         = 0;
+				replayApplied = false;
+				break;
 			}
-
-			m_nativeLayoutCumulativeHeights.resize(lines.size() + 1);
-			if (stablePrefix == 0 && !m_nativeLayoutCumulativeHeights.isEmpty())
-				setNativeLayoutCumulativeHeightAt(0, 0.0);
-			m_nativeLayoutCumulativeDirtyFrom =
-			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, stablePrefix), newSize);
-			renderDeltaFastPathApplied = true;
 		}
-		else
-		{
-			const int newSize = sizeToInt(lines.size());
-			const int stablePrefix =
-			    qBound(0, oldSize - (m_nativeRenderCacheDelta.tailLineMutated ? 1 : 0), newSize);
-			renderDeltaFastPathApplied = preserveVerifiedLayoutPrefix(newSize, 0, stablePrefix);
-		}
-	}
-	else if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged &&
-	         m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-	         m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::TailRemove &&
-	         m_nativeRenderCacheDelta.newLineCount == sizeToInt(lines.size()))
-	{
-		const int  oldSize = qMax(0, m_nativeRenderCacheDelta.oldLineCount);
-		const int  newSize = sizeToInt(lines.size());
-		const bool oldDimensionsMatch =
-		    m_nativeLayoutVisualRows.size() == oldSize && m_nativeLayoutLineLayouts.size() == oldSize &&
-		    m_nativeLayoutLineContentHashes.size() == oldSize &&
-		    m_nativeLayoutRuntimeLineKeys.size() == oldSize && m_nativeLayoutRowsExact.size() == oldSize &&
-		    m_nativeLayoutCumulativeHeights.size() == oldSize + 1;
-		const bool tailLineMutated = m_nativeRenderCacheDelta.tailLineMutated && newSize > 0;
-		const int  stablePrefix    = qBound(0, newSize - (tailLineMutated ? 1 : 0), newSize);
-		if (oldDimensionsMatch)
-		{
-			m_nativeLayoutVisualRows.resize(newSize);
-			m_nativeLayoutLineLayouts.resize(newSize);
-			m_nativeLayoutLineContentHashes.resize(newSize);
-			m_nativeLayoutRuntimeLineKeys.resize(newSize);
-			m_nativeLayoutRowsExact.resize(newSize);
-			for (int i = stablePrefix; i < newSize; ++i)
-			{
-				m_nativeLayoutVisualRows[i] = -1;
-				m_nativeLayoutLineLayouts[i].clear();
-				m_nativeLayoutLineContentHashes[i] = 0;
-				m_nativeLayoutRuntimeLineKeys[i]   = runtimeLineKeyForLine(lines.at(i));
-				m_nativeLayoutRowsExact[i]         = 0;
-			}
-
-			m_nativeLayoutCumulativeHeights.resize(newSize + 1);
-			if (stablePrefix == 0 && !m_nativeLayoutCumulativeHeights.isEmpty())
-				setNativeLayoutCumulativeHeightAt(0, 0.0);
-			m_nativeLayoutCumulativeDirtyFrom =
-			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, stablePrefix), newSize);
-			renderDeltaFastPathApplied = true;
-		}
-		else
-		{
-			renderDeltaFastPathApplied = preserveVerifiedLayoutPrefix(newSize, 0, stablePrefix);
-		}
-	}
-	else if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged &&
-	         m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-	         m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::HeadTrimTailAppend &&
-	         m_nativeRenderCacheDelta.newLineCount == sizeToInt(lines.size()))
-	{
-		const int  oldSize       = qMax(0, m_nativeRenderCacheDelta.oldLineCount);
-		const int  newSize       = sizeToInt(lines.size());
-		const int  headTrimCount = qBound(0, m_nativeRenderCacheDelta.headTrimCount, oldSize);
-		const bool oldDimensionsMatch =
-		    m_nativeLayoutVisualRows.size() == oldSize && m_nativeLayoutLineLayouts.size() == oldSize &&
-		    m_nativeLayoutLineContentHashes.size() == oldSize &&
-		    m_nativeLayoutRuntimeLineKeys.size() == oldSize && m_nativeLayoutRowsExact.size() == oldSize &&
-		    m_nativeLayoutCumulativeHeights.size() == oldSize + 1;
-		if (oldDimensionsMatch && headTrimCount > 0 && oldSize >= headTrimCount)
-		{
-			const int preservedCount = qBound(0, oldSize - headTrimCount, newSize);
-			dropLayoutHead(headTrimCount);
-
-			m_nativeLayoutVisualRows.resize(newSize);
-			m_nativeLayoutLineLayouts.resize(newSize);
-			m_nativeLayoutLineContentHashes.resize(newSize);
-			m_nativeLayoutRuntimeLineKeys.resize(newSize);
-			m_nativeLayoutRowsExact.resize(newSize);
-			for (int i = preservedCount; i < newSize; ++i)
-			{
-				m_nativeLayoutVisualRows[i] = -1;
-				m_nativeLayoutLineLayouts[i].clear();
-				m_nativeLayoutLineContentHashes[i] = 0;
-				m_nativeLayoutRuntimeLineKeys[i]   = runtimeLineKeyForLine(lines.at(i));
-				m_nativeLayoutRowsExact[i]         = 0;
-			}
-
-			m_nativeLayoutCumulativeHeights.resize(newSize + 1);
-			if (!m_nativeLayoutCumulativeHeights.isEmpty())
-				setNativeLayoutCumulativeHeightAt(0, 0.0);
-			m_nativeLayoutCumulativeDirtyFrom =
-			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, preservedCount), newSize);
-			renderDeltaFastPathApplied = true;
-		}
-		else
-		{
-			const int preservedCount   = qBound(0, oldSize - headTrimCount, newSize);
-			renderDeltaFastPathApplied = preserveVerifiedLayoutPrefix(newSize, headTrimCount, preservedCount);
-		}
-	}
-	else if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged &&
-	         m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-	         m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::RuntimeLineRestitch &&
-	         m_nativeRenderCacheDelta.newLineCount == sizeToInt(lines.size()))
-	{
-		const int  oldSize            = qMax(0, m_nativeRenderCacheDelta.oldLineCount);
-		const int  newSize            = sizeToInt(lines.size());
-		const bool oldDimensionsMatch = oldSize == newSize && m_nativeLayoutVisualRows.size() == oldSize &&
-		                                m_nativeLayoutLineLayouts.size() == oldSize &&
-		                                m_nativeLayoutLineContentHashes.size() == oldSize &&
-		                                m_nativeLayoutRuntimeLineKeys.size() == oldSize &&
-		                                m_nativeLayoutRowsExact.size() == oldSize &&
-		                                m_nativeLayoutCumulativeHeights.size() == oldSize + 1;
-		if (oldDimensionsMatch && newSize > 0)
-		{
-			const int changedIndex = qBound(0, m_nativeRenderCacheDelta.stablePrefixCount, newSize - 1);
-			m_nativeLayoutVisualRows[changedIndex] = -1;
-			m_nativeLayoutLineLayouts[changedIndex].clear();
-			m_nativeLayoutLineContentHashes[changedIndex] = 0;
-			m_nativeLayoutRuntimeLineKeys[changedIndex]   = runtimeLineKeyForLine(lines.at(changedIndex));
-			m_nativeLayoutRowsExact[changedIndex]         = 0;
-			m_nativeLayoutCumulativeDirtyFrom =
-			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, changedIndex), newSize);
-			renderDeltaFastPathApplied = true;
-		}
-		else
-		{
-			const int stablePrefix =
-			    qBound(0, m_nativeRenderCacheDelta.stablePrefixCount, qMin(oldSize, newSize));
-			renderDeltaFastPathApplied = preserveVerifiedLayoutPrefix(newSize, 0, stablePrefix);
-		}
-	}
-	else if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged &&
-	         m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-	         m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::RuntimeRangeRestitch &&
-	         m_nativeRenderCacheDelta.newLineCount == sizeToInt(lines.size()))
-	{
-		const int oldSize          = qMax(0, m_nativeRenderCacheDelta.oldLineCount);
-		const int newSize          = sizeToInt(lines.size());
-		const int headTrimCount    = qBound(0, m_nativeRenderCacheDelta.headTrimCount, oldSize);
-		const int preservedOldSize = qMax(0, oldSize - headTrimCount);
-		const int stablePrefix =
-		    qBound(0, m_nativeRenderCacheDelta.stablePrefixCount, qMin(preservedOldSize, newSize));
-		const bool oldDimensionsMatch =
-		    m_nativeLayoutVisualRows.size() == oldSize && m_nativeLayoutLineLayouts.size() == oldSize &&
-		    m_nativeLayoutLineContentHashes.size() == oldSize &&
-		    m_nativeLayoutRuntimeLineKeys.size() == oldSize && m_nativeLayoutRowsExact.size() == oldSize &&
-		    m_nativeLayoutCumulativeHeights.size() == oldSize + 1;
-		if (oldDimensionsMatch)
-		{
-			if (headTrimCount > 0)
-				dropLayoutHead(headTrimCount);
-
-			m_nativeLayoutVisualRows.resize(newSize);
-			m_nativeLayoutLineLayouts.resize(newSize);
-			m_nativeLayoutLineContentHashes.resize(newSize);
-			m_nativeLayoutRuntimeLineKeys.resize(newSize);
-			m_nativeLayoutRowsExact.resize(newSize);
-			for (int i = stablePrefix; i < newSize; ++i)
-			{
-				m_nativeLayoutVisualRows[i] = -1;
-				m_nativeLayoutLineLayouts[i].clear();
-				m_nativeLayoutLineContentHashes[i] = 0;
-				m_nativeLayoutRuntimeLineKeys[i]   = runtimeLineKeyForLine(lines.at(i));
-				m_nativeLayoutRowsExact[i]         = 0;
-			}
-
-			m_nativeLayoutCumulativeHeights.resize(newSize + 1);
-			if (!m_nativeLayoutCumulativeHeights.isEmpty())
-				setNativeLayoutCumulativeHeightAt(0, 0.0);
-			m_nativeLayoutCumulativeDirtyFrom =
-			    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, stablePrefix), newSize);
-			renderDeltaFastPathApplied = true;
-		}
-		else
-		{
-			renderDeltaFastPathApplied = preserveVerifiedLayoutPrefix(newSize, headTrimCount, stablePrefix);
-		}
+		if (!replayApplied)
+			resetAllLayoutCachesForCurrentLines();
+		renderDeltaFastPathApplied = true;
 	}
 
-	const bool layoutRangesMatch      = renderDeltaFastPathApplied ? true : [&]
+	auto pruneConsumedRenderDeltas = [this]
 	{
-		if (m_nativeLayoutRuntimeLineKeys.size() != lines.size())
+		const int deltaCount    = sizeToInt(m_nativeRenderCacheDeltas.size());
+		int       consumedCount = 0;
+		while (consumedCount < deltaCount &&
+		       m_nativeRenderCacheDeltas.at(consumedCount).revision <= m_nativeLayoutCachedRenderRevision)
+		{
+			++consumedCount;
+		}
+		if (consumedCount > 0)
+			m_nativeRenderCacheDeltas.remove(0, consumedCount);
+	};
+
+	const bool layoutRangesMatch = renderDeltaFastPathApplied ? true : [&]
+	{
+		if (renderRevisionChanged)
+			return false;
+		if (m_nativeLayoutSlots.size() != lines.size())
 			return false;
 		if (lines.isEmpty())
 			return true;
-		return m_nativeLayoutRuntimeLineKeys.constFirst() == runtimeLineKeyForLine(lines.constFirst()) &&
-		       m_nativeLayoutRuntimeLineKeys.constLast() == runtimeLineKeyForLine(lines.constLast());
+		return m_nativeLayoutSlots.constFirst().runtimeLineKey == runtimeLineKeyForLine(lines.constFirst()) &&
+		       m_nativeLayoutSlots.constLast().runtimeLineKey == runtimeLineKeyForLine(lines.constLast());
 	}();
-	const bool layoutRangesFullyMatch = (!renderDeltaFastPathApplied && renderRevisionChanged) ? [&]
-	{
-		if (m_nativeLayoutRuntimeLineKeys.size() != lines.size())
-			return false;
-		for (int i = 0; i < lines.size(); ++i)
-		{
-			if (m_nativeLayoutRuntimeLineKeys.at(i) != runtimeLineKeyForLine(lines.at(i)))
-				return false;
-		}
-		return true;
-	}()
-	                                                                                           : false;
 	if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged &&
-	    ((cacheDimensionsMatch && layoutRangesFullyMatch) ||
-	     (renderDeltaFastPathApplied && m_nativeLayoutCumulativeDirtyFrom >= sizeToInt(lines.size()))))
+	    renderDeltaFastPathApplied && dirtyHeightRanges.isEmpty())
 	{
 		m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
+		pruneConsumedRenderDeltas();
 		return;
 	}
 
@@ -4721,58 +5224,49 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 		if (const bool preserveLineLayouts = cacheWasValid && !fontChanged && !styleChanged;
 		    preserveLineLayouts)
 		{
-			if (m_nativeLayoutVisualRows.size() != lines.size())
-				m_nativeLayoutVisualRows.assign(lines.size(), -1);
+			if (const bool lineCacheSizeChanged = m_nativeLayoutSlots.size() != lines.size();
+			    lineCacheSizeChanged)
+			{
+				const int oldSize = sizeToInt(m_nativeLayoutSlots.size());
+				m_nativeLayoutSlots.resize(lines.size());
+				invalidateLayoutSlots(oldSize, sizeToInt(lines.size()));
+			}
 			else if (wrapChanged)
-				std::ranges::fill(m_nativeLayoutVisualRows, -1);
-
-			if (m_nativeLayoutLineLayouts.size() != lines.size())
-				m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
-			if (m_nativeLayoutLineContentHashes.size() != lines.size())
-				m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
-			if (m_nativeLayoutRowsExact.size() != lines.size())
-				m_nativeLayoutRowsExact.assign(lines.size(), 0);
+			{
+				invalidateLayoutSlots(0, sizeToInt(lines.size()));
+			}
 		}
 		else
 		{
-			m_nativeLayoutVisualRows.assign(lines.size(), -1);
-			m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
-			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
-			m_nativeLayoutRowsExact.assign(lines.size(), 0);
+			resetLayoutLineCaches(lines.size());
 		}
-		m_nativeLayoutCumulativeHeights.assign(lines.size() + 1, 0.0);
-		m_nativeLayoutCumulativeHeightOrigin = 0.0;
-		m_nativeLayoutCumulativeDirtyFrom    = 0;
-		m_nativeLayoutCacheValid             = true;
-		m_nativeLayoutCachedWrapWidth        = wrapWidthPixels;
-		m_nativeLayoutCachedLocalWrapWidth   = localWrapWidthPixels;
-		m_nativeLayoutCachedLineSpacing      = lineSpacingSetting;
-		m_nativeLayoutCachedStyleKey         = styleKey;
-		m_nativeLayoutCachedLineAdvance      = defaultLineAdvance;
-		m_nativeLayoutCachedFont             = layoutFont;
-		m_nativeLayoutCachedRenderRevision   = m_nativeRenderLineCacheRevision;
-		refreshLayoutRuntimeLineKeys();
+		m_nativeLayoutHeightIndex.assign(lines.size(), defaultLineAdvance);
+		markHeightRangeDirty(0, sizeToInt(lines.size()));
+		m_nativeLayoutCacheValid           = true;
+		m_nativeLayoutCachedWrapWidth      = wrapWidthPixels;
+		m_nativeLayoutCachedLocalWrapWidth = localWrapWidthPixels;
+		m_nativeLayoutCachedLineSpacing    = lineSpacingSetting;
+		m_nativeLayoutCachedStyleKey       = styleKey;
+		m_nativeLayoutCachedLineAdvance    = defaultLineAdvance;
+		m_nativeLayoutCachedFont           = layoutFont;
+		m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
 		++m_nativeLayoutCacheResets;
 	}
 	else if ((renderRevisionChanged && !renderDeltaFastPathApplied) || !layoutRangesMatch)
 	{
-		bool       remappedFastPath = false;
-		const bool oldDimensionsMatch =
-		    m_nativeLayoutRuntimeLineKeys.size() == m_nativeLayoutVisualRows.size() &&
-		    m_nativeLayoutRuntimeLineKeys.size() == m_nativeLayoutLineLayouts.size() &&
-		    m_nativeLayoutRuntimeLineKeys.size() == m_nativeLayoutLineContentHashes.size() &&
-		    m_nativeLayoutRuntimeLineKeys.size() == m_nativeLayoutRowsExact.size();
+		bool remappedFastPath = false;
 
-		if (oldDimensionsMatch && !m_nativeLayoutRuntimeLineKeys.isEmpty() && !lines.isEmpty())
+		if (const bool oldDimensionsMatch = m_nativeLayoutSlots.size() == m_nativeLayoutHeightIndex.size();
+		    oldDimensionsMatch && !m_nativeLayoutSlots.isEmpty() && !lines.isEmpty())
 		{
-			const int     oldSize = sizeToInt(m_nativeLayoutRuntimeLineKeys.size());
+			const int     oldSize = sizeToInt(m_nativeLayoutSlots.size());
 			const int     newSize = sizeToInt(lines.size());
 
 			const quint64 firstNewLineKey = runtimeLineKeyForLine(lines.constFirst());
 			int           oldStartIndex   = -1;
 			for (int i = 0; i < oldSize; ++i)
 			{
-				if (m_nativeLayoutRuntimeLineKeys.at(i) == firstNewLineKey)
+				if (m_nativeLayoutSlots.at(i).runtimeLineKey == firstNewLineKey)
 				{
 					oldStartIndex = i;
 					break;
@@ -4783,7 +5277,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 			{
 				int mappedCount = 0;
 				while (mappedCount < newSize && oldStartIndex + mappedCount < oldSize &&
-				       m_nativeLayoutRuntimeLineKeys.at(oldStartIndex + mappedCount) ==
+				       m_nativeLayoutSlots.at(oldStartIndex + mappedCount).runtimeLineKey ==
 				           runtimeLineKeyForLine(lines.at(mappedCount)))
 				{
 					++mappedCount;
@@ -4794,65 +5288,18 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 				        mappedCount > 0 && (oldSuffixFullyMapped || mappedCount == newSize);
 				    simpleRemap)
 				{
+					const int oldExactPrefix      = qBound(0, m_nativeLayoutExactPrefixCount, oldSize);
+					const int remappedExactPrefix = oldStartIndex < oldExactPrefix
+					                                    ? qMin(mappedCount, oldExactPrefix - oldStartIndex)
+					                                    : 0;
 					if (oldStartIndex > 0)
-					{
-						for (int i = 0; i < mappedCount; ++i)
-						{
-							const int sourceIndex        = oldStartIndex + i;
-							m_nativeLayoutVisualRows[i]  = m_nativeLayoutVisualRows.at(sourceIndex);
-							m_nativeLayoutLineLayouts[i] = std::move(m_nativeLayoutLineLayouts[sourceIndex]);
-							m_nativeLayoutLineContentHashes[i] =
-							    m_nativeLayoutLineContentHashes.at(sourceIndex);
-							m_nativeLayoutRuntimeLineKeys[i] = m_nativeLayoutRuntimeLineKeys.at(sourceIndex);
-							m_nativeLayoutRowsExact[i]       = m_nativeLayoutRowsExact.at(sourceIndex);
-						}
-					}
+						dropLayoutHead(oldStartIndex);
 
-					m_nativeLayoutVisualRows.resize(newSize);
-					m_nativeLayoutLineLayouts.resize(newSize);
-					m_nativeLayoutLineContentHashes.resize(newSize);
-					m_nativeLayoutRuntimeLineKeys.resize(newSize);
-					m_nativeLayoutRowsExact.resize(newSize);
-					for (int i = mappedCount; i < newSize; ++i)
-					{
-						m_nativeLayoutVisualRows[i] = -1;
-						m_nativeLayoutLineLayouts[i].clear();
-						m_nativeLayoutLineContentHashes[i] = 0;
-						m_nativeLayoutRuntimeLineKeys[i]   = runtimeLineKeyForLine(lines.at(i));
-						m_nativeLayoutRowsExact[i]         = 0;
-					}
-
-					m_nativeLayoutCumulativeHeights.resize(newSize + 1);
-					if (oldStartIndex == 0)
-					{
-						m_nativeLayoutCumulativeDirtyFrom =
-						    qBound(0, qMin(m_nativeLayoutCumulativeDirtyFrom, mappedCount), newSize);
-					}
-					else
-					{
-						setNativeLayoutCumulativeHeightAt(0, 0.0);
-						qreal prefixDocY             = 0.0;
-						int   firstChangedVisualLine = mappedCount;
-						for (int i = 0; i < mappedCount; ++i)
-						{
-							const NativeOutputRenderLine &line = lines.at(i);
-							const bool                    exactLineHasLayout =
-							    m_nativeLayoutRowsExact.at(i) == 0 || line.text.isEmpty() ||
-							    static_cast<bool>(m_nativeLayoutLineLayouts.at(i));
-							if (m_nativeLayoutVisualRows.at(i) <= 0 || !exactLineHasLayout ||
-							    m_nativeLayoutLineContentHashes.at(i) != lineContentHashForWidth(line))
-							{
-								firstChangedVisualLine = i;
-								break;
-							}
-
-							prefixDocY +=
-							    static_cast<qreal>(m_nativeLayoutVisualRows.at(i)) * defaultLineAdvance;
-							setNativeLayoutCumulativeHeightAt(i + 1, prefixDocY);
-						}
-						m_nativeLayoutCumulativeDirtyFrom =
-						    qBound(0, firstChangedVisualLine, sizeToInt(lines.size()));
-					}
+					m_nativeLayoutHeightIndex.resize(newSize, defaultLineAdvance);
+					m_nativeLayoutSlots.resize(newSize);
+					const int reusablePrefix = reusableAlignedPrefix(mappedCount);
+					invalidateUnreusableAlignedRanges(reusablePrefix, newSize);
+					m_nativeLayoutExactPrefixCount = qMin(remappedExactPrefix, reusablePrefix);
 
 					remappedFastPath = true;
 				}
@@ -4861,219 +5308,222 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 
 		if (!remappedFastPath)
 		{
-			IndexedRingBuffer<int>                         oldRows;
-			IndexedRingBuffer<quint64>                     oldLineKeys;
-			IndexedRingBuffer<QSharedPointer<QTextLayout>> oldLayouts;
-			IndexedRingBuffer<quint64>                     oldHashes;
-			IndexedRingBuffer<uchar>                       oldExactRows;
-			oldRows.swap(m_nativeLayoutVisualRows);
-			oldLineKeys.swap(m_nativeLayoutRuntimeLineKeys);
-			oldLayouts.swap(m_nativeLayoutLineLayouts);
-			oldHashes.swap(m_nativeLayoutLineContentHashes);
-			oldExactRows.swap(m_nativeLayoutRowsExact);
+			IndexedRingBuffer<NativeLayoutSlot> oldSlots;
+			NativeLayoutHeightIndex             oldHeightIndex;
+			oldSlots.swap(m_nativeLayoutSlots);
+			oldHeightIndex.swap(m_nativeLayoutHeightIndex);
 
-			m_nativeLayoutVisualRows.assign(lines.size(), -1);
-			m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
-			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
-			m_nativeLayoutRowsExact.assign(lines.size(), 0);
-			QVector<int> remappedOldIndexes(lines.size(), -1);
+			const int newSize = sizeToInt(lines.size());
+			m_nativeLayoutSlots.clear();
+			m_nativeLayoutHeightIndex.clear();
+			m_nativeLayoutSlots.reserve(lines.size());
+			m_nativeLayoutHeightIndex.reserve(lines.size());
 
-			const bool   oldDimensionsStillMatch =
-			    !oldLineKeys.isEmpty() && oldLineKeys.size() == oldRows.size() &&
-			    oldLineKeys.size() == oldLayouts.size() && oldLineKeys.size() == oldHashes.size() &&
-			    oldLineKeys.size() == oldExactRows.size();
-			auto mapLineFromOld = [&](const int newIndex, const int oldIndex)
+			const bool oldDimensionsStillMatch =
+			    !oldSlots.isEmpty() && oldSlots.size() == oldHeightIndex.size();
+			auto appendInvalidLine = [&](const quint64 newLineKey)
 			{
-				if (newIndex < 0 || newIndex >= lines.size() || oldIndex < 0 ||
-				    oldIndex >= oldLineKeys.size())
-				{
-					return;
-				}
-				m_nativeLayoutVisualRows[newIndex]        = oldRows.at(oldIndex);
-				m_nativeLayoutLineLayouts[newIndex]       = std::move(oldLayouts[oldIndex]);
-				m_nativeLayoutLineContentHashes[newIndex] = oldHashes.at(oldIndex);
-				m_nativeLayoutRowsExact[newIndex]         = oldExactRows.at(oldIndex);
-				remappedOldIndexes[newIndex]              = oldIndex;
+				NativeLayoutSlot slot;
+				slot.runtimeLineKey = newLineKey;
+				m_nativeLayoutSlots.push_back(std::move(slot));
+				m_nativeLayoutHeightIndex.append(defaultLineAdvance);
 			};
-			if (oldDimensionsStillMatch && !lines.isEmpty())
+			auto appendLineFromOld = [&](const int oldIndex)
 			{
-				int oldIndex = 0;
-				for (int newIndex = 0; newIndex < lines.size() && oldIndex < oldLineKeys.size(); ++newIndex)
+				m_nativeLayoutSlots.push_back(std::move(oldSlots[oldIndex]));
+				m_nativeLayoutHeightIndex.append(oldHeightIndex.heightAt(oldIndex));
+			};
+			int       oldIndex = 0;
+			const int oldSize  = sizeToInt(oldSlots.size());
+			for (int newIndex = 0; newIndex < newSize; ++newIndex)
+			{
+				const quint64 newLineKey = runtimeLineKeyForLine(lines.at(newIndex));
+				if (oldDimensionsStillMatch)
 				{
-					const quint64 newLineKey = runtimeLineKeyForLine(lines.at(newIndex));
-					while (oldIndex < oldLineKeys.size() && oldLineKeys.at(oldIndex) != newLineKey)
-					{
+					while (oldIndex < oldSize && oldSlots.at(oldIndex).runtimeLineKey != newLineKey)
 						++oldIndex;
+					if (oldIndex < oldSize)
+					{
+						appendLineFromOld(oldIndex);
+						++oldIndex;
+						continue;
 					}
-					if (oldIndex >= oldLineKeys.size())
-						break;
-					mapLineFromOld(newIndex, oldIndex);
-					++oldIndex;
 				}
+				appendInvalidLine(newLineKey);
 			}
 
-			refreshLayoutRuntimeLineKeys();
-			m_nativeLayoutCumulativeHeights.resize(lines.size() + 1);
-			setNativeLayoutCumulativeHeightAt(0, 0.0);
-			auto lineCanReuseMappedLayout = [&](const int i)
+			int  dirtyStart      = -1;
+			int  exactPrefix     = 0;
+			bool exactPrefixOpen = true;
+			auto flushDirtyRange = [&](const int end)
 			{
-				if (i < 0 || i >= lines.size())
-					return false;
-
-				const NativeOutputRenderLine &line = lines.at(i);
-				const bool exactLineHasLayout = m_nativeLayoutRowsExact.at(i) == 0 || line.text.isEmpty() ||
-				                                static_cast<bool>(m_nativeLayoutLineLayouts.at(i));
-				if (m_nativeLayoutVisualRows.at(i) <= 0 || !exactLineHasLayout)
-					return false;
-
-				return m_nativeLayoutLineContentHashes.at(i) == lineContentHashForWidth(line);
+				if (dirtyStart < 0)
+					return;
+				markHeightRangeDirty(dirtyStart, end);
+				dirtyStart = -1;
 			};
-
-			int   firstChangedVisualLine = 0;
-			qreal prefixDocY             = 0.0;
-			while (firstChangedVisualLine < lines.size())
+			const int remappedSize = sizeToInt(lines.size());
+			for (int i = 0; i < remappedSize; ++i)
 			{
-				if (remappedOldIndexes.at(firstChangedVisualLine) < 0 ||
-				    !lineCanReuseMappedLayout(firstChangedVisualLine))
+				const bool canReuse = lineCanReuseCachedLayout(i);
+				if (exactPrefixOpen)
 				{
-					break;
+					if (canReuse && m_nativeLayoutSlots.at(i).rowsExact != 0)
+						++exactPrefix;
+					else
+						exactPrefixOpen = false;
 				}
-				prefixDocY += static_cast<qreal>(m_nativeLayoutVisualRows.at(firstChangedVisualLine)) *
-				              defaultLineAdvance;
-				setNativeLayoutCumulativeHeightAt(firstChangedVisualLine + 1, prefixDocY);
-				++firstChangedVisualLine;
+				if (!canReuse)
+				{
+					const quint64 currentRuntimeKey       = m_nativeLayoutSlots.at(i).runtimeLineKey;
+					m_nativeLayoutSlots[i]                = NativeLayoutSlot{};
+					m_nativeLayoutSlots[i].runtimeLineKey = currentRuntimeKey;
+					if (dirtyStart < 0)
+						dirtyStart = i;
+					continue;
+				}
+				flushDirtyRange(i);
 			}
-			m_nativeLayoutCumulativeDirtyFrom = qBound(0, firstChangedVisualLine, sizeToInt(lines.size()));
+			flushDirtyRange(remappedSize);
+			m_nativeLayoutExactPrefixCount = exactPrefix;
 		}
 	}
 	else
 	{
-		if (m_nativeLayoutVisualRows.size() != lines.size())
+		if (m_nativeLayoutSlots.size() != lines.size())
 		{
-			m_nativeLayoutVisualRows.assign(lines.size(), -1);
-			m_nativeLayoutCumulativeDirtyFrom = 0;
+			resetLayoutLineCaches(lines.size());
+			m_nativeLayoutHeightIndex.assign(lines.size(), defaultLineAdvance);
+			markHeightRangeDirty(0, sizeToInt(lines.size()));
 		}
-		if (m_nativeLayoutRowsExact.size() != lines.size())
+		if (m_nativeLayoutHeightIndex.size() != lines.size())
 		{
-			m_nativeLayoutRowsExact.assign(lines.size(), 0);
-			m_nativeLayoutCumulativeDirtyFrom = 0;
-		}
-		if (m_nativeLayoutRuntimeLineKeys.size() != lines.size())
-			refreshLayoutRuntimeLineKeys();
-		if (m_nativeLayoutCumulativeHeights.size() != lines.size() + 1)
-		{
-			m_nativeLayoutCumulativeHeights.resize(lines.size() + 1);
-			m_nativeLayoutCumulativeDirtyFrom = 0;
-		}
-		if (m_nativeLayoutLineLayouts.size() != lines.size())
-		{
-			m_nativeLayoutLineLayouts.assign(lines.size(), QSharedPointer<QTextLayout>{});
-			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
-			m_nativeLayoutCumulativeDirtyFrom = 0;
-		}
-		else if (m_nativeLayoutLineContentHashes.size() != lines.size())
-		{
-			m_nativeLayoutLineContentHashes.assign(lines.size(), 0);
-			m_nativeLayoutCumulativeDirtyFrom = 0;
+			m_nativeLayoutHeightIndex.resize(lines.size(), defaultLineAdvance);
+			markHeightRangeDirty(0, sizeToInt(lines.size()));
 		}
 	}
 
 	if (cacheWasValid && localWrapChanged)
 	{
 		m_nativeLayoutCachedLocalWrapWidth = localWrapWidthPixels;
-		m_nativeLayoutCumulativeDirtyFrom  = 0;
+		invalidateLayoutSlots(0, sizeToInt(lines.size()));
 	}
 
-	if (m_nativeLayoutCumulativeHeights.size() != lines.size() + 1)
+	if (m_nativeLayoutHeightIndex.size() != lines.size())
 	{
-		m_nativeLayoutCumulativeHeights.resize(lines.size() + 1);
-		m_nativeLayoutCumulativeDirtyFrom = 0;
+		m_nativeLayoutHeightIndex.resize(lines.size(), defaultLineAdvance);
+		markHeightRangeDirty(0, sizeToInt(lines.size()));
 	}
 
-	const int dirtyFrom = qBound(0, m_nativeLayoutCumulativeDirtyFrom, sizeToInt(lines.size()));
-	if (dirtyFrom == 0)
-		setNativeLayoutCumulativeHeightAt(0, 0.0);
-
-	qreal              docY = (dirtyFrom > 0 && dirtyFrom < m_nativeLayoutCumulativeHeights.size())
-	                              ? nativeLayoutCumulativeHeightAt(dirtyFrom)
-	                              : 0.0;
 	const QFontMetrics layoutFontMetrics(layoutFont);
-	for (int i = dirtyFrom; i < lines.size(); ++i)
+	auto               refreshHeightRange = [&](const int first, const int lastExclusive)
 	{
-		const NativeOutputRenderLine &line = lines.at(i);
-		const bool hasLocalContent = (line.flags & (WorldRuntime::LineNote | WorldRuntime::LineInput)) != 0;
-		const int  effectiveWrapWidth = hasLocalContent ? localWrapWidthPixels : wrapWidthPixels;
-		const quint64 contentHash     = lineContentHashForWidth(line);
-		const bool    hashMatches     = i < m_nativeLayoutLineContentHashes.size() &&
-		                                m_nativeLayoutLineContentHashes.at(i) == contentHash;
-		if (!hashMatches)
+		const int boundedFirst = qBound(0, first, sizeToInt(lines.size()));
+		const int boundedLast  = qBound(boundedFirst, lastExclusive, sizeToInt(lines.size()));
+		for (int i = boundedFirst; i < boundedLast; ++i)
 		{
-			m_nativeLayoutLineLayouts[i].clear();
-			m_nativeLayoutLineContentHashes[i] = contentHash;
-			m_nativeLayoutVisualRows[i] = estimateNativeLineRows(line, effectiveWrapWidth, layoutFontMetrics);
-			m_nativeLayoutRowsExact[i]  = line.text.isEmpty() ? 1 : 0;
+			const NativeOutputRenderLine &line = lines.at(i);
+			const bool                    hasLocalContent =
+			    (line.flags & (WorldRuntime::LineNote | WorldRuntime::LineInput)) != 0;
+			const int         effectiveWrapWidth = hasLocalContent ? localWrapWidthPixels : wrapWidthPixels;
+			const quint64     contentHash        = lineContentHashForWidth(line);
+			NativeLayoutSlot &slot               = m_nativeLayoutSlots[i];
+			slot.runtimeLineKey                  = runtimeLineKeyForLine(line);
+			const bool hashMatches               = slot.lineContentHash == contentHash;
+			if (!hashMatches)
+			{
+				slot.lineLayout.clear();
+				slot.lineContentHash = contentHash;
+				slot.visualRows      = estimateNativeLineRows(line, effectiveWrapWidth, layoutFontMetrics);
+				slot.rowsExact       = line.text.isEmpty() ? 1 : 0;
+			}
+			else if (slot.visualRows <= 0)
+			{
+				slot.visualRows = estimateNativeLineRows(line, effectiveWrapWidth, layoutFontMetrics);
+				slot.rowsExact  = line.text.isEmpty() ? 1 : 0;
+			}
 		}
-		else if (m_nativeLayoutVisualRows.at(i) <= 0)
-		{
-			m_nativeLayoutVisualRows[i] = estimateNativeLineRows(line, effectiveWrapWidth, layoutFontMetrics);
-			m_nativeLayoutRowsExact[i]  = line.text.isEmpty() ? 1 : 0;
-		}
-		const int visualRowsForLine = qMax(1, m_nativeLayoutVisualRows.at(i));
-		docY += static_cast<qreal>(visualRowsForLine) * defaultLineAdvance;
-		if (i + 1 < m_nativeLayoutCumulativeHeights.size())
-			setNativeLayoutCumulativeHeightAt(i + 1, docY);
-	}
-	m_nativeLayoutCumulativeDirtyFrom  = sizeToInt(lines.size());
+		m_nativeLayoutHeightIndex.setLayoutSlotHeightRange(boundedFirst, boundedLast, m_nativeLayoutSlots,
+		                                                   defaultLineAdvance);
+	};
+	applyLayoutInvalidationRanges();
+	mergeDirtyHeightRanges();
+	for (const QPair<int, int> &range : dirtyHeightRanges)
+		refreshHeightRange(range.first, range.second);
+	if (!dirtyHeightRanges.isEmpty())
+		refreshNativeLayoutExactPrefixFrom(dirtyHeightRanges.constFirst().first);
 	m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
+	pruneConsumedRenderDeltas();
 }
 
 qreal WorldView::nativeLayoutCumulativeHeightAt(const int index) const
 {
-	if (index < 0 || index >= m_nativeLayoutCumulativeHeights.size())
-		return 0.0;
-	return m_nativeLayoutCumulativeHeights.at(index) - m_nativeLayoutCumulativeHeightOrigin;
+	return m_nativeLayoutHeightIndex.prefixHeightAt(index);
 }
 
-void WorldView::setNativeLayoutCumulativeHeightAt(const int index, const qreal value) const
+int WorldView::nativeLayoutLineAtY(const qreal y) const
 {
-	if (index < 0 || index >= m_nativeLayoutCumulativeHeights.size())
-		return;
-	m_nativeLayoutCumulativeHeights[index] = value + m_nativeLayoutCumulativeHeightOrigin;
-}
-
-void WorldView::resetNativeLayoutCumulativeHeightOrigin() const
-{
-	if (qFuzzyIsNull(m_nativeLayoutCumulativeHeightOrigin))
-		return;
-	for (qsizetype i = 0; i < m_nativeLayoutCumulativeHeights.size(); ++i)
-		m_nativeLayoutCumulativeHeights[i] =
-		    qMax<qreal>(0.0, m_nativeLayoutCumulativeHeights.at(i) - m_nativeLayoutCumulativeHeightOrigin);
-	m_nativeLayoutCumulativeHeightOrigin = 0.0;
+	return m_nativeLayoutHeightIndex.lineAtY(y);
 }
 
 const QTextLayout *WorldView::nativeLayoutForLine(const int index) const
 {
-	if (index < 0 || index >= m_nativeLayoutLineLayouts.size())
+	if (index < 0 || index >= m_nativeLayoutSlots.size())
 		return nullptr;
-	if (const auto &layout = m_nativeLayoutLineLayouts.at(index); layout)
+	if (const auto &layout = m_nativeLayoutSlots.at(index).lineLayout; layout)
 		return layout.data();
 	return nullptr;
 }
 
 void WorldView::bumpNativeRenderLineCacheRevision(const NativeRenderCacheDeltaKind kind,
                                                   const int oldLineCount, const bool tailLineMutated,
-                                                  const int headTrimCount, const int stablePrefixCount) const
+                                                  const int headTrimCount, const int stablePrefixCount,
+                                                  const bool headLineMutated) const
 {
+	NativeRenderCacheDelta delta;
+	delta.kind              = kind;
+	delta.oldLineCount      = qMax(0, oldLineCount);
+	delta.newLineCount      = sizeToInt(m_nativeRenderLineCache.size());
+	delta.tailLineMutated   = tailLineMutated;
+	delta.headLineMutated   = headLineMutated;
+	delta.headTrimCount     = qMax(0, headTrimCount);
+	delta.stablePrefixCount = qMax(0, stablePrefixCount);
+	commitNativeRenderCacheDelta(delta);
+}
+
+void WorldView::bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(
+    const int oldLineCount, const bool tailLineMutated, const int headTrimCount, const int stablePrefixCount,
+    const bool headLineMutated, const int replaceFirstLine, const int removedLineCount,
+    const int insertedLineCount) const
+{
+	NativeRenderCacheDelta delta;
+	delta.kind                     = NativeRenderCacheDeltaKind::RuntimeRangeRestitch;
+	delta.oldLineCount             = qMax(0, oldLineCount);
+	delta.newLineCount             = sizeToInt(m_nativeRenderLineCache.size());
+	delta.tailLineMutated          = tailLineMutated;
+	delta.headLineMutated          = headLineMutated;
+	delta.headTrimCount            = qBound(0, headTrimCount, delta.oldLineCount);
+	delta.stablePrefixCount        = qMax(0, stablePrefixCount);
+	const int postTrimOldLineCount = delta.oldLineCount - delta.headTrimCount;
+	delta.replaceFirstLine         = qBound(0, replaceFirstLine, postTrimOldLineCount);
+	delta.removedLineCount  = qBound(0, removedLineCount, postTrimOldLineCount - delta.replaceFirstLine);
+	delta.insertedLineCount = qBound(0, insertedLineCount, delta.newLineCount);
+	commitNativeRenderCacheDelta(delta);
+}
+
+void WorldView::commitNativeRenderCacheDelta(NativeRenderCacheDelta delta) const
+{
+	const quint64 previousRevision = m_nativeRenderLineCacheRevision;
 	++m_nativeRenderLineCacheRevision;
-	m_nativeRenderCacheDelta.kind              = kind;
-	m_nativeRenderCacheDelta.revision          = m_nativeRenderLineCacheRevision;
-	m_nativeRenderCacheDelta.oldLineCount      = qMax(0, oldLineCount);
-	m_nativeRenderCacheDelta.newLineCount      = sizeToInt(m_nativeRenderLineCache.size());
-	m_nativeRenderCacheDelta.tailLineMutated   = tailLineMutated;
-	m_nativeRenderCacheDelta.headTrimCount     = qMax(0, headTrimCount);
-	m_nativeRenderCacheDelta.stablePrefixCount = qMax(0, stablePrefixCount);
-	if (m_nativeRenderCacheDelta.headTrimCount > 0)
-		m_nativeSelectionPendingHeadTrimLines += m_nativeRenderCacheDelta.headTrimCount;
+	delta.fromRevision = previousRevision;
+	delta.revision     = m_nativeRenderLineCacheRevision;
+
+	m_nativeRenderCacheDelta = delta;
+	if (!m_nativeLayoutCacheValid)
+		m_nativeRenderCacheDeltas.clear();
+	m_nativeRenderCacheDeltas.push_back(delta);
+	if (delta.headTrimCount > 0)
+		m_nativeSelectionPendingHeadTrimLines += delta.headTrimCount;
 	m_nativeSplitTopHeadTrimPixelsRevision = 0;
 	m_nativeSplitTopHeadTrimPixels         = 0;
 }
@@ -5085,11 +5535,6 @@ void WorldView::markNativeRuntimeTailRestitchPending() const
 
 	m_nativeRenderLineCacheFromRuntime = true;
 	m_nativeRuntimeTailRestitchPending = true;
-	if (m_nativeLayoutCacheValid)
-	{
-		const int tailIndex               = qMax(0, sizeToInt(m_nativeLayoutVisualRows.size()) - 1);
-		m_nativeLayoutCumulativeDirtyFrom = qMin(m_nativeLayoutCumulativeDirtyFrom, tailIndex);
-	}
 	requestNativeOutputTailRepaint();
 }
 
@@ -5119,18 +5564,22 @@ void WorldView::rebuildNativeRenderCacheFromLineEntries(
 	const int oldLineCount = sizeToInt(m_nativeRenderLineCache.size());
 	m_nativeRenderLineCache.clear();
 	m_nativeRenderLineCache.reserve(lines.size());
+	m_nativeRenderRuntimeIndexBase = 0;
 
 	QDateTime                        previousLineTime;
 	QString                          currentLineText;
 	QVector<WorldRuntime::StyleSpan> currentLineSpans;
-	double                           currentLineOpacity      = 1.0;
-	qint64                           currentFirstRuntimeLine = 0;
-	qint64                           currentLastRuntimeLine  = 0;
+	double                           currentLineOpacity       = 1.0;
+	qint64                           currentFirstRuntimeLine  = 0;
+	qint64                           currentLastRuntimeLine   = 0;
+	qint64                           currentFirstRuntimeIndex = -1;
 	QVector<qint64>                  currentSourceRuntimeLines;
 	int                              currentLineFlags            = 0;
 	bool                             currentLogicalLineHasSource = false;
-	for (const WorldRuntime::LineEntry &entry : lines)
+	const int                        runtimeLineCount            = sizeToInt(lines.size());
+	for (int runtimeIndex = 0; runtimeIndex < runtimeLineCount; ++runtimeIndex)
 	{
+		const WorldRuntime::LineEntry &entry = lines.at(runtimeIndex);
 		if ((entry.flags & WorldRuntime::LineHidden) != 0)
 			continue;
 
@@ -5142,6 +5591,7 @@ void WorldView::rebuildNativeRenderCacheFromLineEntries(
 		{
 			currentFirstRuntimeLine     = entry.lineNumber;
 			currentLastRuntimeLine      = entry.lineNumber;
+			currentFirstRuntimeIndex    = m_nativeRenderRuntimeIndexBase + runtimeIndex;
 			currentLineFlags            = entry.flags;
 			currentLogicalLineHasSource = true;
 		}
@@ -5175,6 +5625,7 @@ void WorldView::rebuildNativeRenderCacheFromLineEntries(
 			renderLine.sourceRuntimeLineKey =
 			    nativeRuntimeLineKey(renderLine.sourceRuntimeLineNumbers, renderLine.firstRuntimeLineNumber,
 			                         renderLine.lastRuntimeLineNumber);
+			renderLine.firstRuntimeLineIndex = currentFirstRuntimeIndex;
 			m_nativeRenderLineCache.push_back(std::move(renderLine));
 			currentLineText.clear();
 			currentLineSpans.clear();
@@ -5182,6 +5633,7 @@ void WorldView::rebuildNativeRenderCacheFromLineEntries(
 			currentLineOpacity          = 1.0;
 			currentFirstRuntimeLine     = 0;
 			currentLastRuntimeLine      = 0;
+			currentFirstRuntimeIndex    = -1;
 			currentLineFlags            = 0;
 			currentLogicalLineHasSource = false;
 		}
@@ -5204,6 +5656,7 @@ void WorldView::rebuildNativeRenderCacheFromLineEntries(
 		renderLine.sourceRuntimeLineKey =
 		    nativeRuntimeLineKey(renderLine.sourceRuntimeLineNumbers, renderLine.firstRuntimeLineNumber,
 		                         renderLine.lastRuntimeLineNumber);
+		renderLine.firstRuntimeLineIndex = currentFirstRuntimeIndex;
 		m_nativeRenderLineCache.push_back(std::move(renderLine));
 	}
 
@@ -5277,6 +5730,7 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		    m_nativeCachedRuntimeFirstLineNumber != 0 || m_nativeCachedRuntimeLastLineNumber != 0 ||
 		    !m_nativeCachedRuntimeLastHardReturn || !m_nativeCachedRuntimeLineNumbersContiguous;
 		m_nativeRenderLineCache.clear();
+		m_nativeRenderRuntimeIndexBase             = 0;
 		m_nativeRenderLineCacheValid               = true;
 		m_nativeRenderLineCacheFromRuntime         = true;
 		m_nativeCachedRuntimeCount                 = 0;
@@ -5528,7 +5982,7 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 				tailMutated                  = true;
 				line.text += displayText;
 				line.opacity = lineOpacityForTimestamp(entry.time);
-				extendNativeRuntimeLineRange(line, entry.lineNumber);
+				extendNativeRuntimeLineRange(line, entry.lineNumber, m_nativeRenderRuntimeIndexBase + i);
 				line.flags |= entry.flags;
 				cacheChanged = true;
 				if (!displaySpans.isEmpty())
@@ -5552,6 +6006,7 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 				renderLine.sourceRuntimeLineKey =
 				    nativeRuntimeLineKey(renderLine.sourceRuntimeLineNumbers,
 				                         renderLine.firstRuntimeLineNumber, renderLine.lastRuntimeLineNumber);
+				renderLine.firstRuntimeLineIndex = m_nativeRenderRuntimeIndexBase + i;
 				m_nativeRenderLineCache.push_back(std::move(renderLine));
 				cacheChanged = true;
 			}
@@ -5590,65 +6045,49 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		}
 	};
 
-	auto restitchTrimmedHeadLogicalLine =
-	    [this, &runtimeLines](const qint64 newFirstLineNumber, const bool suppressRevisionBump = false)
+	auto restitchTrimmedHeadLogicalLineFromIndex =
+	    [this, &runtimeLines, &nextRenderableRuntimeIndex](const int  requestedStartIndex,
+	                                                       const bool suppressRevisionBump = false)
 	{
 		if (m_nativeRenderLineCache.isEmpty())
 			return true;
 
-		const NativeOutputRenderLine &existingHead = m_nativeRenderLineCache.first();
-		if (!existingHead.sourceRuntimeLineNumbers.isEmpty())
-		{
-			bool hasTrimmedSource   = false;
-			bool hasRemainingSource = false;
-			for (const qint64 lineNumber : existingHead.sourceRuntimeLineNumbers)
-			{
-				if (lineNumber < newFirstLineNumber)
-					hasTrimmedSource = true;
-				else
-					hasRemainingSource = true;
-			}
-			if (!hasTrimmedSource)
-				return true;
-			if (!hasRemainingSource)
-				return false;
-		}
-		else
-		{
-			if (existingHead.firstRuntimeLineNumber >= newFirstLineNumber)
-				return true;
-			if (existingHead.lastRuntimeLineNumber < newFirstLineNumber)
-				return false;
-		}
-
-		const int startIndex = findRuntimeLineIndexByNumberNear(runtimeLines, newFirstLineNumber, 0, false);
+		const int startIndex = nextRenderableRuntimeIndex(requestedStartIndex);
 		if (startIndex < 0 || startIndex >= runtimeLines.size())
 			return false;
 
+		const NativeOutputRenderLine &existingHead            = m_nativeRenderLineCache.first();
+		const qint64                  firstRetainedLineNumber = runtimeLines.at(startIndex).lineNumber;
+		if (!nativeRuntimeLineRangeContains(existingHead, firstRetainedLineNumber))
+			return existingHead.firstRuntimeLineIndex >= m_nativeRenderRuntimeIndexBase;
+
 		QString                          rebuiltText;
 		QVector<WorldRuntime::StyleSpan> rebuiltSpans;
-		double                           rebuiltOpacity      = 1.0;
-		qint64                           rebuiltFirstRuntime = 0;
-		qint64                           rebuiltLastRuntime  = 0;
+		double                           rebuiltOpacity           = 1.0;
+		qint64                           rebuiltFirstRuntime      = 0;
+		qint64                           rebuiltLastRuntime       = 0;
+		qint64                           rebuiltFirstRuntimeIndex = -1;
 		QVector<qint64>                  rebuiltSourceRuntimeLines;
 		int                              rebuiltFlags = 0;
 		bool                             hasSource    = false;
-		bool                             closed       = false;
 		QDateTime                        previousLineTime;
 
 		for (int i = startIndex; i < runtimeLines.size(); ++i)
 		{
-			const WorldRuntime::LineEntry   &entry = runtimeLines.at(i);
+			const WorldRuntime::LineEntry &entry = runtimeLines.at(i);
+			if ((entry.flags & WorldRuntime::LineHidden) != 0)
+				continue;
 			QString                          displayText(entry.text);
 			QVector<WorldRuntime::StyleSpan> displaySpans(entry.spans);
 			buildDisplayLine(entry, previousLineTime, displayText, displaySpans);
 
 			if (!hasSource)
 			{
-				rebuiltFirstRuntime = entry.lineNumber;
-				rebuiltLastRuntime  = entry.lineNumber;
-				rebuiltFlags        = entry.flags;
-				hasSource           = true;
+				rebuiltFirstRuntime      = entry.lineNumber;
+				rebuiltLastRuntime       = entry.lineNumber;
+				rebuiltFirstRuntimeIndex = m_nativeRenderRuntimeIndexBase + i;
+				rebuiltFlags             = entry.flags;
+				hasSource                = true;
 			}
 			else
 			{
@@ -5664,32 +6103,22 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 
 			if (entry.hardReturn)
 			{
-				closed = true;
 				break;
 			}
 			previousLineTime = entry.time;
 		}
 
 		if (!hasSource || rebuiltSourceRuntimeLines.isEmpty() ||
-		    rebuiltSourceRuntimeLines.constFirst() != newFirstLineNumber)
-			return false;
-		if (!existingHead.sourceRuntimeLineNumbers.isEmpty())
-		{
-			const qsizetype suffixStart = existingHead.sourceRuntimeLineNumbers.indexOf(newFirstLineNumber);
-			if (suffixStart < 0)
-				return false;
-			const QVector<qint64> expectedSourceRuntimeLines =
-			    existingHead.sourceRuntimeLineNumbers.sliced(suffixStart);
-			if (rebuiltSourceRuntimeLines != expectedSourceRuntimeLines)
-				return false;
-		}
-		else if (rebuiltLastRuntime != existingHead.lastRuntimeLineNumber)
-		{
-			return false;
-		}
-		if (!closed && rebuiltLastRuntime != runtimeLines.last().lineNumber)
+		    rebuiltSourceRuntimeLines.constFirst() != firstRetainedLineNumber)
 			return false;
 
+		const QVector<qint64> existingSourceRuntimeLines = nativeRuntimeLineNumbers(existingHead);
+		const qsizetype       suffixStart = existingSourceRuntimeLines.indexOf(firstRetainedLineNumber);
+		if (suffixStart < 0)
+			return false;
+		const QVector<qint64> expectedSourceRuntimeLines = existingSourceRuntimeLines.sliced(suffixStart);
+		if (rebuiltSourceRuntimeLines != expectedSourceRuntimeLines)
+			return false;
 		NativeOutputRenderLine rebuiltLine{
 		    std::move(rebuiltText),
 		    std::move(rebuiltSpans),
@@ -5704,14 +6133,25 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		rebuiltLine.sourceRuntimeLineKey =
 		    nativeRuntimeLineKey(rebuiltLine.sourceRuntimeLineNumbers, rebuiltLine.firstRuntimeLineNumber,
 		                         rebuiltLine.lastRuntimeLineNumber);
-		const int oldLineCount          = sizeToInt(m_nativeRenderLineCache.size());
-		m_nativeRenderLineCache.first() = std::move(rebuiltLine);
+		rebuiltLine.firstRuntimeLineIndex = rebuiltFirstRuntimeIndex;
+		const int oldLineCount            = sizeToInt(m_nativeRenderLineCache.size());
+		m_nativeRenderLineCache.first()   = std::move(rebuiltLine);
 		if (!suppressRevisionBump)
 		{
 			++m_nativeRenderCacheIncrementalUpdates;
 			bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::HeadMutation, oldLineCount);
 		}
 		return true;
+	};
+
+	auto restitchTrimmedHeadLogicalLine =
+	    [&runtimeLines, &restitchTrimmedHeadLogicalLineFromIndex](const qint64 newFirstLineNumber,
+	                                                              const bool   suppressRevisionBump = false)
+	{
+		const int startIndex = findRuntimeLineIndexByNumberNear(runtimeLines, newFirstLineNumber, 0, false);
+		if (startIndex < 0 || startIndex >= runtimeLines.size())
+			return false;
+		return restitchTrimmedHeadLogicalLineFromIndex(startIndex, suppressRevisionBump);
 	};
 
 	if (!m_nativeRenderLineCacheValid || !m_nativeRenderLineCacheFromRuntime)
@@ -5749,6 +6189,25 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		m_nativeCachedRuntimeLineNumbersContiguous = contiguous;
 		m_nativeCachedRuntimeFirstEntry            = runtimeLines.first();
 		m_nativeCachedRuntimeLastEntry             = runtimeLines.last();
+	};
+
+	auto removedRuntimeHeadCountFromCachedLast = [this, &runtimeLines]() -> int
+	{
+		if (m_nativeCachedRuntimeCount <= 0 || runtimeLines.isEmpty())
+			return -1;
+
+		for (qsizetype i = runtimeLines.size(); i > 0; --i)
+		{
+			const qsizetype                index       = i - 1;
+			const WorldRuntime::LineEntry &runtimeLine = runtimeLines.at(index);
+			if (runtimeLine.lineNumber == m_nativeCachedRuntimeLastEntry.lineNumber &&
+			    lineEntriesEquivalentForCache(runtimeLine, m_nativeCachedRuntimeLastEntry))
+			{
+				return qMax(0, m_nativeCachedRuntimeCount - 1 - sizeToInt(index));
+			}
+		}
+
+		return -1;
 	};
 
 	auto softRebuildFromRuntime = [this, &appendRuntimeRange, &clearRuntimeCache,
@@ -5864,10 +6323,22 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		if (restitchStartIndex >= runtimeLines.size())
 			return true;
 
-		const int oldLineCount     = sizeToInt(m_nativeRenderLineCache.size());
-		int       trimmedHeadCount = 0;
+		const int oldLineCount       = sizeToInt(m_nativeRenderLineCache.size());
+		bool      headLineRestitched = false;
+		int       trimmedHeadCount   = 0;
 		if (newFirstLineNumber > oldFirstLineNumber)
 		{
+			const qint64 removedRuntimeHeadCount =
+			    m_nativeCachedRuntimeLineNumbersContiguous && runtimeNowContiguous
+			        ? qMax<qint64>(0, newFirstLineNumber - oldFirstLineNumber)
+			        : removedRuntimeHeadCountFromCachedLast();
+			if (removedRuntimeHeadCount < 0)
+			{
+				recordNativeRestitchFailureDiagnostic(NativeRestitchFailureDiagnosticKind::RangeHeadTrim,
+				                                      restitchStartIndex);
+				return false;
+			}
+			m_nativeRenderRuntimeIndexBase += removedRuntimeHeadCount;
 			while (
 			    trimmedHeadCount < m_nativeRenderLineCache.size() &&
 			    renderLineBeforeRuntimeLine(m_nativeRenderLineCache.at(trimmedHeadCount), newFirstLineNumber))
@@ -5888,6 +6359,7 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 					                                      restitchStartIndex);
 					return false;
 				}
+				headLineRestitched = true;
 			}
 		}
 		if (m_nativeRenderLineCache.isEmpty())
@@ -5902,6 +6374,14 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		const int nextRenderableIndex = nextRenderableRuntimeIndex(restitchStartIndex);
 		if (nextRenderableIndex < 0)
 		{
+			if (headLineRestitched || trimmedHeadCount > 0)
+			{
+				const int stablePrefixCount =
+				    headLineRestitched ? 0 : sizeToInt(m_nativeRenderLineCache.size());
+				bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(oldLineCount, false, trimmedHeadCount,
+				                                                      stablePrefixCount, headLineRestitched,
+				                                                      stablePrefixCount, 0, 0);
+			}
 			runtimeRangeRestitchApplied = true;
 			return true;
 		}
@@ -6095,21 +6575,33 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 			for (NativeOutputRenderLine &line : preservedSuffix)
 				m_nativeRenderLineCache.push_back(std::move(line));
 		}
+		const int newLineCount         = sizeToInt(m_nativeRenderLineCache.size());
+		const int preservedSuffixCount = sizeToInt(preservedSuffix.size());
+		const int postTrimOldLineCount = qMax(0, oldLineCount - trimmedHeadCount);
+		const int replaceFirstLine     = qBound(0, dropRenderIndex, postTrimOldLineCount);
+		const int removedLastLine      = qBound(replaceFirstLine, removeEndIndex, postTrimOldLineCount);
+		const int removedLineCount     = removedLastLine - replaceFirstLine;
+		const int dirtyFirstLine       = qBound(0, dropRenderIndex, newLineCount);
+		const int insertedLineCount =
+		    qBound(0, newLineCount - preservedSuffixCount - dirtyFirstLine, newLineCount - dirtyFirstLine);
 		if (!appendChanged)
 		{
-			if (dropRenderIndex >= oldLineCount && preservedSuffix.isEmpty())
+			if (dropRenderIndex >= oldLineCount && preservedSuffix.isEmpty() && !headLineRestitched &&
+			    trimmedHeadCount == 0)
 			{
 				runtimeRangeRestitchApplied = true;
 				return true;
 			}
-			bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::RuntimeRangeRestitch, oldLineCount,
-			                                  true, trimmedHeadCount, dropRenderIndex);
+			bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(
+			    oldLineCount, true, trimmedHeadCount, headLineRestitched ? 0 : dropRenderIndex,
+			    headLineRestitched, replaceFirstLine, removedLineCount, insertedLineCount);
 			runtimeRangeRestitchApplied = true;
 			return true;
 		}
 
-		bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::RuntimeRangeRestitch, oldLineCount,
-		                                  true, trimmedHeadCount, dropRenderIndex);
+		bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(
+		    oldLineCount, true, trimmedHeadCount, headLineRestitched ? 0 : dropRenderIndex,
+		    headLineRestitched, replaceFirstLine, removedLineCount, insertedLineCount);
 		runtimeRangeRestitchApplied = true;
 		return true;
 	};
@@ -6184,6 +6676,7 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		renderLine.sourceRuntimeLineKey =
 		    nativeRuntimeLineKey(renderLine.sourceRuntimeLineNumbers, renderLine.firstRuntimeLineNumber,
 		                         renderLine.lastRuntimeLineNumber);
+		renderLine.firstRuntimeLineIndex = m_nativeRenderRuntimeIndexBase + runtimeIndex;
 
 		const int oldLineCount               = sizeToInt(m_nativeRenderLineCache.size());
 		m_nativeRenderLineCache[renderIndex] = std::move(renderLine);
@@ -6280,10 +6773,60 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 
 			if (overlapLastIndex >= 0)
 			{
-				const int oldLineCountBeforeHeadTrim = sizeToInt(m_nativeRenderLineCache.size());
-				bool      cacheTrimmed               = false;
-				int       trimmedHeadCount           = 0;
-				if (newFirstLineNumber > oldFirstLineNumber)
+				const int  oldLineCountBeforeHeadTrim = sizeToInt(m_nativeRenderLineCache.size());
+				bool       cacheTrimmed               = false;
+				bool       headLineRestitched         = false;
+				int        trimmedHeadCount           = 0;
+				const int  appendStartIndex           = overlapLastIndex + 1;
+				const bool appendWillFollow           = appendStartIndex < runtimeLines.size();
+				const int  removedRuntimeHeadCount =
+				    qMax(0, m_nativeCachedRuntimeCount - 1 - overlapLastIndex);
+				if (removedRuntimeHeadCount > 0)
+				{
+					m_nativeRenderRuntimeIndexBase += removedRuntimeHeadCount;
+					const int    firstRetainedRenderableIndex = nextRenderableRuntimeIndex(0);
+					const qint64 firstRetainedLineNumber =
+					    firstRetainedRenderableIndex >= 0
+					        ? runtimeLines.at(firstRetainedRenderableIndex).lineNumber
+					        : 0;
+					int dropCount = 0;
+					while (dropCount < m_nativeRenderLineCache.size())
+					{
+						const NativeOutputRenderLine &line = m_nativeRenderLineCache.at(dropCount);
+						if (line.firstRuntimeLineIndex >= m_nativeRenderRuntimeIndexBase)
+							break;
+						if (firstRetainedLineNumber > 0 &&
+						    nativeRuntimeLineRangeContains(line, firstRetainedLineNumber))
+						{
+							break;
+						}
+						++dropCount;
+					}
+					if (dropCount > 0)
+					{
+						m_nativeRenderLineCache.remove(0, dropCount);
+						++m_nativeRenderCacheTrimDrops;
+						cacheTrimmed     = true;
+						trimmedHeadCount = dropCount;
+					}
+					if (firstRetainedRenderableIndex >= 0 && !m_nativeRenderLineCache.isEmpty() &&
+					    m_nativeRenderLineCache.first().firstRuntimeLineIndex <
+					        m_nativeRenderRuntimeIndexBase)
+					{
+						if (!restitchTrimmedHeadLogicalLineFromIndex(firstRetainedRenderableIndex,
+						                                             cacheTrimmed || appendWillFollow))
+						{
+							recordNativeRestitchFailureDiagnostic(
+							    NativeRestitchFailureDiagnosticKind::HeadTrim, qMax(0, overlapLastIndex));
+							incrementRebuildReason(RuntimeRebuildReason::RestitchFailure);
+							softRebuildFromRuntime(runtimeNowContiguous, finalizeRuntimeCacheMetadata,
+							                       NativeAppendDiagnosticKind::SoftRestitchFailure);
+							return;
+						}
+						headLineRestitched = true;
+					}
+				}
+				else if (newFirstLineNumber > oldFirstLineNumber)
 				{
 					int dropCount = 0;
 					while (dropCount < m_nativeRenderLineCache.size() &&
@@ -6302,7 +6845,8 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 					if (!m_nativeRenderLineCache.isEmpty() &&
 					    renderLineStraddlesRuntimeLine(m_nativeRenderLineCache.first(), newFirstLineNumber))
 					{
-						if (!restitchTrimmedHeadLogicalLine(newFirstLineNumber))
+						if (!restitchTrimmedHeadLogicalLine(newFirstLineNumber,
+						                                    cacheTrimmed || appendWillFollow))
 						{
 							recordNativeRestitchFailureDiagnostic(
 							    NativeRestitchFailureDiagnosticKind::HeadTrim, qMax(0, overlapLastIndex));
@@ -6311,29 +6855,35 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 							                       NativeAppendDiagnosticKind::SoftRestitchFailure);
 							return;
 						}
+						headLineRestitched = true;
 					}
 				}
 
-				const int appendStartIndex = overlapLastIndex + 1;
 				if (appendStartIndex < runtimeLines.size())
 				{
-					if (cacheTrimmed)
+					if (cacheTrimmed || headLineRestitched)
 					{
-						bool appendChanged     = false;
-						bool appendTailMutated = false;
+						bool                             appendChanged     = false;
+						bool                             appendTailMutated = false;
+						const NativeAppendDiagnosticKind diagnosticKind =
+						    cacheTrimmed ? NativeAppendDiagnosticKind::HeadTrimTailAppend
+						                 : NativeAppendDiagnosticKind::NonContiguousTailAppend;
 						appendRuntimeRange(appendStartIndex, true, &appendChanged, &appendTailMutated,
-						                   nullptr, -1, NativeAppendDiagnosticKind::HeadTrimTailAppend);
+						                   nullptr, -1, diagnosticKind);
 						if (appendChanged)
 						{
-							bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::HeadTrimTailAppend,
-							                                  oldLineCountBeforeHeadTrim, appendTailMutated,
-							                                  trimmedHeadCount);
+							const NativeRenderCacheDeltaKind deltaKind =
+							    cacheTrimmed ? NativeRenderCacheDeltaKind::HeadTrimTailAppend
+							                 : NativeRenderCacheDeltaKind::TailAppend;
+							bumpNativeRenderLineCacheRevision(deltaKind, oldLineCountBeforeHeadTrim,
+							                                  appendTailMutated, trimmedHeadCount, 0,
+							                                  headLineRestitched);
 						}
 						else
 						{
 							bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::HeadMutation,
 							                                  oldLineCountBeforeHeadTrim, false,
-							                                  trimmedHeadCount);
+							                                  trimmedHeadCount, 0, headLineRestitched);
 						}
 					}
 					else
@@ -6345,7 +6895,8 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 				else if (cacheTrimmed)
 				{
 					bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::HeadMutation,
-					                                  oldLineCountBeforeHeadTrim, false, trimmedHeadCount);
+					                                  oldLineCountBeforeHeadTrim, false, trimmedHeadCount, 0,
+					                                  headLineRestitched);
 				}
 
 				finalizeRuntimeCacheMetadata(runtimeNowContiguous);
@@ -6399,9 +6950,11 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 
 	const int oldLineCountBeforeHeadTrim = sizeToInt(m_nativeRenderLineCache.size());
 	bool      cacheTrimmed               = false;
+	bool      headLineRestitched         = false;
 	int       trimmedHeadCount           = 0;
 	if (newFirstLineNumber > oldFirstLineNumber)
 	{
+		m_nativeRenderRuntimeIndexBase += qMax<qint64>(0, newFirstLineNumber - oldFirstLineNumber);
 		int dropCount = 0;
 		while (dropCount < m_nativeRenderLineCache.size() &&
 		       renderLineBeforeRuntimeLine(m_nativeRenderLineCache.at(dropCount), newFirstLineNumber))
@@ -6418,7 +6971,8 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 		if (!m_nativeRenderLineCache.isEmpty() &&
 		    renderLineStraddlesRuntimeLine(m_nativeRenderLineCache.first(), newFirstLineNumber))
 		{
-			if (!restitchTrimmedHeadLogicalLine(newFirstLineNumber))
+			const bool appendWillFollow = newLastLineNumber > oldLastLineNumber;
+			if (!restitchTrimmedHeadLogicalLine(newFirstLineNumber, cacheTrimmed || appendWillFollow))
 			{
 				recordNativeRestitchFailureDiagnostic(NativeRestitchFailureDiagnosticKind::HeadTrim,
 				                                      qMax(0, trimmedHeadCount));
@@ -6427,6 +6981,7 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 				                       NativeAppendDiagnosticKind::SoftRestitchFailure);
 				return finalizeNativeOutputRenderLines();
 			}
+			headLineRestitched = true;
 		}
 	}
 
@@ -6452,22 +7007,28 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 			m_nativeCachedRuntimeLastHardReturn                 = runtimePreviousEntry.hardReturn;
 			m_nativeCachedRuntimeLastEntry                      = runtimePreviousEntry;
 		}
-		if (cacheTrimmed)
+		if (cacheTrimmed || headLineRestitched)
 		{
-			bool appendChanged     = false;
-			bool appendTailMutated = false;
+			bool                             appendChanged     = false;
+			bool                             appendTailMutated = false;
+			const NativeAppendDiagnosticKind diagnosticKind =
+			    cacheTrimmed ? NativeAppendDiagnosticKind::HeadTrimTailAppend
+			                 : NativeAppendDiagnosticKind::TailAppend;
 			appendRuntimeRange(appendStartIndex, true, &appendChanged, &appendTailMutated, nullptr, -1,
-			                   NativeAppendDiagnosticKind::HeadTrimTailAppend);
+			                   diagnosticKind);
 			if (appendChanged)
 			{
-				bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::HeadTrimTailAppend,
-				                                  oldLineCountBeforeHeadTrim, appendTailMutated,
-				                                  trimmedHeadCount);
+				const NativeRenderCacheDeltaKind deltaKind =
+				    cacheTrimmed ? NativeRenderCacheDeltaKind::HeadTrimTailAppend
+				                 : NativeRenderCacheDeltaKind::TailAppend;
+				bumpNativeRenderLineCacheRevision(deltaKind, oldLineCountBeforeHeadTrim, appendTailMutated,
+				                                  trimmedHeadCount, 0, headLineRestitched);
 			}
 			else
 			{
 				bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::HeadMutation,
-				                                  oldLineCountBeforeHeadTrim, false, trimmedHeadCount);
+				                                  oldLineCountBeforeHeadTrim, false, trimmedHeadCount, 0,
+				                                  headLineRestitched);
 			}
 		}
 		else
@@ -6479,7 +7040,8 @@ const WorldView::NativeOutputRenderLines &WorldView::nativeOutputRenderLines() c
 	else if (cacheTrimmed)
 	{
 		bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind::HeadMutation,
-		                                  oldLineCountBeforeHeadTrim, false, trimmedHeadCount);
+		                                  oldLineCountBeforeHeadTrim, false, trimmedHeadCount, 0,
+		                                  headLineRestitched);
 	}
 
 	finalizeRuntimeCacheMetadata(true);
@@ -6539,9 +7101,8 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 		ensureNativeLayoutCaches(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont);
 	const qreal effectiveLineAdvance =
 	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : lineAdvance;
-	qreal     docY = m_nativeLayoutCumulativeHeights.size() > lines.size()
-	                     ? nativeLayoutCumulativeHeightAt(lines.size())
-	                     : 0.0;
+	qreal docY =
+	    m_nativeLayoutHeightIndex.size() == lines.size() ? m_nativeLayoutHeightIndex.totalHeight() : 0.0;
 
 	const int nativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
 	int       scrollY         = 0;
@@ -6568,21 +7129,16 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	int         lineIndex = sizeToInt(lines.size()) - 1;
 	qreal       lineY     = 0.0;
 	qreal       lineYEnd  = docY;
-	const auto  firstAbove =
-	    std::upper_bound(m_nativeLayoutCumulativeHeights.cbegin() + 1, m_nativeLayoutCumulativeHeights.cend(),
-	                     yDoc + m_nativeLayoutCumulativeHeightOrigin);
-	lineIndex = qBound(0, static_cast<int>(firstAbove - m_nativeLayoutCumulativeHeights.cbegin()) - 1,
-	                   sizeToInt(lines.size()) - 1);
-	lineY     = nativeLayoutCumulativeHeightAt(lineIndex);
-	lineYEnd  = nativeLayoutCumulativeHeightAt(lineIndex + 1);
+	lineIndex             = qBound(0, nativeLayoutLineAtY(yDoc), sizeToInt(lines.size()) - 1);
+	lineY                 = nativeLayoutCumulativeHeightAt(lineIndex);
+	lineYEnd              = nativeLayoutCumulativeHeightAt(lineIndex + 1);
 	if (allowCacheBuild &&
 	    ensureNativeLayoutRange(lines, qMax(0, lineIndex - 2),
 	                            qMin(sizeToInt(lines.size()) - 1, lineIndex + 2), wrapWidthPixels,
 	                            localWrapWidthPixels, lineSpacing, layoutFont))
 	{
-		docY                             = m_nativeLayoutCumulativeHeights.size() > lines.size()
-		                                       ? nativeLayoutCumulativeHeightAt(lines.size())
-		                                       : 0.0;
+		docY =
+		    m_nativeLayoutHeightIndex.size() == lines.size() ? m_nativeLayoutHeightIndex.totalHeight() : 0.0;
 		const int updatedNativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
 		if (updatedNativeMaxScroll > 0)
 		{
@@ -6595,15 +7151,10 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 			else
 				effectiveScrollY = qBound(0, scrollY, updatedNativeMaxScroll);
 		}
-		const qreal updatedYDoc       = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
-		const auto  updatedFirstAbove = std::upper_bound(m_nativeLayoutCumulativeHeights.cbegin() + 1,
-		                                                 m_nativeLayoutCumulativeHeights.cend(),
-		                                                 updatedYDoc + m_nativeLayoutCumulativeHeightOrigin);
-		lineIndex =
-		    qBound(0, static_cast<int>(updatedFirstAbove - m_nativeLayoutCumulativeHeights.cbegin()) - 1,
-		           sizeToInt(lines.size()) - 1);
-		lineY    = nativeLayoutCumulativeHeightAt(lineIndex);
-		lineYEnd = nativeLayoutCumulativeHeightAt(lineIndex + 1);
+		const qreal updatedYDoc = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
+		lineIndex               = qBound(0, nativeLayoutLineAtY(updatedYDoc), sizeToInt(lines.size()) - 1);
+		lineY                   = nativeLayoutCumulativeHeightAt(lineIndex);
+		lineYEnd                = nativeLayoutCumulativeHeightAt(lineIndex + 1);
 	}
 
 	const NativeOutputRenderLine &line = lines.at(lineIndex);
@@ -6715,7 +7266,8 @@ bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const Nat
 	if (viewportRect.width() <= 0 || viewportRect.height() <= 0)
 		return false;
 
-	const int    lineIndex = qBound(0, position.line, sizeToInt(lines.size()) - 1);
+	const int    lineCount = sizeToInt(lines.size());
+	const int    lineIndex = qBound(0, position.line, lineCount - 1);
 
 	const bool   wrapEnabled          = view->lineWrapMode() != WrapTextBrowser::NoWrap;
 	const int    wrapWidthPixels      = nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
@@ -6734,17 +7286,16 @@ bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const Nat
 		syncNativeOutputScrollBarsFromLayout(lines, false);
 	}
 
-	if (lineIndex + 1 >= m_nativeLayoutCumulativeHeights.size())
+	if (m_nativeLayoutHeightIndex.size() != lines.size())
 		return false;
 
 	const qreal effectiveLineAdvance =
 	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : fallbackLineAdvance;
-	const qreal docY            = m_nativeLayoutCumulativeHeights.size() > lines.size()
-	                                  ? nativeLayoutCumulativeHeightAt(lines.size())
-	                                  : 0.0;
-	const int   nativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
-	int         scrollY         = 0;
-	int         scrollMax       = 0;
+	const qreal docY =
+	    m_nativeLayoutHeightIndex.size() == lines.size() ? m_nativeLayoutHeightIndex.totalHeight() : 0.0;
+	const int nativeMaxScroll = qMax(0, static_cast<int>(std::ceil(docY)) - viewportRect.height());
+	int       scrollY         = 0;
+	int       scrollMax       = 0;
 	if (const QScrollBar *const bar = view->verticalScrollBar())
 	{
 		scrollY   = qMax(0, bar->value());
@@ -6851,7 +7402,7 @@ void WorldView::scrollNativeOutputRangeIntoView(const WrapTextBrowser *view, int
 	if (layoutHeightChanged)
 		syncNativeOutputScrollBarsFromLayout(lines, false);
 
-	if (lastLine + 1 >= m_nativeLayoutCumulativeHeights.size())
+	if (m_nativeLayoutHeightIndex.size() != lines.size())
 		return;
 
 	const int rangeTop = qMax(0, static_cast<int>(std::floor(nativeLayoutCumulativeHeightAt(firstLine))));
@@ -6999,29 +7550,116 @@ void WorldView::clearNativeOutputSelection(const bool notify)
 		applyResolvedOutputSelection(false, 0, 0, 0, 0);
 }
 
-void WorldView::applyPendingNativeSelectionHeadTrim(const NativeOutputRenderLines &lines)
+WorldView::NativeOutputPositionIdentity
+WorldView::nativeOutputSelectionIdentityForPosition(const NativeOutputRenderLines &lines,
+                                                    const NativeOutputPosition    &position)
 {
-	const int trimCount = m_nativeSelectionPendingHeadTrimLines;
-	if (trimCount <= 0)
+	if (position.line < 0 || position.line >= sizeToInt(lines.size()))
+		return {};
+
+	const NativeOutputRenderLine &line = lines.at(position.line);
+	if (line.firstRuntimeLineNumber <= 0 && line.lastRuntimeLineNumber <= 0)
+		return {};
+	return {
+	    nativeRuntimeLineKey(line),
+	    line.firstRuntimeLineNumber,
+	    line.lastRuntimeLineNumber,
+	};
+}
+
+bool WorldView::remapNativeOutputSelectionPosition(NativeOutputPosition               &position,
+                                                   const NativeOutputPositionIdentity &identity,
+                                                   const NativeOutputRenderLines      &lines) const
+{
+	if (lines.isEmpty())
+		return false;
+
+	auto lineMatchesIdentity = [&lines, &identity](const int lineIndex)
+	{
+		if (lineIndex < 0 || lineIndex >= sizeToInt(lines.size()))
+			return false;
+		if (identity.firstRuntimeLineNumber <= 0 && identity.lastRuntimeLineNumber <= 0)
+			return false;
+		const NativeOutputRenderLine &line = lines.at(lineIndex);
+		if (identity.lineKey != 0 && nativeRuntimeLineKey(line) == identity.lineKey)
+			return true;
+		if (identity.firstRuntimeLineNumber > 0 &&
+		    nativeRuntimeLineRangeContains(line, identity.firstRuntimeLineNumber))
+		{
+			return true;
+		}
+		return identity.lastRuntimeLineNumber > 0 &&
+		       nativeRuntimeLineRangeContains(line, identity.lastRuntimeLineNumber);
+	};
+
+	const int maxLine       = sizeToInt(lines.size()) - 1;
+	const int expectedIndex = qBound(0, position.line - m_nativeSelectionPendingHeadTrimLines, maxLine);
+	if (lineMatchesIdentity(expectedIndex))
+	{
+		position.line   = expectedIndex;
+		position.column = qBound(0, position.column, sizeToInt(lines.at(position.line).text.size()));
+		return true;
+	}
+	if (lineMatchesIdentity(position.line))
+	{
+		position.line   = qBound(0, position.line, maxLine);
+		position.column = qBound(0, position.column, sizeToInt(lines.at(position.line).text.size()));
+		return true;
+	}
+
+	const int searchRadius = qMin(512, maxLine);
+	for (int distance = 1; distance <= searchRadius; ++distance)
+	{
+		const int beforeIndex = expectedIndex - distance;
+		if (lineMatchesIdentity(beforeIndex))
+		{
+			position.line   = beforeIndex;
+			position.column = qBound(0, position.column, sizeToInt(lines.at(position.line).text.size()));
+			return true;
+		}
+		const int afterIndex = expectedIndex + distance;
+		if (lineMatchesIdentity(afterIndex))
+		{
+			position.line   = afterIndex;
+			position.column = qBound(0, position.column, sizeToInt(lines.at(position.line).text.size()));
+			return true;
+		}
+	}
+
+	const int lineCount = sizeToInt(lines.size());
+	for (int lineIndex = 0; lineIndex < lineCount; ++lineIndex)
+	{
+		if (!lineMatchesIdentity(lineIndex))
+			continue;
+		position.line   = lineIndex;
+		position.column = qBound(0, position.column, sizeToInt(lines.at(position.line).text.size()));
+		return true;
+	}
+	return false;
+}
+
+void WorldView::applyPendingNativeSelectionRenderDelta(const NativeOutputRenderLines &lines)
+{
+	const int  trimCount       = m_nativeSelectionPendingHeadTrimLines;
+	const bool revisionChanged = m_nativeOutputSelection.renderRevision != m_nativeRenderLineCacheRevision;
+	if (trimCount <= 0 && !revisionChanged)
 		return;
-	m_nativeSelectionPendingHeadTrimLines = 0;
 
 	if (!m_nativeOutputSelection.hasSelection && !m_nativeOutputSelection.dragging)
+	{
+		m_nativeSelectionPendingHeadTrimLines = 0;
 		return;
+	}
 	if (lines.isEmpty())
 	{
 		clearNativeOutputSelection(true);
 		return;
 	}
 
-	auto shiftLineIndex = [trimCount](NativeOutputPosition &position) { position.line -= trimCount; };
-	shiftLineIndex(m_nativeOutputSelection.anchor);
-	shiftLineIndex(m_nativeOutputSelection.cursor);
-	shiftLineIndex(m_nativeOutputSelection.start);
-	shiftLineIndex(m_nativeOutputSelection.end);
-
-	if (m_nativeOutputSelection.anchor.line < 0 || m_nativeOutputSelection.cursor.line < 0 ||
-	    m_nativeOutputSelection.start.line < 0 || m_nativeOutputSelection.end.line < 0)
+	if (!remapNativeOutputSelectionPosition(m_nativeOutputSelection.anchor,
+	                                        m_nativeOutputSelection.anchorIdentity, lines) ||
+	    !remapNativeOutputSelectionPosition(m_nativeOutputSelection.cursor,
+	                                        m_nativeOutputSelection.cursorIdentity, lines))
 	{
 		clearNativeOutputSelection(true);
 		return;
@@ -7036,8 +7674,6 @@ void WorldView::applyPendingNativeSelectionHeadTrim(const NativeOutputRenderLine
 	};
 	clampPosition(m_nativeOutputSelection.anchor);
 	clampPosition(m_nativeOutputSelection.cursor);
-	clampPosition(m_nativeOutputSelection.start);
-	clampPosition(m_nativeOutputSelection.end);
 
 	NativeOutputPosition start = m_nativeOutputSelection.anchor;
 	NativeOutputPosition end   = m_nativeOutputSelection.cursor;
@@ -7046,6 +7682,12 @@ void WorldView::applyPendingNativeSelectionHeadTrim(const NativeOutputRenderLine
 	m_nativeOutputSelection.start        = start;
 	m_nativeOutputSelection.end          = end;
 	m_nativeOutputSelection.hasSelection = start.line != end.line || start.column != end.column;
+	m_nativeOutputSelection.anchorIdentity =
+	    nativeOutputSelectionIdentityForPosition(lines, m_nativeOutputSelection.anchor);
+	m_nativeOutputSelection.cursorIdentity =
+	    nativeOutputSelectionIdentityForPosition(lines, m_nativeOutputSelection.cursor);
+	m_nativeOutputSelection.renderRevision = m_nativeRenderLineCacheRevision;
+	m_nativeSelectionPendingHeadTrimLines  = 0;
 	if (!m_nativeOutputSelection.hasSelection)
 		clearNativeOutputSelection(true);
 }
@@ -7072,7 +7714,7 @@ void WorldView::clearNativeSelectionIfOutsideVisibleViewport(const WrapTextBrows
 		return;
 	}
 
-	applyPendingNativeSelectionHeadTrim(lines);
+	applyPendingNativeSelectionRenderDelta(lines);
 	if (!m_nativeOutputSelection.hasSelection)
 		return;
 }
@@ -7129,6 +7771,11 @@ void WorldView::setNativeOutputSelection(const WrapTextBrowser      *sourceView,
 	m_nativeOutputSelection.cursor       = {cursorLine, cursorCol};
 	m_nativeOutputSelection.start        = start;
 	m_nativeOutputSelection.end          = end;
+	m_nativeOutputSelection.anchorIdentity =
+	    nativeOutputSelectionIdentityForPosition(lines, m_nativeOutputSelection.anchor);
+	m_nativeOutputSelection.cursorIdentity =
+	    nativeOutputSelectionIdentityForPosition(lines, m_nativeOutputSelection.cursor);
+	m_nativeOutputSelection.renderRevision = m_nativeRenderLineCacheRevision;
 	if (hasSelection)
 		m_lastOutputSelectionView = const_cast<WrapTextBrowser *>(sourceView);
 	else if (m_lastOutputSelectionView == sourceView)
@@ -7159,7 +7806,7 @@ bool WorldView::nativeOutputSelectionBounds(int &startLine, int &startColumn, in
 	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return false;
-	const_cast<WorldView *>(this)->applyPendingNativeSelectionHeadTrim(lines);
+	const_cast<WorldView *>(this)->applyPendingNativeSelectionRenderDelta(lines);
 	if (!m_nativeOutputSelection.hasSelection)
 		return false;
 
@@ -7544,18 +8191,20 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 	paintNativeOutputBackground(painter, clippedUpdateRegion);
 	paintMiniWindows(painter, true, clippedUpdateRegion);
 
-	const bool renderCacheNeedsSync = !nativeRenderBaseCacheMatchesCurrentSource();
-	if (renderCacheNeedsSync)
-		const_cast<WorldView *>(this)->requestNativeRuntimeOutputPresentationSync(false, false);
-
-	const NativeOutputRenderLines &lines =
-	    renderCacheNeedsSync ? m_nativeRenderLineCache : finalizeNativeOutputRenderLines();
-	const bool diagnosticsEnabled = nativeCanvasDiagnosticsEnabled();
+	const NativeOutputRenderLines &lines              = nativeOutputRenderLines();
+	const bool                     diagnosticsEnabled = nativeCanvasDiagnosticsEnabled();
 	if (diagnosticsEnabled)
 	{
+		QStringList tailLines;
+		const int   tailStart = qMax(0, sizeToInt(lines.size()) - 8);
+		tailLines.reserve(sizeToInt(lines.size()) - tailStart);
+		const int lineCount = sizeToInt(lines.size());
+		for (int i = tailStart; i < lineCount; ++i)
+			tailLines.push_back(lines.at(i).text);
 		m_nativeOutputCanvas->setProperty("qmud_native_plain_line_count", lines.size());
 		m_nativeOutputCanvas->setProperty("qmud_native_plain_last_line",
 		                                  lines.isEmpty() ? QString() : lines.constLast().text);
+		m_nativeOutputCanvas->setProperty("qmud_native_plain_tail_lines", tailLines);
 		m_nativeOutputCanvas->setProperty("qmud_native_visual_row_count", 0);
 		m_nativeOutputCanvas->setProperty("qmud_native_cache_full_rebuilds", m_nativeRenderCacheFullRebuilds);
 		m_nativeOutputCanvas->setProperty("qmud_native_cache_soft_rebuilds", m_nativeRenderCacheSoftRebuilds);
@@ -7657,9 +8306,8 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 	}
 	const qreal effectiveLineAdvance =
 	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : fallbackLineAdvance;
-	qreal     docY = m_nativeLayoutCumulativeHeights.size() > lines.size()
-	                     ? nativeLayoutCumulativeHeightAt(lines.size())
-	                     : 0.0;
+	qreal docY =
+	    m_nativeLayoutHeightIndex.size() == lines.size() ? m_nativeLayoutHeightIndex.totalHeight() : 0.0;
 	const int totalVisualRows =
 	    effectiveLineAdvance > 0.0 ? qMax(0, static_cast<int>(std::round(docY / effectiveLineAdvance))) : 0;
 	for (RenderPane &pane : panes)
@@ -7706,18 +8354,8 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 		painter->setClipRegion(clippedPaneRegion);
 		const bool drawSelectionForPane =
 		    hasNativeSelection && pane.view && pane.view == m_nativeOutputSelection.sourceView;
-		auto firstVisibleIt =
-		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
-		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
-		int firstVisibleLine =
-		    qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
-		auto lastVisibleIt =
-		    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
-		                                                   m_nativeLayoutCumulativeHeights.cend()),
-		                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
-		int lastVisibleLine = qMin(sizeToInt(lines.size()) - 1,
-		                           sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
+		int firstVisibleLine = nativeLayoutLineAtY(visibleTop);
+		int lastVisibleLine  = qMin(sizeToInt(lines.size()) - 1, nativeLayoutLineAtY(visibleBottom));
 		if (firstVisibleLine > lastVisibleLine)
 		{
 			painter->restore();
@@ -7729,33 +8367,22 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 		                            qMin(sizeToInt(lines.size()) - 1, lastVisibleLine + 2), wrapWidthPixels,
 		                            localWrapWidthPixels, lineSpacingSetting, layoutFont))
 		{
-			docY             = m_nativeLayoutCumulativeHeights.size() > lines.size()
-			                       ? nativeLayoutCumulativeHeightAt(lines.size())
-			                       : 0.0;
+			docY = m_nativeLayoutHeightIndex.size() == lines.size() ? m_nativeLayoutHeightIndex.totalHeight()
+			                                                        : 0.0;
 			nativeMaxScroll  = qMax(0, static_cast<int>(std::ceil(docY)) - pane.textRect.height());
 			effectiveScrollY = nativeMaxScroll > 0 ? qBound(0, pane.scrollY, nativeMaxScroll) : 0;
 			visibleTop       = static_cast<qreal>(effectiveScrollY) +
 			                   static_cast<qreal>(clippedPaneRect.top() - pane.textRect.top());
 			visibleBottom    = static_cast<qreal>(effectiveScrollY) +
 			                   static_cast<qreal>(clippedPaneRect.bottom() - pane.textRect.top());
-			firstVisibleIt =
-			    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin() + 1,
-			                                                   m_nativeLayoutCumulativeHeights.cend()),
-			                             visibleTop + m_nativeLayoutCumulativeHeightOrigin);
-			firstVisibleLine =
-			    qMax(0, sizeToInt(firstVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
-			lastVisibleIt =
-			    std::ranges::upper_bound(std::ranges::subrange(m_nativeLayoutCumulativeHeights.cbegin(),
-			                                                   m_nativeLayoutCumulativeHeights.cend()),
-			                             visibleBottom + m_nativeLayoutCumulativeHeightOrigin);
-			lastVisibleLine = qMin(sizeToInt(lines.size()) - 1,
-			                       sizeToInt(lastVisibleIt - m_nativeLayoutCumulativeHeights.cbegin()) - 1);
+			firstVisibleLine = nativeLayoutLineAtY(visibleTop);
+			lastVisibleLine  = qMin(sizeToInt(lines.size()) - 1, nativeLayoutLineAtY(visibleBottom));
 		}
+		qreal lineTop = nativeLayoutCumulativeHeightAt(firstVisibleLine);
 		for (int i = firstVisibleLine; i <= lastVisibleLine; ++i)
 		{
 			const NativeOutputRenderLine &line        = lines.at(i);
-			const qreal                   lineTop     = nativeLayoutCumulativeHeightAt(i);
-			const qreal                   lineBottom  = nativeLayoutCumulativeHeightAt(i + 1);
+			const qreal                   lineBottom  = lineTop + m_nativeLayoutHeightIndex.heightAt(i);
 			const qreal                   lineOpacity = qBound(0.0, line.opacity, 1.0);
 			const int                     lineY       = static_cast<int>(
 			    std::floor(static_cast<qreal>(pane.textRect.top() - effectiveScrollY) + lineTop));
@@ -7765,7 +8392,10 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 			                         qMax(1, lineBottomY - lineY));
 			lineBackgroundRect = lineBackgroundRect.intersected(clippedPaneRect);
 			if (lineBackgroundRect.isEmpty() || !clippedPaneRegion.intersects(lineBackgroundRect))
+			{
+				lineTop = lineBottom;
 				continue;
+			}
 			if (clearScrollBlitLineBackgrounds)
 			{
 				if (!lineBackgroundRect.isEmpty() && !scrollBlitExposedRect.contains(lineBackgroundRect))
@@ -7794,11 +8424,17 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 			}
 
 			if (line.text.isEmpty())
+			{
+				lineTop = lineBottom;
 				continue;
+			}
 
 			const QTextLayout *layout = nativeLayoutForLine(i);
 			if (!layout || layout->lineCount() <= 0)
+			{
+				lineTop = lineBottom;
 				continue;
+			}
 
 			QVector<QRectF> selectionRects;
 			if (drawSelectionForPane && i >= selectionStartLineZero && i <= selectionEndLineZero)
@@ -7850,6 +8486,7 @@ void WorldView::paintNativeOutputCanvas(QPainter *painter, const QRegion &update
 
 			for (const QRectF &rect : std::as_const(selectionRects))
 				painter->fillRect(rect, selectionColour);
+			lineTop = lineBottom;
 		}
 		painter->restore();
 		updateNativeOutputPanePaintState(pane.view, pane.textRect, clippedPaneRegion, effectiveScrollY,
@@ -8676,7 +9313,7 @@ void WorldView::selectOutputRange(int zeroBasedLine, int startColumn, int endCol
 	if (layoutHeightChanged)
 		syncNativeOutputScrollBarsFromLayout(lines, false);
 
-	if (zeroBasedLine + 1 >= m_nativeLayoutCumulativeHeights.size())
+	if (m_nativeLayoutHeightIndex.size() != lines.size())
 		return;
 
 	const int lineTop = qMax(0, static_cast<int>(std::floor(nativeLayoutCumulativeHeightAt(zeroBasedLine))));
@@ -9643,11 +10280,6 @@ void WorldView::updatePartialOutputText(const QString &text, const QVector<World
 			m_nativePartialOutputSpans.push_back(span);
 		}
 	}
-	if (m_nativeLayoutCacheValid)
-	{
-		const int tailIndex               = qMax(0, sizeToInt(m_nativeLayoutVisualRows.size()) - 1);
-		m_nativeLayoutCumulativeDirtyFrom = qMin(m_nativeLayoutCumulativeDirtyFrom, tailIndex);
-	}
 	syncOutputTextVisibilityForNativeCanvas();
 	requestOutputScrollToEnd();
 	requestNativeOutputTailRepaint();
@@ -9665,15 +10297,10 @@ void WorldView::clearPartialOutput()
 	m_nativeHasPartialOutput = false;
 	m_nativePartialOutputText.clear();
 	m_nativePartialOutputSpans.clear();
-	removeNativePartialRenderLineOverlay(false);
+	removeNativePartialRenderLineOverlay(true);
 	m_hasPartialOutput    = false;
 	m_partialOutputStart  = 0;
 	m_partialOutputLength = 0;
-	if (m_nativeLayoutCacheValid)
-	{
-		const int tailIndex               = qMax(0, sizeToInt(m_nativeLayoutVisualRows.size()) - 1);
-		m_nativeLayoutCumulativeDirtyFrom = qMin(m_nativeLayoutCumulativeDirtyFrom, tailIndex);
-	}
 	syncOutputTextVisibilityForNativeCanvas();
 	requestNativeOutputTailRepaint();
 	requestOutputScrollToEnd();
@@ -9689,14 +10316,9 @@ bool WorldView::commitPendingIncomingPartialOutput()
 	m_nativeHasPartialOutput = false;
 	m_nativePartialOutputText.clear();
 	m_nativePartialOutputSpans.clear();
-	m_hasPartialOutput    = false;
-	m_partialOutputStart  = 0;
-	m_partialOutputLength = 0;
-	if (m_nativeLayoutCacheValid)
-	{
-		const int tailIndex               = qMax(0, sizeToInt(m_nativeLayoutVisualRows.size()) - 1);
-		m_nativeLayoutCumulativeDirtyFrom = qMin(m_nativeLayoutCumulativeDirtyFrom, tailIndex);
-	}
+	m_hasPartialOutput                  = false;
+	m_partialOutputStart                = 0;
+	m_partialOutputLength               = 0;
 	m_nativeRenderLineCacheFromRuntime  = true;
 	m_accessibleOutputPendingTailAppend = true;
 	syncOutputTextVisibilityForNativeCanvas();
@@ -11822,7 +12444,7 @@ void WorldView::updateLineInformationTooltip(const QWidget *watched, const QMous
 	}
 
 	const NativeOutputRenderLines &renderLines = nativeOutputRenderLines();
-	if (hit.line < 0 || hit.line >= renderLines.size())
+	if (hit.line < 0 || hit.line >= sizeToInt(renderLines.size()))
 	{
 		hideLineInfoTooltip();
 		return;
@@ -11831,14 +12453,26 @@ void WorldView::updateLineInformationTooltip(const QWidget *watched, const QMous
 	const NativeOutputRenderLine  &renderLine   = renderLines.at(hit.line);
 	const auto                    &runtimeLines = m_runtime->lines();
 	const WorldRuntime::LineEntry *resolvedLine = nullptr;
-	if (renderLine.firstRuntimeLineNumber > 0)
+	const qint64 expectedRuntimeLineNumber      = renderLine.sourceRuntimeLineNumbers.isEmpty()
+	                                                  ? renderLine.firstRuntimeLineNumber
+	                                                  : renderLine.sourceRuntimeLineNumbers.constFirst();
+	if (expectedRuntimeLineNumber > 0 && renderLine.firstRuntimeLineIndex >= 0)
 	{
-		const int runtimeIndex = findRuntimeLineIndexByNumberNear(
-		    runtimeLines, renderLine.firstRuntimeLineNumber, hit.line, false);
-		if (runtimeIndex >= 0 && runtimeIndex < runtimeLines.size())
+		const qint64 runtimeIndex = renderLine.firstRuntimeLineIndex - m_nativeRenderRuntimeIndexBase;
+		if (runtimeIndex >= 0 && runtimeIndex < runtimeLines.size() &&
+		    runtimeLines.at(runtimeIndex).lineNumber == expectedRuntimeLineNumber)
+		{
+			resolvedLine = &runtimeLines.at(runtimeIndex);
+		}
+	}
+	if (!resolvedLine && expectedRuntimeLineNumber > 0)
+	{
+		const int runtimeIndex =
+		    findRuntimeLineIndexByNumberNear(runtimeLines, expectedRuntimeLineNumber, hit.line, false);
+		if (runtimeIndex >= 0 && runtimeIndex < sizeToInt(runtimeLines.size()))
 			resolvedLine = &runtimeLines.at(runtimeIndex);
 	}
-	if (!resolvedLine && hit.line < runtimeLines.size())
+	if (!resolvedLine && hit.line < sizeToInt(runtimeLines.size()))
 		resolvedLine = &runtimeLines.at(hit.line);
 	if (!resolvedLine)
 	{

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -2577,10 +2577,16 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLin
 			    m_nativeLayoutSlots.size() == lines.size() &&
 			    m_nativeLayoutHeightIndex.size() == lines.size())
 			{
+				const bool pendingSplitTopHeadTrim =
+				    m_nativeSplitTopHeadTrimAdjustedRevision != m_nativeRenderLineCacheRevision &&
+				    m_nativeSplitTopHeadTrimPixelsRevision == m_nativeRenderLineCacheRevision &&
+				    m_nativeSplitTopHeadTrimLines > 0;
 				const int headTrimCount =
-				    (m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision)
-				        ? qMax(0, m_nativeRenderCacheDelta.headTrimCount)
-				        : 0;
+				    pendingSplitTopHeadTrim
+				        ? m_nativeSplitTopHeadTrimLines
+				        : ((m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision)
+				               ? qMax(0, m_nativeRenderCacheDelta.headTrimCount)
+				               : 0);
 				auto findAnchorLineIndex = [this, &lines, headTrimCount](const int     oldLineIndex,
 				                                                         const quint64 anchorKey,
 				                                                         const qint64 anchorRuntimeLineNumber)
@@ -2654,8 +2660,8 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLin
 					    anchorTopOffset;
 					targetValue           = qBound(0, anchoredValue, maxScroll);
 					splitTopAnchorApplied = true;
-					if (m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-					    m_nativeRenderCacheDelta.headTrimCount > 0)
+					if (m_nativeSplitTopHeadTrimPixelsRevision == m_nativeRenderLineCacheRevision &&
+					    m_nativeSplitTopHeadTrimPixels > 0)
 					{
 						m_nativeSplitTopHeadTrimAdjustedRevision = m_nativeRenderLineCacheRevision;
 					}
@@ -2664,9 +2670,8 @@ void WorldView::syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLin
 			}
 			if (!splitTopAnchorApplied && !canAutoFollowTail &&
 			    m_nativeSplitTopHeadTrimAdjustedRevision != m_nativeRenderLineCacheRevision &&
-			    m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-			    m_nativeRenderCacheDelta.headTrimCount > 0 &&
-			    m_nativeSplitTopHeadTrimPixelsRevision == m_nativeRenderLineCacheRevision)
+			    m_nativeSplitTopHeadTrimPixelsRevision == m_nativeRenderLineCacheRevision &&
+			    m_nativeSplitTopHeadTrimPixels > 0)
 			{
 				const int trimmedScroll                  = qMax(0, m_nativeSplitTopHeadTrimPixels);
 				targetValue                              = qMax(0, targetValue - trimmedScroll);
@@ -2943,17 +2948,7 @@ bool WorldView::requestNativeOutputScrollAwarePresentationRepaint(
 		return false;
 	dirtyRect = dirtyRect.intersected(paneRect);
 
-	const bool hasHeadTrim =
-	    m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::HeadTrimTailAppend ||
-	    m_nativeRenderCacheDelta.headTrimCount > 0;
-	int scrollDelta = currentScrollY - m_nativePrimaryPaintState.scrollY;
-	if (hasHeadTrim)
-	{
-		if (m_nativeSplitTopHeadTrimPixelsRevision != m_nativeRenderLineCacheRevision ||
-		    m_nativeSplitTopHeadTrimPixels <= 0)
-			return false;
-		scrollDelta += m_nativeSplitTopHeadTrimPixels;
-	}
+	const int scrollDelta = currentScrollY - m_nativePrimaryPaintState.scrollY;
 
 	if (scrollDelta == 0)
 	{
@@ -4486,14 +4481,25 @@ bool WorldView::nativeLayoutCacheReadyFor(const NativeOutputRenderLines &lines, 
                                           const int localWrapWidthPixels, const int lineSpacingSetting,
                                           const QFont &layoutFont) const
 {
+	return !m_nativeLayoutRangePreparedOnly &&
+	       nativeLayoutRangeStateReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting,
+	                                      layoutFont);
+}
+
+bool WorldView::nativeLayoutRangeStateReadyFor(const NativeOutputRenderLines &lines,
+                                               const int wrapWidthPixels, const int localWrapWidthPixels,
+                                               const int lineSpacingSetting, const QFont &layoutFont) const
+{
 	const qreal lineSpacingFactor = (100.0 + static_cast<qreal>(lineSpacingSetting)) / 100.0;
 	const qreal lineAdvance =
 	    static_cast<qreal>(qMax(1, QFontMetrics(layoutFont).lineSpacing())) * lineSpacingFactor;
 	const quint64 styleKey = nativeLayoutStyleKey();
 	const bool    cacheDimensionsMatch =
 	    m_nativeLayoutHeightIndex.size() == lines.size() && m_nativeLayoutSlots.size() == lines.size();
-	return m_nativeLayoutCacheValid && cacheDimensionsMatch &&
-	       m_nativeLayoutCachedRenderRevision == m_nativeRenderLineCacheRevision &&
+	const bool revisionReady = m_nativeLayoutCachedRenderRevision == m_nativeRenderLineCacheRevision ||
+	                           (m_nativeLayoutRangePreparedOnly &&
+	                            m_nativeLayoutRangePreparedRevision == m_nativeRenderLineCacheRevision);
+	return m_nativeLayoutCacheValid && cacheDimensionsMatch && revisionReady &&
 	       m_nativeLayoutCachedWrapWidth == wrapWidthPixels &&
 	       m_nativeLayoutCachedLocalWrapWidth == localWrapWidthPixels &&
 	       m_nativeLayoutCachedLineSpacing == lineSpacingSetting &&
@@ -4580,6 +4586,266 @@ int WorldView::estimateNativeLineRows(const NativeOutputRenderLine &line, const 
 	return qMax(1, rows);
 }
 
+bool WorldView::prepareNativeLayoutRangeState(const NativeOutputRenderLines &lines, const int wrapWidthPixels,
+                                              const int localWrapWidthPixels, const int lineSpacingSetting,
+                                              const QFont &layoutFont) const
+{
+	if (lines.isEmpty())
+		return false;
+
+	const qreal lineSpacingFactor = (100.0 + static_cast<qreal>(lineSpacingSetting)) / 100.0;
+	const qreal defaultLineAdvance =
+	    static_cast<qreal>(qMax(1, QFontMetrics(layoutFont).lineSpacing())) * lineSpacingFactor;
+	const quint64 styleKey = nativeLayoutStyleKey();
+
+	const bool    cacheWasValid = m_nativeLayoutCacheValid;
+	const bool    keyMatches = cacheWasValid && m_nativeLayoutCachedWrapWidth == wrapWidthPixels &&
+	                           m_nativeLayoutCachedLocalWrapWidth == localWrapWidthPixels &&
+	                           m_nativeLayoutCachedLineSpacing == lineSpacingSetting &&
+	                           m_nativeLayoutCachedStyleKey == styleKey &&
+	                           m_nativeLayoutCachedFont == layoutFont &&
+	                           qFuzzyCompare(m_nativeLayoutCachedLineAdvance + 1.0, defaultLineAdvance + 1.0);
+
+	auto          setCacheKey = [&]
+	{
+		m_nativeLayoutCacheValid            = true;
+		m_nativeLayoutCachedWrapWidth       = wrapWidthPixels;
+		m_nativeLayoutCachedLocalWrapWidth  = localWrapWidthPixels;
+		m_nativeLayoutCachedLineSpacing     = lineSpacingSetting;
+		m_nativeLayoutCachedStyleKey        = styleKey;
+		m_nativeLayoutCachedLineAdvance     = defaultLineAdvance;
+		m_nativeLayoutCachedFont            = layoutFont;
+		m_nativeLayoutRangePreparedRevision = m_nativeRenderLineCacheRevision;
+		m_nativeLayoutRangePreparedOnly     = true;
+	};
+
+	auto resetAllMetadata = [&]
+	{
+		m_nativeLayoutSlots.assign(lines.size(), NativeLayoutSlot{});
+		m_nativeLayoutHeightIndex.assign(lines.size(), defaultLineAdvance);
+		m_nativeLayoutExactPrefixCount = 0;
+	};
+
+	auto resetSlot = [&](const int index)
+	{
+		if (index < 0 || index >= sizeToInt(m_nativeLayoutSlots.size()) ||
+		    index >= sizeToInt(m_nativeLayoutHeightIndex.size()))
+		{
+			return;
+		}
+		m_nativeLayoutSlots[index] = NativeLayoutSlot{};
+		m_nativeLayoutHeightIndex.setHeight(index, defaultLineAdvance);
+		if (index < m_nativeLayoutExactPrefixCount)
+			m_nativeLayoutExactPrefixCount = index;
+	};
+
+	auto replaceMetadataRange = [&](const int first, const int removeCount, const int insertCount)
+	{
+		const int lineCount     = sizeToInt(m_nativeLayoutSlots.size());
+		const int boundedFirst  = qBound(0, first, lineCount);
+		const int boundedRemove = qBound(0, removeCount, lineCount - boundedFirst);
+		const int boundedInsert = qMax(0, insertCount);
+		m_nativeLayoutSlots.replace(boundedFirst, boundedRemove, boundedInsert, NativeLayoutSlot{});
+		m_nativeLayoutHeightIndex.replace(boundedFirst, boundedRemove, boundedInsert, defaultLineAdvance);
+		if (boundedFirst < m_nativeLayoutExactPrefixCount)
+			m_nativeLayoutExactPrefixCount = boundedFirst;
+		else
+			m_nativeLayoutExactPrefixCount =
+			    qMin(m_nativeLayoutExactPrefixCount, sizeToInt(m_nativeLayoutSlots.size()));
+	};
+
+	auto dropHead = [&](const int requestedCount)
+	{
+		const int count = qBound(0, requestedCount, sizeToInt(m_nativeLayoutSlots.size()));
+		if (count <= 0)
+			return;
+		m_nativeLayoutSlots.remove(0, count);
+		m_nativeLayoutHeightIndex.removeFront(count);
+		m_nativeLayoutExactPrefixCount = qMax(0, m_nativeLayoutExactPrefixCount - count);
+	};
+
+	auto dimensionsMatch = [&](const int expectedSize)
+	{
+		return sizeToInt(m_nativeLayoutSlots.size()) == expectedSize &&
+		       sizeToInt(m_nativeLayoutHeightIndex.size()) == expectedSize;
+	};
+
+	if (!keyMatches)
+	{
+		resetAllMetadata();
+		clearCurrentNativeSplitTopHeadTrimAdjustment();
+		setCacheKey();
+		return true;
+	}
+
+	if (nativeLayoutRangeStateReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting,
+	                                   layoutFont))
+	{
+		return true;
+	}
+
+	auto collectRangeReplayDeltas = [&]
+	{
+		QVector<NativeRenderCacheDelta> replayDeltas;
+		quint64 expectedRevision = m_nativeLayoutRangePreparedOnly ? m_nativeLayoutRangePreparedRevision
+		                                                           : m_nativeLayoutCachedRenderRevision;
+		for (const NativeRenderCacheDelta &delta : std::as_const(m_nativeRenderCacheDeltas))
+		{
+			if (delta.revision <= expectedRevision)
+				continue;
+			if (delta.fromRevision != expectedRevision)
+				return QVector<NativeRenderCacheDelta>{};
+			replayDeltas.push_back(delta);
+			expectedRevision = delta.revision;
+			if (expectedRevision == m_nativeRenderLineCacheRevision)
+				break;
+		}
+		if (expectedRevision != m_nativeRenderLineCacheRevision)
+			replayDeltas.clear();
+		return replayDeltas;
+	};
+
+	NativeSplitTopHeadTrimAdjustment pendingSplitTopHeadTrimAdjustment;
+	auto mergePendingSplitTopHeadTrimAdjustment = [&](const NativeSplitTopHeadTrimAdjustment &adjustment)
+	{
+		if (!adjustment.valid)
+			return;
+		if (pendingSplitTopHeadTrimAdjustment.valid &&
+		    pendingSplitTopHeadTrimAdjustment.revision == adjustment.revision)
+		{
+			pendingSplitTopHeadTrimAdjustment.pixels += adjustment.pixels;
+			pendingSplitTopHeadTrimAdjustment.lines += adjustment.lines;
+			return;
+		}
+		pendingSplitTopHeadTrimAdjustment = adjustment;
+	};
+
+	auto applyMetadataDelta = [&](const NativeRenderCacheDelta &delta)
+	{
+		const int                              oldSize = qMax(0, delta.oldLineCount);
+		const int                              newSize = qMax(0, delta.newLineCount);
+		const NativeSplitTopHeadTrimAdjustment splitTopHeadTrimAdjustment =
+		    nativeSplitTopHeadTrimAdjustmentForDelta(delta, defaultLineAdvance,
+		                                             m_nativeRenderLineCacheRevision);
+		auto applySuccessfulSplitTopHeadTrimAdjustment = [&]
+		{
+			mergePendingSplitTopHeadTrimAdjustment(splitTopHeadTrimAdjustment);
+			return true;
+		};
+		if (delta.kind == NativeRenderCacheDeltaKind::FullReset)
+		{
+			resetAllMetadata();
+			pendingSplitTopHeadTrimAdjustment = {};
+			clearNativeSplitTopHeadTrimAdjustment();
+			return true;
+		}
+		if (!dimensionsMatch(oldSize))
+			return false;
+
+		switch (delta.kind)
+		{
+		case NativeRenderCacheDeltaKind::TailAppend:
+		{
+			const int insertCount = qMax(0, newSize - oldSize);
+			replaceMetadataRange(oldSize, 0, insertCount);
+			if (delta.headLineMutated)
+				resetSlot(0);
+			if (delta.tailLineMutated && oldSize > 0)
+				resetSlot(oldSize - 1);
+			return dimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
+		}
+		case NativeRenderCacheDeltaKind::TailRemove:
+		{
+			const int removeCount = qMax(0, oldSize - newSize);
+			replaceMetadataRange(newSize, removeCount, 0);
+			if (delta.tailLineMutated && newSize > 0)
+				resetSlot(newSize - 1);
+			return dimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
+		}
+		case NativeRenderCacheDeltaKind::HeadMutation:
+		{
+			dropHead(qBound(0, delta.headTrimCount, oldSize));
+			if (dimensionsMatch(newSize))
+			{
+				if (newSize > 0)
+					resetSlot(0);
+				return applySuccessfulSplitTopHeadTrimAdjustment();
+			}
+			break;
+		}
+		case NativeRenderCacheDeltaKind::HeadTrimTailAppend:
+		{
+			const int headTrimCount = qBound(0, delta.headTrimCount, oldSize);
+			if (headTrimCount <= 0 || oldSize < headTrimCount)
+				return false;
+			const int preservedCount = qBound(0, oldSize - headTrimCount, newSize);
+			const int insertCount    = newSize - preservedCount;
+			if (insertCount < 0)
+				return false;
+			dropHead(headTrimCount);
+			replaceMetadataRange(preservedCount, 0, insertCount);
+			if (delta.headLineMutated && newSize > 0)
+				resetSlot(0);
+			if (delta.tailLineMutated && preservedCount > 0)
+				resetSlot(preservedCount - 1);
+			return dimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
+		}
+		case NativeRenderCacheDeltaKind::RuntimeLineRestitch:
+		{
+			if (oldSize == newSize)
+			{
+				resetSlot(qBound(0, delta.stablePrefixCount, qMax(0, newSize - 1)));
+				return applySuccessfulSplitTopHeadTrimAdjustment();
+			}
+			break;
+		}
+		case NativeRenderCacheDeltaKind::RuntimeRangeRestitch:
+		{
+			const int headTrimCount = qBound(0, delta.headTrimCount, oldSize);
+			dropHead(headTrimCount);
+			const int  postTrimOldSize = oldSize - headTrimCount;
+			const int  replaceFirst    = qBound(0, delta.replaceFirstLine, postTrimOldSize);
+			const int  removeCount     = qBound(0, delta.removedLineCount, postTrimOldSize - replaceFirst);
+			const int  insertCount     = qBound(0, delta.insertedLineCount, newSize);
+			const bool structuralRemap = postTrimOldSize - removeCount + insertCount == newSize;
+			if (!structuralRemap)
+				return false;
+			replaceMetadataRange(replaceFirst, removeCount, insertCount);
+			if (delta.headLineMutated && newSize > 0)
+				resetSlot(0);
+			return dimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
+		}
+		case NativeRenderCacheDeltaKind::FullReset:
+		case NativeRenderCacheDeltaKind::Unknown:
+			break;
+		}
+		return false;
+	};
+
+	const QVector<NativeRenderCacheDelta> replayDeltas  = collectRangeReplayDeltas();
+	bool                                  appliedDeltas = !replayDeltas.isEmpty();
+	for (const NativeRenderCacheDelta &delta : replayDeltas)
+	{
+		if (applyMetadataDelta(delta))
+			continue;
+		appliedDeltas = false;
+		break;
+	}
+
+	if (!appliedDeltas || !dimensionsMatch(sizeToInt(lines.size())))
+	{
+		resetAllMetadata();
+		clearCurrentNativeSplitTopHeadTrimAdjustment();
+	}
+	else
+	{
+		applyNativeSplitTopHeadTrimAdjustment(pendingSplitTopHeadTrimAdjustment);
+	}
+
+	setCacheKey();
+	return true;
+}
+
 bool WorldView::ensureNativeLayoutRange(const NativeOutputRenderLines &lines, int firstLine, int lastLine,
                                         const int wrapWidthPixels, const int localWrapWidthPixels,
                                         const int lineSpacingSetting, const QFont &layoutFont) const
@@ -4587,11 +4853,12 @@ bool WorldView::ensureNativeLayoutRange(const NativeOutputRenderLines &lines, in
 	if (lines.isEmpty())
 		return false;
 
-	if (!nativeLayoutCacheReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting,
-	                               layoutFont))
+	if (!nativeLayoutRangeStateReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting,
+	                                    layoutFont))
 	{
-		ensureNativeLayoutCaches(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting,
-		                         layoutFont);
+		if (!prepareNativeLayoutRangeState(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacingSetting,
+		                                   layoutFont))
+			return false;
 	}
 
 	firstLine = qBound(0, firstLine, sizeToInt(lines.size()) - 1);
@@ -4609,8 +4876,10 @@ bool WorldView::ensureNativeLayoutRange(const NativeOutputRenderLines &lines, in
 		const bool  hasPreviousSlot = i < sizeToInt(m_nativeLayoutSlots.size());
 		const int   previousRows    = hasPreviousSlot ? m_nativeLayoutSlots.at(i).visualRows : 0;
 		const uchar previousExact   = hasPreviousSlot ? m_nativeLayoutSlots.at(i).rowsExact : 0;
-		const int   exactRows   = ensureNativeLineLayout(lines, i, wrapWidthPixels, localWrapWidthPixels,
-		                                                 defaultLineAdvance, layoutFont, layoutContentSalt);
+		const int   exactRows = ensureNativeLineLayout(lines, i, wrapWidthPixels, localWrapWidthPixels,
+		                                               defaultLineAdvance, layoutFont, layoutContentSalt);
+		if (i < sizeToInt(m_nativeLayoutSlots.size()))
+			m_nativeLayoutSlots[i].runtimeLineKey = nativeRuntimeLineKey(lines.at(i));
 		const qreal exactHeight = static_cast<qreal>(qMax(1, exactRows)) * defaultLineAdvance;
 		if (!qFuzzyCompare(m_nativeLayoutHeightIndex.heightAt(i) + 1.0, exactHeight + 1.0))
 		{
@@ -4647,6 +4916,86 @@ void WorldView::refreshNativeLayoutExactPrefixFrom(const int firstLine) const
 	while (exactPrefix < lineCount && m_nativeLayoutSlots.at(exactPrefix).rowsExact != 0)
 		++exactPrefix;
 	m_nativeLayoutExactPrefixCount = exactPrefix;
+}
+
+WorldView::NativeSplitTopHeadTrimAdjustment WorldView::nativeSplitTopHeadTrimAdjustmentForDelta(
+    const NativeRenderCacheDelta &delta, const qreal defaultLineAdvance, const quint64 targetRevision) const
+{
+	const quint64 recordedRevision = targetRevision != 0 ? targetRevision : m_nativeRenderLineCacheRevision;
+	if (recordedRevision == 0 || delta.revision == 0 || delta.revision > recordedRevision ||
+	    delta.headTrimCount <= 0)
+	{
+		return {};
+	}
+
+	const int oldSize       = qMax(0, delta.oldLineCount);
+	const int headTrimCount = qBound(0, delta.headTrimCount, oldSize);
+	if (headTrimCount <= 0 || sizeToInt(m_nativeLayoutSlots.size()) != oldSize)
+		return {};
+
+	qreal trimmedHeadDocY = -1.0;
+	if (sizeToInt(m_nativeLayoutHeightIndex.size()) == oldSize &&
+	    headTrimCount <= sizeToInt(m_nativeLayoutHeightIndex.size()))
+	{
+		trimmedHeadDocY = qMax<qreal>(0.0, nativeLayoutCumulativeHeightAt(headTrimCount));
+	}
+	else
+	{
+		const qreal oldLineAdvance =
+		    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : defaultLineAdvance;
+		qreal sumRows       = 0.0;
+		bool  haveExactRows = true;
+		for (int i = 0; i < headTrimCount; ++i)
+		{
+			const int visualRows = m_nativeLayoutSlots.at(i).visualRows;
+			if (visualRows <= 0)
+			{
+				haveExactRows = false;
+				break;
+			}
+			sumRows += static_cast<qreal>(visualRows) * oldLineAdvance;
+		}
+		if (haveExactRows)
+			trimmedHeadDocY = sumRows;
+	}
+
+	if (trimmedHeadDocY < 0.0)
+		return {};
+
+	const int trimmedPixels = qMax(0, static_cast<int>(std::round(trimmedHeadDocY)));
+	return {.valid = true, .revision = recordedRevision, .pixels = trimmedPixels, .lines = headTrimCount};
+}
+
+void WorldView::clearNativeSplitTopHeadTrimAdjustment() const
+{
+	m_nativeSplitTopHeadTrimPixelsRevision = 0;
+	m_nativeSplitTopHeadTrimPixels         = 0;
+	m_nativeSplitTopHeadTrimLines          = 0;
+}
+
+void WorldView::clearCurrentNativeSplitTopHeadTrimAdjustment() const
+{
+	if (m_nativeSplitTopHeadTrimPixelsRevision != m_nativeRenderLineCacheRevision)
+		return;
+	clearNativeSplitTopHeadTrimAdjustment();
+}
+
+void WorldView::applyNativeSplitTopHeadTrimAdjustment(
+    const NativeSplitTopHeadTrimAdjustment &adjustment) const
+{
+	if (!adjustment.valid)
+		return;
+
+	if (m_nativeSplitTopHeadTrimPixelsRevision == adjustment.revision)
+	{
+		m_nativeSplitTopHeadTrimPixels += adjustment.pixels;
+		m_nativeSplitTopHeadTrimLines += adjustment.lines;
+		return;
+	}
+
+	m_nativeSplitTopHeadTrimPixelsRevision = adjustment.revision;
+	m_nativeSplitTopHeadTrimPixels         = adjustment.pixels;
+	m_nativeSplitTopHeadTrimLines          = adjustment.lines;
 }
 
 int WorldView::ensureNativeLineLayout(const NativeOutputRenderLines &lines, const int index,
@@ -4760,55 +5109,16 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 
 	const bool layoutCacheKeyChanged = !cacheWasValid || wrapChanged || lineSpacingChanged || fontChanged ||
 	                                   styleChanged || lineAdvanceChanged;
+	const bool rangePreparedOnly     = m_nativeLayoutRangePreparedOnly;
+	const bool rangePreparedAtCurrent =
+	    rangePreparedOnly && m_nativeLayoutRangePreparedRevision == m_nativeRenderLineCacheRevision;
 
 	const bool cacheDimensionsMatch =
 	    m_nativeLayoutHeightIndex.size() == lines.size() && m_nativeLayoutSlots.size() == lines.size();
 	if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && !renderRevisionChanged &&
-	    cacheDimensionsMatch)
+	    cacheDimensionsMatch && !rangePreparedOnly)
 	{
 		return;
-	}
-
-	if (cacheWasValid && renderRevisionChanged &&
-	    m_nativeRenderCacheDelta.revision == m_nativeRenderLineCacheRevision &&
-	    m_nativeRenderCacheDelta.headTrimCount > 0)
-	{
-		const int oldSize       = qMax(0, m_nativeRenderCacheDelta.oldLineCount);
-		const int headTrimCount = qBound(0, m_nativeRenderCacheDelta.headTrimCount, oldSize);
-		if (headTrimCount > 0 && sizeToInt(m_nativeLayoutSlots.size()) == oldSize)
-		{
-			qreal trimmedHeadDocY = -1.0;
-			if (sizeToInt(m_nativeLayoutHeightIndex.size()) == oldSize &&
-			    headTrimCount <= sizeToInt(m_nativeLayoutHeightIndex.size()))
-			{
-				trimmedHeadDocY = qMax<qreal>(0.0, nativeLayoutCumulativeHeightAt(headTrimCount));
-			}
-			else
-			{
-				const qreal oldLineAdvance = m_nativeLayoutCachedLineAdvance > 0.0
-				                                 ? m_nativeLayoutCachedLineAdvance
-				                                 : defaultLineAdvance;
-				qreal       sumRows        = 0.0;
-				bool        haveExactRows  = true;
-				for (int i = 0; i < headTrimCount; ++i)
-				{
-					const int visualRows = m_nativeLayoutSlots.at(i).visualRows;
-					if (visualRows <= 0)
-					{
-						haveExactRows = false;
-						break;
-					}
-					sumRows += static_cast<qreal>(visualRows) * oldLineAdvance;
-				}
-				if (haveExactRows)
-					trimmedHeadDocY = sumRows;
-			}
-			if (trimmedHeadDocY >= 0.0)
-			{
-				m_nativeSplitTopHeadTrimPixelsRevision = m_nativeRenderLineCacheRevision;
-				m_nativeSplitTopHeadTrimPixels = qMax(0, static_cast<int>(std::round(trimmedHeadDocY)));
-			}
-		}
 	}
 
 	auto runtimeLineKeyForLine = [](const NativeOutputRenderLine &line)
@@ -5055,7 +5365,8 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 	auto collectLayoutReplayDeltas = [&]
 	{
 		QVector<NativeRenderCacheDelta> replayDeltas;
-		quint64                         expectedRevision = m_nativeLayoutCachedRenderRevision;
+		quint64 expectedRevision = m_nativeLayoutRangePreparedOnly ? m_nativeLayoutRangePreparedRevision
+		                                                           : m_nativeLayoutCachedRenderRevision;
 		for (const NativeRenderCacheDelta &delta : std::as_const(m_nativeRenderCacheDeltas))
 		{
 			if (delta.revision <= expectedRevision)
@@ -5072,10 +5383,33 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 		return replayDeltas;
 	};
 
+	NativeSplitTopHeadTrimAdjustment pendingSplitTopHeadTrimAdjustment;
+	auto mergePendingSplitTopHeadTrimAdjustment = [&](const NativeSplitTopHeadTrimAdjustment &adjustment)
+	{
+		if (!adjustment.valid)
+			return;
+		if (pendingSplitTopHeadTrimAdjustment.valid &&
+		    pendingSplitTopHeadTrimAdjustment.revision == adjustment.revision)
+		{
+			pendingSplitTopHeadTrimAdjustment.pixels += adjustment.pixels;
+			pendingSplitTopHeadTrimAdjustment.lines += adjustment.lines;
+			return;
+		}
+		pendingSplitTopHeadTrimAdjustment = adjustment;
+	};
+
 	auto applyExactRenderDelta = [&](const NativeRenderCacheDelta &delta)
 	{
-		const int oldSize = qMax(0, delta.oldLineCount);
-		const int newSize = qMax(0, delta.newLineCount);
+		const int                              oldSize = qMax(0, delta.oldLineCount);
+		const int                              newSize = qMax(0, delta.newLineCount);
+		const NativeSplitTopHeadTrimAdjustment splitTopHeadTrimAdjustment =
+		    nativeSplitTopHeadTrimAdjustmentForDelta(delta, defaultLineAdvance,
+		                                             m_nativeRenderLineCacheRevision);
+		auto applySuccessfulSplitTopHeadTrimAdjustment = [&]
+		{
+			mergePendingSplitTopHeadTrimAdjustment(splitTopHeadTrimAdjustment);
+			return true;
+		};
 		if (delta.kind != NativeRenderCacheDeltaKind::FullReset && !layoutDimensionsMatch(oldSize))
 			return false;
 
@@ -5085,6 +5419,8 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 			resetLayoutLineCaches(newSize);
 			m_nativeLayoutHeightIndex.assign(newSize, defaultLineAdvance);
 			markHeightRangeDirty(0, newSize);
+			pendingSplitTopHeadTrimAdjustment = {};
+			clearNativeSplitTopHeadTrimAdjustment();
 			return true;
 		case NativeRenderCacheDeltaKind::TailAppend:
 		{
@@ -5097,7 +5433,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 			const int stablePrefix =
 			    headLineMutated ? 0 : qBound(0, oldSize - (tailLineMutated ? 1 : 0), newSize);
 			markHeightRangeDirty(stablePrefix, newSize);
-			return layoutDimensionsMatch(newSize);
+			return layoutDimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
 		}
 		case NativeRenderCacheDeltaKind::TailRemove:
 		{
@@ -5107,7 +5443,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 			const bool tailLineMutated = delta.tailLineMutated && newSize > 0;
 			const int  stablePrefix    = qBound(0, newSize - (tailLineMutated ? 1 : 0), newSize);
 			markHeightRangeDirty(stablePrefix, newSize);
-			return layoutDimensionsMatch(newSize);
+			return layoutDimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
 		}
 		case NativeRenderCacheDeltaKind::HeadTrimTailAppend:
 		{
@@ -5125,7 +5461,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 			const bool tailLineMutated = delta.tailLineMutated && preservedCount > 0;
 			const int  tailDirtyFirst  = qBound(0, preservedCount - (tailLineMutated ? 1 : 0), newSize);
 			markHeightRangeDirty(tailDirtyFirst, newSize);
-			return layoutDimensionsMatch(newSize);
+			return layoutDimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
 		}
 		case NativeRenderCacheDeltaKind::RuntimeLineRestitch:
 		{
@@ -5133,7 +5469,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 				return false;
 			const int changedIndex = qBound(0, delta.stablePrefixCount, newSize - 1);
 			replaceLayoutRange(changedIndex, 1, 1, true);
-			return layoutDimensionsMatch(newSize);
+			return layoutDimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
 		}
 		case NativeRenderCacheDeltaKind::RuntimeRangeRestitch:
 		{
@@ -5151,7 +5487,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 				markHeightRangeDirty(replaceFirst, replaceFirst + insertCount);
 			if (delta.headLineMutated && newSize > 0)
 				markHeightRangeDirty(0, 1);
-			return layoutDimensionsMatch(newSize);
+			return layoutDimensionsMatch(newSize) ? applySuccessfulSplitTopHeadTrimAdjustment() : false;
 		}
 		case NativeRenderCacheDeltaKind::HeadMutation:
 		{
@@ -5161,7 +5497,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 				return false;
 			if ((delta.headLineMutated || headTrimCount <= 0) && newSize > 0)
 				markHeightRangeDirty(0, 1);
-			return true;
+			return applySuccessfulSplitTopHeadTrimAdjustment();
 		}
 		case NativeRenderCacheDeltaKind::Unknown:
 			return false;
@@ -5172,19 +5508,36 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 	bool renderDeltaFastPathApplied = false;
 	if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged)
 	{
-		const QVector<NativeRenderCacheDelta> replayDeltas  = collectLayoutReplayDeltas();
-		bool                                  replayApplied = !replayDeltas.isEmpty();
-		for (const NativeRenderCacheDelta &delta : replayDeltas)
+		if (rangePreparedAtCurrent)
 		{
-			if (!applyExactRenderDelta(delta))
-			{
-				replayApplied = false;
-				break;
-			}
+			invalidateUnreusableAlignedRanges(0, sizeToInt(lines.size()));
+			renderDeltaFastPathApplied = true;
 		}
-		if (!replayApplied)
-			resetAllLayoutCachesForCurrentLines();
-		renderDeltaFastPathApplied = true;
+		else
+		{
+			const QVector<NativeRenderCacheDelta> replayDeltas  = collectLayoutReplayDeltas();
+			bool                                  replayApplied = !replayDeltas.isEmpty();
+			for (const NativeRenderCacheDelta &delta : replayDeltas)
+			{
+				if (!applyExactRenderDelta(delta))
+				{
+					replayApplied = false;
+					break;
+				}
+			}
+			if (replayApplied && !layoutDimensionsMatch(sizeToInt(lines.size())))
+				replayApplied = false;
+			if (!replayApplied)
+			{
+				resetAllLayoutCachesForCurrentLines();
+				clearCurrentNativeSplitTopHeadTrimAdjustment();
+			}
+			else
+			{
+				applyNativeSplitTopHeadTrimAdjustment(pendingSplitTopHeadTrimAdjustment);
+			}
+			renderDeltaFastPathApplied = true;
+		}
 	}
 
 	auto pruneConsumedRenderDeltas = [this]
@@ -5202,6 +5555,8 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 
 	const bool layoutRangesMatch = renderDeltaFastPathApplied ? true : [&]
 	{
+		if (rangePreparedOnly)
+			return true;
 		if (renderRevisionChanged)
 			return false;
 		if (m_nativeLayoutSlots.size() != lines.size())
@@ -5212,9 +5567,11 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 		       m_nativeLayoutSlots.constLast().runtimeLineKey == runtimeLineKeyForLine(lines.constLast());
 	}();
 	if (cacheWasValid && !layoutCacheKeyChanged && !localWrapChanged && renderRevisionChanged &&
-	    renderDeltaFastPathApplied && dirtyHeightRanges.isEmpty())
+	    renderDeltaFastPathApplied && dirtyHeightRanges.isEmpty() && !rangePreparedOnly)
 	{
-		m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
+		m_nativeLayoutCachedRenderRevision  = m_nativeRenderLineCacheRevision;
+		m_nativeLayoutRangePreparedOnly     = false;
+		m_nativeLayoutRangePreparedRevision = 0;
 		pruneConsumedRenderDeltas();
 		return;
 	}
@@ -5250,6 +5607,7 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 		m_nativeLayoutCachedLineAdvance    = defaultLineAdvance;
 		m_nativeLayoutCachedFont           = layoutFont;
 		m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
+		clearCurrentNativeSplitTopHeadTrimAdjustment();
 		++m_nativeLayoutCacheResets;
 	}
 	else if ((renderRevisionChanged && !renderDeltaFastPathApplied) || !layoutRangesMatch)
@@ -5401,12 +5759,15 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 			m_nativeLayoutHeightIndex.resize(lines.size(), defaultLineAdvance);
 			markHeightRangeDirty(0, sizeToInt(lines.size()));
 		}
+		if (rangePreparedOnly && !renderDeltaFastPathApplied)
+			invalidateUnreusableAlignedRanges(0, sizeToInt(lines.size()));
 	}
 
 	if (cacheWasValid && localWrapChanged)
 	{
 		m_nativeLayoutCachedLocalWrapWidth = localWrapWidthPixels;
 		invalidateLayoutSlots(0, sizeToInt(lines.size()));
+		clearCurrentNativeSplitTopHeadTrimAdjustment();
 	}
 
 	if (m_nativeLayoutHeightIndex.size() != lines.size())
@@ -5452,7 +5813,9 @@ void WorldView::ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, c
 		refreshHeightRange(range.first, range.second);
 	if (!dirtyHeightRanges.isEmpty())
 		refreshNativeLayoutExactPrefixFrom(dirtyHeightRanges.constFirst().first);
-	m_nativeLayoutCachedRenderRevision = m_nativeRenderLineCacheRevision;
+	m_nativeLayoutCachedRenderRevision  = m_nativeRenderLineCacheRevision;
+	m_nativeLayoutRangePreparedOnly     = false;
+	m_nativeLayoutRangePreparedRevision = 0;
 	pruneConsumedRenderDeltas();
 }
 
@@ -5513,7 +5876,13 @@ void WorldView::bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(
 
 void WorldView::commitNativeRenderCacheDelta(NativeRenderCacheDelta delta) const
 {
-	const quint64 previousRevision = m_nativeRenderLineCacheRevision;
+	const quint64 previousRevision         = m_nativeRenderLineCacheRevision;
+	const bool    canCarrySplitTopHeadTrim = delta.kind != NativeRenderCacheDeltaKind::FullReset &&
+	                                         delta.kind != NativeRenderCacheDeltaKind::Unknown;
+	const bool    carryPendingSplitTopHeadTrim =
+	    canCarrySplitTopHeadTrim && m_nativeSplitTopHeadTrimPixelsRevision == previousRevision &&
+	    m_nativeSplitTopHeadTrimAdjustedRevision != previousRevision && m_nativeSplitTopHeadTrimPixels > 0 &&
+	    m_nativeSplitTopHeadTrimLines > 0;
 	++m_nativeRenderLineCacheRevision;
 	delta.fromRevision = previousRevision;
 	delta.revision     = m_nativeRenderLineCacheRevision;
@@ -5524,8 +5893,10 @@ void WorldView::commitNativeRenderCacheDelta(NativeRenderCacheDelta delta) const
 	m_nativeRenderCacheDeltas.push_back(delta);
 	if (delta.headTrimCount > 0)
 		m_nativeSelectionPendingHeadTrimLines += delta.headTrimCount;
-	m_nativeSplitTopHeadTrimPixelsRevision = 0;
-	m_nativeSplitTopHeadTrimPixels         = 0;
+	if (carryPendingSplitTopHeadTrim)
+		m_nativeSplitTopHeadTrimPixelsRevision = m_nativeRenderLineCacheRevision;
+	else
+		clearNativeSplitTopHeadTrimAdjustment();
 }
 
 void WorldView::markNativeRuntimeTailRestitchPending() const
@@ -7094,11 +7465,15 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 	                           ((100.0 + static_cast<qreal>(lineSpacing)) / 100.0);
 	const QFont &layoutFont  = view->font();
 	const bool   cacheReadyForHitTest =
-	    nativeLayoutCacheReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont);
+	    nativeLayoutRangeStateReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont);
 	if (!allowCacheBuild && !cacheReadyForHitTest)
 		return false;
 	if (!cacheReadyForHitTest)
-		ensureNativeLayoutCaches(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont);
+	{
+		if (!prepareNativeLayoutRangeState(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing,
+		                                   layoutFont))
+			return false;
+	}
 	const qreal effectiveLineAdvance =
 	    m_nativeLayoutCachedLineAdvance > 0.0 ? m_nativeLayoutCachedLineAdvance : lineAdvance;
 	qreal docY =
@@ -7125,13 +7500,13 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 			effectiveScrollY = qBound(0, scrollY, nativeMaxScroll);
 	}
 
-	const qreal yDoc      = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
-	int         lineIndex = sizeToInt(lines.size()) - 1;
-	qreal       lineY     = 0.0;
-	qreal       lineYEnd  = docY;
-	lineIndex             = qBound(0, nativeLayoutLineAtY(yDoc), sizeToInt(lines.size()) - 1);
-	lineY                 = nativeLayoutCumulativeHeightAt(lineIndex);
-	lineYEnd              = nativeLayoutCumulativeHeightAt(lineIndex + 1);
+	qreal yDoc      = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
+	int   lineIndex = sizeToInt(lines.size()) - 1;
+	qreal lineY     = 0.0;
+	qreal lineYEnd  = docY;
+	lineIndex       = qBound(0, nativeLayoutLineAtY(yDoc), sizeToInt(lines.size()) - 1);
+	lineY           = nativeLayoutCumulativeHeightAt(lineIndex);
+	lineYEnd        = nativeLayoutCumulativeHeightAt(lineIndex + 1);
 	if (allowCacheBuild &&
 	    ensureNativeLayoutRange(lines, qMax(0, lineIndex - 2),
 	                            qMin(sizeToInt(lines.size()) - 1, lineIndex + 2), wrapWidthPixels,
@@ -7151,10 +7526,14 @@ bool WorldView::nativeOutputHitTest(const WrapTextBrowser *view, const QPoint &v
 			else
 				effectiveScrollY = qBound(0, scrollY, updatedNativeMaxScroll);
 		}
-		const qreal updatedYDoc = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
-		lineIndex               = qBound(0, nativeLayoutLineAtY(updatedYDoc), sizeToInt(lines.size()) - 1);
-		lineY                   = nativeLayoutCumulativeHeightAt(lineIndex);
-		lineYEnd                = nativeLayoutCumulativeHeightAt(lineIndex + 1);
+		else
+		{
+			effectiveScrollY = 0;
+		}
+		yDoc      = static_cast<qreal>(effectiveScrollY) + static_cast<qreal>(y);
+		lineIndex = qBound(0, nativeLayoutLineAtY(yDoc), sizeToInt(lines.size()) - 1);
+		lineY     = nativeLayoutCumulativeHeightAt(lineIndex);
+		lineYEnd  = nativeLayoutCumulativeHeightAt(lineIndex + 1);
 	}
 
 	const NativeOutputRenderLine &line = lines.at(lineIndex);
@@ -7277,14 +7656,9 @@ bool WorldView::nativeOutputCharacterRect(const WrapTextBrowser *view, const Nat
 	const qreal  fallbackLineAdvance  = static_cast<qreal>(qMax(1, QFontMetrics(layoutFont).lineSpacing())) *
 	                                    ((100.0 + static_cast<qreal>(lineSpacing)) / 100.0);
 
-	if (!nativeLayoutCacheReadyFor(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont))
-		ensureNativeLayoutCaches(lines, wrapWidthPixels, localWrapWidthPixels, lineSpacing, layoutFont);
-	if (ensureNativeLayoutRange(lines, qMax(0, lineIndex - 2),
-	                            qMin(sizeToInt(lines.size()) - 1, lineIndex + 2), wrapWidthPixels,
-	                            localWrapWidthPixels, lineSpacing, layoutFont))
-	{
-		syncNativeOutputScrollBarsFromLayout(lines, false);
-	}
+	static_cast<void>(ensureNativeLayoutRange(
+	    lines, qMax(0, lineIndex - 2), qMin(sizeToInt(lines.size()) - 1, lineIndex + 2), wrapWidthPixels,
+	    localWrapWidthPixels, lineSpacing, layoutFont));
 
 	if (m_nativeLayoutHeightIndex.size() != lines.size())
 		return false;
@@ -7500,7 +7874,8 @@ bool WorldView::nativeOutputHitTestForMouseEvent(const QWidget *watched, const Q
 }
 
 void WorldView::applyResolvedOutputSelection(const bool hasSelection, const int startLine,
-                                             const int startColumn, const int endLine, const int endColumn)
+                                             const int startColumn, const int endLine, const int endColumn,
+                                             const bool allowClipboardCopy)
 {
 	const bool selectionSame =
 	    (hasSelection == m_hasOutputSelection && startLine == m_lastSelectionStartLine &&
@@ -7515,7 +7890,7 @@ void WorldView::applyResolvedOutputSelection(const bool hasSelection, const int 
 	m_lastSelectionEndLine     = endLine;
 	m_lastSelectionEndColumn   = endColumn;
 
-	if (hasSelection && m_runtime)
+	if (allowClipboardCopy && hasSelection && m_runtime)
 	{
 		const QMap<QString, QString> &attrs   = m_runtime->worldAttributes();
 		auto                          enabled = [](const QString &value)
@@ -7638,6 +8013,52 @@ bool WorldView::remapNativeOutputSelectionPosition(NativeOutputPosition         
 	return false;
 }
 
+WorldView::NativeOutputSelectionResolveResult
+WorldView::resolveNativeOutputSelectionStateForLines(const NativeOutputRenderLines &lines,
+                                                     NativeOutputSelectionState    &selection) const
+{
+	selection = m_nativeOutputSelection;
+	if (!selection.hasSelection && !selection.dragging)
+		return NativeOutputSelectionResolveResult::Unmapped;
+	if (lines.isEmpty())
+		return NativeOutputSelectionResolveResult::Unmapped;
+
+	const bool needsRemap = m_nativeSelectionPendingHeadTrimLines > 0 ||
+	                        selection.renderRevision != m_nativeRenderLineCacheRevision;
+	if (needsRemap)
+	{
+		if (!remapNativeOutputSelectionPosition(selection.anchor, selection.anchorIdentity, lines) ||
+		    !remapNativeOutputSelectionPosition(selection.cursor, selection.cursorIdentity, lines))
+		{
+			return NativeOutputSelectionResolveResult::Unmapped;
+		}
+	}
+
+	const int maxLine       = sizeToInt(lines.size()) - 1;
+	auto      clampPosition = [&lines, maxLine](NativeOutputPosition &position)
+	{
+		position.line    = qBound(0, position.line, maxLine);
+		const int maxCol = sizeToInt(lines.at(position.line).text.size());
+		position.column  = qBound(0, position.column, maxCol);
+	};
+	clampPosition(selection.anchor);
+	clampPosition(selection.cursor);
+
+	NativeOutputPosition start = selection.anchor;
+	NativeOutputPosition end   = selection.cursor;
+	if (start.line > end.line || (start.line == end.line && start.column > end.column))
+		qSwap(start, end);
+
+	selection.start          = start;
+	selection.end            = end;
+	selection.hasSelection   = start.line != end.line || start.column != end.column;
+	selection.anchorIdentity = nativeOutputSelectionIdentityForPosition(lines, selection.anchor);
+	selection.cursorIdentity = nativeOutputSelectionIdentityForPosition(lines, selection.cursor);
+	selection.renderRevision = m_nativeRenderLineCacheRevision;
+	return selection.hasSelection ? NativeOutputSelectionResolveResult::MappedSelection
+	                              : NativeOutputSelectionResolveResult::MappedCollapsed;
+}
+
 void WorldView::applyPendingNativeSelectionRenderDelta(const NativeOutputRenderLines &lines)
 {
 	const int  trimCount       = m_nativeSelectionPendingHeadTrimLines;
@@ -7656,40 +8077,29 @@ void WorldView::applyPendingNativeSelectionRenderDelta(const NativeOutputRenderL
 		return;
 	}
 
-	if (!remapNativeOutputSelectionPosition(m_nativeOutputSelection.anchor,
-	                                        m_nativeOutputSelection.anchorIdentity, lines) ||
-	    !remapNativeOutputSelectionPosition(m_nativeOutputSelection.cursor,
-	                                        m_nativeOutputSelection.cursorIdentity, lines))
+	NativeOutputSelectionState               resolvedSelection;
+	const NativeOutputSelectionResolveResult resolveResult =
+	    resolveNativeOutputSelectionStateForLines(lines, resolvedSelection);
+	if (resolveResult == NativeOutputSelectionResolveResult::Unmapped)
 	{
 		clearNativeOutputSelection(true);
 		return;
 	}
 
-	const int maxLine       = sizeToInt(lines.size()) - 1;
-	auto      clampPosition = [&lines, maxLine](NativeOutputPosition &position)
+	const QRect oldPaneRect               = nativeOutputPaneRect(m_nativeOutputSelection.sourceView);
+	m_nativeOutputSelection               = resolvedSelection;
+	m_nativeSelectionPendingHeadTrimLines = 0;
+	if (resolveResult == NativeOutputSelectionResolveResult::MappedSelection)
 	{
-		position.line    = qBound(0, position.line, maxLine);
-		const int maxCol = sizeToInt(lines.at(position.line).text.size());
-		position.column  = qBound(0, position.column, maxCol);
-	};
-	clampPosition(m_nativeOutputSelection.anchor);
-	clampPosition(m_nativeOutputSelection.cursor);
-
-	NativeOutputPosition start = m_nativeOutputSelection.anchor;
-	NativeOutputPosition end   = m_nativeOutputSelection.cursor;
-	if (start.line > end.line || (start.line == end.line && start.column > end.column))
-		qSwap(start, end);
-	m_nativeOutputSelection.start        = start;
-	m_nativeOutputSelection.end          = end;
-	m_nativeOutputSelection.hasSelection = start.line != end.line || start.column != end.column;
-	m_nativeOutputSelection.anchorIdentity =
-	    nativeOutputSelectionIdentityForPosition(lines, m_nativeOutputSelection.anchor);
-	m_nativeOutputSelection.cursorIdentity =
-	    nativeOutputSelectionIdentityForPosition(lines, m_nativeOutputSelection.cursor);
-	m_nativeOutputSelection.renderRevision = m_nativeRenderLineCacheRevision;
-	m_nativeSelectionPendingHeadTrimLines  = 0;
-	if (!m_nativeOutputSelection.hasSelection)
-		clearNativeOutputSelection(true);
+		applyResolvedOutputSelection(true, resolvedSelection.start.line + 1,
+		                             resolvedSelection.start.column + 1, resolvedSelection.end.line + 1,
+		                             resolvedSelection.end.column + 1, false);
+	}
+	else
+	{
+		requestNativeOutputRepaint(oldPaneRect);
+		applyResolvedOutputSelection(false, 0, 0, 0, 0, false);
+	}
 }
 
 void WorldView::clearNativeSelectionIfOutsideVisibleViewport(const WrapTextBrowser *const view)
@@ -7706,17 +8116,6 @@ void WorldView::clearNativeSelectionIfOutsideVisibleViewport(const WrapTextBrows
 		clearNativeOutputSelection(true);
 		return;
 	}
-
-	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
-	if (lines.isEmpty())
-	{
-		clearNativeOutputSelection(true);
-		return;
-	}
-
-	applyPendingNativeSelectionRenderDelta(lines);
-	if (!m_nativeOutputSelection.hasSelection)
-		return;
 }
 
 void WorldView::setNativeOutputSelection(const WrapTextBrowser      *sourceView,
@@ -7797,56 +8196,59 @@ bool WorldView::nativeOutputSelectionBounds(int &startLine, int &startColumn, in
 	startColumn = 0;
 	endLine     = 0;
 	endColumn   = 0;
-	if (!m_nativeOutputSelection.hasSelection)
-		return false;
-	if (m_nativeOutputSelection.sourceView == m_liveOutput &&
-	    (!m_scrollbackSplitActive || !m_liveOutput || !m_liveOutput->isVisible()))
-		return false;
 
-	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
-	if (lines.isEmpty())
-		return false;
-	const_cast<WorldView *>(this)->applyPendingNativeSelectionRenderDelta(lines);
-	if (!m_nativeOutputSelection.hasSelection)
-		return false;
-
-	auto clampLineColumn = [&lines](int line, int column, int *clampedLine = nullptr)
+	NativeOutputSelectionState selection = m_nativeOutputSelection;
+	if (selection.hasSelection || selection.dragging)
 	{
-		const int boundedLine = qBound(0, line, sizeToInt(lines.size()) - 1);
-		if (clampedLine)
-			*clampedLine = boundedLine;
-		const int maxColumn = sizeToInt(lines.at(boundedLine).text.size());
-		return qBound(0, column, maxColumn);
-	};
+		const bool needsRemap = m_nativeSelectionPendingHeadTrimLines > 0 ||
+		                        selection.renderRevision != m_nativeRenderLineCacheRevision;
+		if (needsRemap)
+		{
+			const NativeOutputRenderLines &lines = nativeOutputRenderLines();
+			if (resolveNativeOutputSelectionStateForLines(lines, selection) !=
+			    NativeOutputSelectionResolveResult::MappedSelection)
+				return false;
+		}
+	}
+	if (!selection.hasSelection)
+		return false;
+	if (selection.sourceView == m_liveOutput &&
+	    (!m_scrollbackSplitActive || !m_liveOutput || !m_liveOutput->isVisible()))
+	{
+		return false;
+	}
 
-	int startLineZero = m_nativeOutputSelection.start.line;
-	int endLineZero   = m_nativeOutputSelection.end.line;
-	int startColZero  = clampLineColumn(startLineZero, m_nativeOutputSelection.start.column, &startLineZero);
-	int endColZero    = clampLineColumn(endLineZero, m_nativeOutputSelection.end.column, &endLineZero);
-	if (startLineZero > endLineZero || (startLineZero == endLineZero && startColZero >= endColZero))
+	if (!m_hasOutputSelection)
 		return false;
 
-	startLine   = startLineZero + 1;
-	startColumn = startColZero + 1;
-	endLine     = endLineZero + 1;
-	endColumn   = endColZero + 1;
+	startLine   = selection.start.line + 1;
+	startColumn = selection.start.column + 1;
+	endLine     = selection.end.line + 1;
+	endColumn   = selection.end.column + 1;
 	return true;
 }
 
 QString WorldView::nativeOutputSelectionText() const
 {
-	int startLine   = 0;
-	int startColumn = 0;
-	int endLine     = 0;
-	int endColumn   = 0;
-	if (!nativeOutputSelectionBounds(startLine, startColumn, endLine, endColumn))
-		return {};
-
 	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return {};
 
-	QString text;
+	NativeOutputSelectionState selection;
+	if (resolveNativeOutputSelectionStateForLines(lines, selection) !=
+	    NativeOutputSelectionResolveResult::MappedSelection)
+		return {};
+	if (selection.sourceView == m_liveOutput &&
+	    (!m_scrollbackSplitActive || !m_liveOutput || !m_liveOutput->isVisible()))
+	{
+		return {};
+	}
+
+	QString   text;
+	const int startLine   = selection.start.line + 1;
+	const int startColumn = selection.start.column + 1;
+	const int endLine     = selection.end.line + 1;
+	const int endColumn   = selection.end.column + 1;
 	for (int lineIndex = startLine - 1; lineIndex <= endLine - 1 && lineIndex < lines.size(); ++lineIndex)
 	{
 		const NativeOutputRenderLine &line = lines.at(lineIndex);
@@ -7863,18 +8265,26 @@ QString WorldView::nativeOutputSelectionText() const
 
 QString WorldView::nativeOutputSelectionHtml() const
 {
-	int startLine   = 0;
-	int startColumn = 0;
-	int endLine     = 0;
-	int endColumn   = 0;
-	if (!nativeOutputSelectionBounds(startLine, startColumn, endLine, endColumn))
-		return {};
-
 	const NativeOutputRenderLines &lines = nativeOutputRenderLines();
 	if (lines.isEmpty())
 		return {};
 
-	QColor defaultTextColour = m_outputTextColour;
+	NativeOutputSelectionState selection;
+	if (resolveNativeOutputSelectionStateForLines(lines, selection) !=
+	    NativeOutputSelectionResolveResult::MappedSelection)
+		return {};
+	if (selection.sourceView == m_liveOutput &&
+	    (!m_scrollbackSplitActive || !m_liveOutput || !m_liveOutput->isVisible()))
+	{
+		return {};
+	}
+
+	const int startLine   = selection.start.line + 1;
+	const int startColumn = selection.start.column + 1;
+	const int endLine     = selection.end.line + 1;
+	const int endColumn   = selection.end.column + 1;
+
+	QColor    defaultTextColour = m_outputTextColour;
 	if (!defaultTextColour.isValid())
 		defaultTextColour =
 		    m_output ? m_output->palette().color(QPalette::Text) : palette().color(QPalette::Text);
@@ -8664,6 +9074,7 @@ WorldView::synchronizeNativeRuntimeOutputPresentation(const bool allowLayoutBuil
 		else
 			scrollViewToEnd(m_output);
 	}
+	applyPendingNativeSelectionRenderDelta(lines);
 	clearNativeSelectionIfOutsideVisibleViewport(m_output);
 	clearNativeSelectionIfOutsideVisibleViewport(m_liveOutput);
 	notifyAccessibleOutputPresented(lines);
@@ -9218,12 +9629,7 @@ bool WorldView::hasInputSelection() const
 
 QString WorldView::currentHoveredHyperlink() const
 {
-	WrapTextBrowser     *view = nullptr;
-	NativeOutputPosition position;
-	QString              href;
-	if (nativeOutputHitTestGlobal(QCursor::pos(), view, position, &href, nullptr))
-		return href;
-	return {};
+	return m_hoveredHyperlinkHref;
 }
 
 void WorldView::applyHoveredHyperlink(const QString &href)
@@ -9247,12 +9653,21 @@ void WorldView::applyHoveredHyperlink(const QString &href)
 
 void WorldView::refreshHoveredHyperlinkFromCursor()
 {
-	applyHoveredHyperlink(currentHoveredHyperlink());
+	WrapTextBrowser     *view = nullptr;
+	NativeOutputPosition position;
+	QString              href;
+	const QPoint         cursorPos = QCursor::pos();
+	if (!nativeOutputHitTestGlobal(cursorPos, view, position, &href, nullptr, true))
+	{
+		applyHoveredHyperlink(QString());
+		return;
+	}
+	applyHoveredHyperlink(href);
 }
 
 bool WorldView::hyperlinkHoverActive() const
 {
-	return !m_hoveredHyperlinkHref.isEmpty() || !currentHoveredHyperlink().isEmpty();
+	return !m_hoveredHyperlinkHref.isEmpty();
 }
 
 bool WorldView::isAtBufferEnd() const
@@ -9694,7 +10109,7 @@ QString WorldView::wordUnderCursor() const
 {
 	WrapTextBrowser     *view = nullptr;
 	NativeOutputPosition position;
-	if (!nativeOutputHitTestGlobal(QCursor::pos(), view, position, nullptr, nullptr))
+	if (!nativeOutputHitTestGlobal(QCursor::pos(), view, position, nullptr, nullptr, true))
 		return {};
 
 	return wordAtNativeOutputPosition(position);
@@ -12748,33 +13163,37 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 		NativeOutputPosition mouseMoveHit;
 		bool                 mouseMoveTextHit = false;
 
-		if (event->type() == QEvent::MouseMove)
+		auto                 resolveMouseMoveNativeHit = [&]
 		{
-			if (auto *mouseEvent = dynamic_cast<QMouseEvent *>(event))
+			if (event->type() != QEvent::MouseMove)
+				return;
+			auto *mouseEvent = dynamic_cast<QMouseEvent *>(event);
+			if (!mouseEvent)
 			{
-				QString mouseMoveHref;
-				if (nativeOutputHitTestForMouseEvent(watchedWidget, mouseEvent, mouseMoveHitView,
-				                                     mouseMoveHitPosInView, mouseMoveHit, &mouseMoveHref,
-				                                     nullptr, false, &mouseMoveTextHit))
+				refreshHoveredHyperlinkFromCursor();
+				return;
+			}
+
+			QString mouseMoveHref;
+			if (nativeOutputHitTestForMouseEvent(watchedWidget, mouseEvent, mouseMoveHitView,
+			                                     mouseMoveHitPosInView, mouseMoveHit, &mouseMoveHref, nullptr,
+			                                     true, &mouseMoveTextHit))
+			{
+				hasMouseMoveNativeHit = true;
+				applyHoveredHyperlink(mouseMoveHref);
+				if (m_runtime)
 				{
-					hasMouseMoveNativeHit = true;
-					applyHoveredHyperlink(mouseMoveHref);
-					if (m_runtime)
-					{
-						m_runtime->setWordUnderMenu(
-						    mouseMoveTextHit ? wordAtNativeOutputPosition(mouseMoveHit) : QString(), true);
-					}
-				}
-				else
-				{
-					refreshHoveredHyperlinkFromCursor();
-					if (m_runtime)
-						m_runtime->setWordUnderMenu(QString(), false);
+					m_runtime->setWordUnderMenu(
+					    mouseMoveTextHit ? wordAtNativeOutputPosition(mouseMoveHit) : QString(), true);
 				}
 			}
 			else
+			{
 				refreshHoveredHyperlinkFromCursor();
-		}
+				if (m_runtime)
+					m_runtime->setWordUnderMenu(QString(), false);
+			}
+		};
 
 		bool handled = false;
 		switch (event->type())
@@ -12825,6 +13244,9 @@ bool WorldView::eventFilter(QObject *watched, QEvent *event)
 		default:
 			break;
 		}
+
+		if (!handled)
+			resolveMouseMoveNativeHit();
 
 		if (!handled &&
 		    (event->type() == QEvent::MouseMove || event->type() == QEvent::MouseButtonPress ||

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -12760,7 +12760,7 @@ bool WorldView::executeMacroByName(const QString &name)
 	{
 		if (!confirmReplaceTyping(send))
 			return true;
-		setInputText(send, true);
+		setInputText(send, false);
 		return true;
 	}
 	if (type == QStringLiteral("send_now"))
@@ -12771,7 +12771,7 @@ bool WorldView::executeMacroByName(const QString &name)
 		                           noHistoryFlag.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
 		                           noHistoryFlag.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0);
 		m_runtime->setCurrentActionSource(WorldRuntime::eUserMacro);
-		(void)m_runtime->sendCommand(send, true, false, true, !noHistory, true);
+		(void)m_runtime->executeUserMacroSendNow(send, !noHistory);
 		m_runtime->setCurrentActionSource(WorldRuntime::eUnknownActionSource);
 		return true;
 	}

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -3155,7 +3155,8 @@ void WorldView::notifyAccessibleOutputPresented(const QVector<NativeOutputRender
 	const bool exactTailAppend = m_accessibleOutputPendingTailAppend &&
 	                             (m_nativeRenderCacheDelta.kind == NativeRenderCacheDeltaKind::TailAppend ||
 	                              !m_nativeRenderLineCacheFromRuntime);
-	auto       announceCanvasText = [this](const QString &message)
+	const bool suppressLiveAccessibilityEvents = m_runtime && m_runtime->hasMushReaderLiveSpeechOwner();
+	auto       announceCanvasText              = [this](const QString &message)
 	{
 		const QString announcement = trimLeadingAnnouncementBreaks(message);
 		if (!m_nativeOutputCanvas || !m_nativeOutputCanvas->isVisible() || announcement.isEmpty())
@@ -3164,7 +3165,8 @@ void WorldView::notifyAccessibleOutputPresented(const QVector<NativeOutputRender
 		event.setPoliteness(QAccessible::AnnouncementPoliteness::Polite);
 		QAccessible::updateAccessibility(&event);
 	};
-	if (currentCharacterCount > m_accessibleOutputCharacterCount && exactTailAppend)
+	if (!suppressLiveAccessibilityEvents && currentCharacterCount > m_accessibleOutputCharacterCount &&
+	    exactTailAppend)
 	{
 		const QString insertedText = map.text(m_accessibleOutputCharacterCount, currentCharacterCount);
 		if (!insertedText.isEmpty())
@@ -3178,7 +3180,7 @@ void WorldView::notifyAccessibleOutputPresented(const QVector<NativeOutputRender
 			announceCanvasText(insertedText);
 		}
 	}
-	else if (m_nativeOutputCanvas && m_nativeOutputCanvas->isVisible())
+	else if (!suppressLiveAccessibilityEvents && m_nativeOutputCanvas && m_nativeOutputCanvas->isVisible())
 	{
 		if (m_accessibleOutputText != currentText)
 		{

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -42,6 +42,7 @@ class QMouseEvent;
 class QPainter;
 class WorldOutputCanvas;
 class WorldOutputAccessible;
+class tst_WorldView_Basic;
 
 /**
  * @brief Installs the custom accessibility factory for native world output widgets.
@@ -899,6 +900,7 @@ class WorldView : public QWidget
 
 	private:
 		friend class WorldOutputCanvas;
+		friend class ::tst_WorldView_Basic;
 		struct NativeOutputRenderLine;
 		using NativeOutputRenderLines = IndexedRingBuffer<NativeOutputRenderLine>;
 
@@ -1076,6 +1078,7 @@ class WorldView : public QWidget
 				quint64                          visualHash{0};
 				QVector<qint64>                  sourceRuntimeLineNumbers;
 				quint64                          sourceRuntimeLineKey{0};
+				qint64                           firstRuntimeLineIndex{-1};
 		};
 		/**
 		 * @brief Cache-delta classification for native render-line revisions.
@@ -1097,12 +1100,17 @@ class WorldView : public QWidget
 		struct NativeRenderCacheDelta
 		{
 				NativeRenderCacheDeltaKind kind{NativeRenderCacheDeltaKind::Unknown};
+				quint64                    fromRevision{0};
 				quint64                    revision{0};
 				int                        oldLineCount{0};
 				int                        newLineCount{0};
 				bool                       tailLineMutated{false};
+				bool                       headLineMutated{false};
 				int                        headTrimCount{0};
 				int                        stablePrefixCount{0};
+				int                        replaceFirstLine{-1};
+				int                        removedLineCount{0};
+				int                        insertedLineCount{0};
 		};
 		/**
 		 * @brief Last fully trusted native-output paint state for one pane.
@@ -1165,7 +1173,8 @@ class WorldView : public QWidget
 			HeadTrim,
 		};
 		[[nodiscard]] static quint64 nativeLineContentHash(const NativeOutputRenderLine &line);
-		static void extendNativeRuntimeLineRange(NativeOutputRenderLine &line, qint64 lineNumber);
+		static void extendNativeRuntimeLineRange(NativeOutputRenderLine &line, qint64 lineNumber,
+		                                         qint64 runtimeLineIndex = -1);
 		[[nodiscard]] static bool nativeRuntimeLineRangeContains(const NativeOutputRenderLine &line,
 		                                                         qint64                        lineNumber);
 		[[nodiscard]] static QPair<qint64, qint64> nativeRuntimeLineRange(const NativeOutputRenderLine &line);
@@ -1224,14 +1233,70 @@ class WorldView : public QWidget
 		                             const QFont &layoutFont) const;
 		int  ensureNativeLineLayout(const NativeOutputRenderLines &lines, int index, int wrapWidthPixels,
 		                            int localWrapWidthPixels, qreal defaultLineAdvance,
-		                            const QFont &layoutFont) const;
+		                            const QFont &layoutFont, quint64 layoutContentSalt) const;
 		void ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, int wrapWidthPixels,
 		                              int localWrapWidthPixels, int lineSpacingSetting,
 		                              const QFont &layoutFont) const;
-		[[nodiscard]] qreal              nativeLayoutCumulativeHeightAt(int index) const;
-		void                             setNativeLayoutCumulativeHeightAt(int index, qreal value) const;
-		void                             resetNativeLayoutCumulativeHeightOrigin() const;
-		[[nodiscard]] const QTextLayout *nativeLayoutForLine(int index) const;
+		void refreshNativeLayoutExactPrefixFrom(int firstLine) const;
+		/**
+		 * @brief Per-render-line native layout cache state.
+		 *
+		 * Slots are kept in one ring buffer so structural render-line deltas cannot
+		 * desynchronize row estimates, exact layouts, hashes, and runtime identity.
+		 */
+		struct NativeLayoutSlot
+		{
+				int                         visualRows{-1};
+				quint64                     runtimeLineKey{0};
+				quint64                     lineContentHash{0};
+				QSharedPointer<QTextLayout> lineLayout;
+				uchar                       rowsExact{0};
+		};
+		struct NativeLayoutHeightIndex
+		{
+				[[nodiscard]] qsizetype size() const;
+				[[nodiscard]] bool      isEmpty() const;
+				[[nodiscard]] qreal     heightAt(int index) const;
+				[[nodiscard]] qreal     prefixHeightAt(int index) const;
+				[[nodiscard]] qreal     totalHeight() const;
+				[[nodiscard]] int       lineAtY(qreal y) const;
+				void                    clear();
+				void                    reserve(qsizetype count);
+				void                    append(qreal height);
+				void                    resize(qsizetype count, qreal defaultHeight);
+				void                    assign(qsizetype count, qreal defaultHeight);
+				void                    removeFront(qsizetype count);
+				void replace(int index, int removeCount, int insertCount, qreal defaultHeight);
+				void setHeight(int index, qreal height);
+				void setLayoutSlotHeightRange(int firstLine, int lastLineExclusive,
+				                              const IndexedRingBuffer<NativeLayoutSlot> &layoutSlots,
+				                              qreal                                      lineAdvance);
+				void swap(NativeLayoutHeightIndex &other) noexcept;
+
+			private:
+				friend class ::tst_WorldView_Basic;
+
+				static constexpr int     kBlockSize = 256;
+
+				void                     rebuildBlockSums();
+				void                     rebuildBlockSumsFromBlock(int firstBlock, int firstLine);
+				void                     rebuildFenwick();
+				void                     addBlockLengthDelta(int blockIndex, int delta);
+				void                     addBlockSumDelta(int blockIndex, qreal delta);
+				[[nodiscard]] int        blockLengthPrefix(int blockCount) const;
+				[[nodiscard]] qreal      blockSumPrefix(int blockCount) const;
+				[[nodiscard]] int        blockForLine(int lineIndex, int *prefixLines) const;
+				[[nodiscard]] int        blockForY(qreal y, qreal *prefixHeight) const;
+
+				IndexedRingBuffer<qreal> m_heights;
+				IndexedRingBuffer<int>   m_blockLengths;
+				IndexedRingBuffer<qreal> m_blockSums;
+				QVector<int>             m_lengthFenwick;
+				QVector<qreal>           m_sumFenwick;
+		};
+		[[nodiscard]] qreal                          nativeLayoutCumulativeHeightAt(int index) const;
+		[[nodiscard]] int                            nativeLayoutLineAtY(qreal y) const;
+		[[nodiscard]] const QTextLayout             *nativeLayoutForLine(int index) const;
 		/**
 		 * @brief Builds native-render lines from runtime/standalone line state.
 		 * @return Logical lines with merged soft-returns and style spans.
@@ -1292,10 +1357,32 @@ class WorldView : public QWidget
 		 * @param tailLineMutated `true` when the previous tail logical line text changed.
 		 * @param headTrimCount Number of trimmed head logical lines, when applicable.
 		 * @param stablePrefixCount Number of stable render lines before a middle restitch.
+		 * @param headLineMutated `true` when the post-trim head logical line text changed.
 		 */
 		void bumpNativeRenderLineCacheRevision(NativeRenderCacheDeltaKind kind, int oldLineCount,
 		                                       bool tailLineMutated = false, int headTrimCount = 0,
-		                                       int stablePrefixCount = 0) const;
+		                                       int stablePrefixCount = 0, bool headLineMutated = false) const;
+		/**
+		 * @brief Advances native render cache revision for a runtime range restitch.
+		 * @param oldLineCount Native render-line count before mutation.
+		 * @param tailLineMutated `true` when the previous tail logical line text changed.
+		 * @param headTrimCount Number of trimmed head logical lines before range replacement.
+		 * @param stablePrefixCount Number of stable render lines before the restitched range.
+		 * @param headLineMutated `true` when the post-trim head logical line text changed.
+		 * @param replaceFirstLine Post-trim render-line index where replacement starts.
+		 * @param removedLineCount Number of old render lines removed at @p replaceFirstLine.
+		 * @param insertedLineCount Number of new render lines inserted at @p replaceFirstLine.
+		 */
+		void bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(int oldLineCount, bool tailLineMutated,
+		                                                           int headTrimCount, int stablePrefixCount,
+		                                                           bool headLineMutated, int replaceFirstLine,
+		                                                           int removedLineCount,
+		                                                           int insertedLineCount) const;
+		/**
+		 * @brief Commits a prepared native render-cache delta to the revision log.
+		 * @param delta Prepared delta with pre-revision fields filled in.
+		 */
+		void commitNativeRenderCacheDelta(NativeRenderCacheDelta delta) const;
 		/**
 		 * @brief Returns whether native output interaction mode is active.
 		 */
@@ -1309,17 +1396,29 @@ class WorldView : public QWidget
 				int column{0};
 		};
 		/**
+		 * @brief Stable identity for a native output position's render line.
+		 */
+		struct NativeOutputPositionIdentity
+		{
+				quint64 lineKey{0};
+				qint64  firstRuntimeLineNumber{0};
+				qint64  lastRuntimeLineNumber{0};
+		};
+		/**
 		 * @brief Native output selection state tracked independently of QTextCursor.
 		 */
 		struct NativeOutputSelectionState
 		{
-				bool                 hasSelection{false};
-				bool                 dragging{false};
-				WrapTextBrowser     *sourceView{nullptr};
-				NativeOutputPosition anchor;
-				NativeOutputPosition cursor;
-				NativeOutputPosition start;
-				NativeOutputPosition end;
+				bool                         hasSelection{false};
+				bool                         dragging{false};
+				WrapTextBrowser             *sourceView{nullptr};
+				NativeOutputPosition         anchor;
+				NativeOutputPosition         cursor;
+				NativeOutputPosition         start;
+				NativeOutputPosition         end;
+				NativeOutputPositionIdentity anchorIdentity;
+				NativeOutputPositionIdentity cursorIdentity;
+				quint64                      renderRevision{0};
 		};
 		/**
 		 * @brief Returns the output word at a previously resolved native-output hit position.
@@ -1402,10 +1501,29 @@ class WorldView : public QWidget
 		 */
 		void               clearNativeOutputSelection(bool notify = true);
 		/**
-		 * @brief Applies pending head-trim remapping to native selection line indices.
+		 * @brief Applies pending render-cache remapping to native selection line indices.
 		 * @param lines Current native render lines.
 		 */
-		void               applyPendingNativeSelectionHeadTrim(const NativeOutputRenderLines &lines);
+		void               applyPendingNativeSelectionRenderDelta(const NativeOutputRenderLines &lines);
+		/**
+		 * @brief Captures stable line identity for a native output position.
+		 * @param lines Current native render lines.
+		 * @param position Native output position.
+		 * @return Stable identity for @p position.
+		 */
+		[[nodiscard]] static NativeOutputPositionIdentity
+		                   nativeOutputSelectionIdentityForPosition(const NativeOutputRenderLines &lines,
+		                                                            const NativeOutputPosition    &position);
+		/**
+		 * @brief Remaps a native output position after render-cache mutation.
+		 * @param position Position to remap in-place.
+		 * @param identity Stable identity captured before cache mutation.
+		 * @param lines Current native render lines.
+		 * @return `true` when the position could be remapped.
+		 */
+		[[nodiscard]] bool remapNativeOutputSelectionPosition(NativeOutputPosition               &position,
+		                                                      const NativeOutputPositionIdentity &identity,
+		                                                      const NativeOutputRenderLines &lines) const;
 		/**
 		 * @brief Applies native selection maintenance after viewport/scroll updates.
 		 * @param view Output view associated with the current selection.
@@ -1787,8 +1905,10 @@ class WorldView : public QWidget
 		mutable bool                                m_nativeRuntimeTailRestitchPending{false};
 		mutable int                                 m_nativeRuntimeLineRestitchIndex{-1};
 		mutable int                                 m_nativeRuntimeRangeRestitchStartIndex{-1};
+		mutable qint64                              m_nativeRenderRuntimeIndexBase{0};
 		mutable quint64                             m_nativeRenderLineCacheRevision{0};
 		mutable NativeRenderCacheDelta              m_nativeRenderCacheDelta;
+		mutable QVector<NativeRenderCacheDelta>     m_nativeRenderCacheDeltas;
 		mutable int                                 m_accessibleOutputCharacterCount{-1};
 		mutable quint64                             m_accessibleOutputRevision{0};
 		mutable QString                             m_accessibleOutputText;
@@ -1846,117 +1966,112 @@ class WorldView : public QWidget
 		mutable quint64                             m_nativeSplitTopHeadTrimPixelsRevision{0};
 		mutable int                                 m_nativeSplitTopHeadTrimPixels{0};
 		mutable quint64                             m_nativeSplitTopHeadTrimAdjustedRevision{0};
-		mutable IndexedRingBuffer<int>              m_nativeLayoutVisualRows;
-		mutable IndexedRingBuffer<quint64>          m_nativeLayoutRuntimeLineKeys;
-		mutable IndexedRingBuffer<qreal>            m_nativeLayoutCumulativeHeights;
-		mutable qreal                               m_nativeLayoutCumulativeHeightOrigin{0.0};
-		mutable IndexedRingBuffer<QSharedPointer<QTextLayout>> m_nativeLayoutLineLayouts;
-		mutable IndexedRingBuffer<quint64>                     m_nativeLayoutLineContentHashes;
-		mutable IndexedRingBuffer<uchar>                       m_nativeLayoutRowsExact;
-		mutable int                                            m_nativeLayoutCumulativeDirtyFrom{0};
-		mutable bool                                           m_nativeLayoutCacheValid{false};
-		mutable int                                            m_nativeLayoutCachedWrapWidth{0};
-		mutable int                                            m_nativeLayoutCachedLocalWrapWidth{0};
-		mutable int                                            m_nativeLayoutCachedLineSpacing{0};
-		mutable quint64                                        m_nativeLayoutCachedStyleKey{0};
-		mutable qreal                                          m_nativeLayoutCachedLineAdvance{0.0};
-		mutable QFont                                          m_nativeLayoutCachedFont;
-		mutable quint64                                        m_nativeLayoutCachedRenderRevision{0};
-		mutable int                                            m_nativeLayoutCacheResets{0};
-		mutable int                                            m_nativeLayoutRowMeasurements{0};
-		IndexedRingBuffer<WorldRuntime::LineEntry>             m_nativeStandaloneOutputLines;
-		qint64                                                 m_nativeStandaloneNextLineNumber{1};
-		bool                                                   m_wrapInput{false};
-		int                                                    m_inputPixelOffset{0};
-		WorldRuntime                                          *m_runtime{nullptr};
-		QFont                                                  m_defaultOutputFont;
-		QFont                                                  m_defaultInputFont;
-		bool                                                   m_displayMyInput{false};
-		bool                                                   m_escapeDeletesInput{false};
-		bool                                                   m_saveDeletedCommand{false};
-		bool                                                   m_confirmOnPaste{false};
-		bool                                                   m_ctrlBackspaceDeletesLastWord{false};
-		bool                                                   m_arrowsChangeHistory{false};
-		bool                                                   m_arrowKeysWrap{false};
-		bool                                                   m_arrowRecallsPartial{false};
-		bool                                                   m_altArrowRecallsPartial{false};
-		bool                                                   m_ctrlZGoesToEndOfBuffer{false};
-		bool                                                   m_ctrlPGoesToPreviousCommand{false};
-		bool                                                   m_ctrlNGoesToNextCommand{false};
-		bool                                                   m_confirmBeforeReplacingTyping{false};
-		bool                                                   m_doubleClickInserts{false};
-		bool                                                   m_doubleClickSends{false};
-		bool                                                   m_showBold{true};
-		bool                                                   m_showItalic{true};
-		bool                                                   m_showUnderline{true};
-		bool                                                   m_alternativeInverse{false};
-		bool                                                   m_lineInformation{false};
-		int                                                    m_lineSpacing{0};
-		bool                                                   m_lowerCaseTabCompletion{false};
-		bool                                                   m_tabCompletionSpace{false};
-		bool                                                   m_autoRepeat{false};
-		bool                                                   m_keepCommandsOnSameLine{false};
-		bool                                                   m_noEchoOff{false};
-		bool                                                   m_noEcho{false};
-		bool                                                   m_alwaysRecordCommandHistory{false};
-		bool                                                   m_hyperlinkAddsToCommandHistory{false};
-		bool                                                   m_inputChanged{false};
-		bool                                                   m_settingText{false};
-		bool                                                   m_notifyingPluginCommandChanged{false};
-		bool                                                   m_frozen{false};
-		bool                                                   m_autoPause{false};
-		QString                                                m_wordDelimiters;
-		QString                                                m_wordDelimitersDblClick;
-		bool                                                   m_smoothScrolling{false};
-		bool                                                   m_smootherScrolling{false};
-		bool                                                   m_allTypingToCommandWindow{false};
-		bool                                                   m_autoResizeCommandWindow{false};
-		int                                                    m_autoResizeMinimumLines{1};
-		int                                                    m_autoResizeMaximumLines{20};
-		int                                                    m_tabCompletionLines{200};
-		QString                                                m_tabCompletionDefaults;
-		QString                                                m_tabCompletionCycleTargetLower;
-		int                                                    m_tabCompletionCycleStartColumn{-1};
-		int                                                    m_tabCompletionCycleEndColumn{-1};
-		int                                                    m_tabCompletionCycleLastSource{-2};
-		bool                                                   m_tabCompletionCycleActive{false};
-		QSet<QString>                                          m_tabCompletionCycleSeenCompletions;
-		int                                                    m_fadeOutputBufferAfterSeconds{0};
-		int                                                    m_fadeOutputOpacityPercent{100};
-		int                                                    m_fadeOutputSeconds{1};
-		QTimer                                                *m_fadeTimer{nullptr};
-		QDateTime                                              m_timeFadeCancelled;
-		bool                                                   m_breakBeforeNextServerOutput{false};
-		bool                                                   m_keepPauseAtBottom{false};
-		bool                                                   m_userScrollAction{false};
-		bool                                                   m_startPausedApplied{false};
-		bool                                                   m_defaultInputHeightApplied{false};
-		bool                                                   m_scrollbackSplitActive{false};
-		int                                                    m_lastLiveSplitSize{0};
-		int                                                    m_wrapColumn{0};
-		int                                                    m_historyLimit{0};
-		bool                                                   m_useCustomLinkColour{false};
-		bool                                                   m_underlineHyperlinks{true};
-		QColor                                                 m_hyperlinkColour;
-		QColor                                                 m_outputBackground;
-		QColor                                                 m_outputTextColour;
-		TimestampRenderSettings                                m_outputTimestampRenderSettings;
-		TimestampRenderSettings                                m_inputTimestampRenderSettings;
-		TimestampRenderSettings                                m_notesTimestampRenderSettings;
-		bool                                                   m_bleedBackground{false};
-		int                                                    m_historyIndex{-1};
-		int                                                    m_partialIndex{-1};
-		QString                                                m_partialCommand;
-		QString                                                m_lastCommand;
-		QVector<QString>                                       m_history;
-		QVector<PendingOutput>                                 m_pendingOutput;
-		bool                                                   m_flushingPending{false};
-		bool                                                   m_hasPartialOutput{false};
-		int                                                    m_partialOutputStart{0};
-		int                                                    m_partialOutputLength{0};
-		bool                                                   m_nativeHasPartialOutput{false};
-		QString                                                m_nativePartialOutputText;
-		QVector<WorldRuntime::StyleSpan>                       m_nativePartialOutputSpans;
+		mutable IndexedRingBuffer<NativeLayoutSlot> m_nativeLayoutSlots;
+		mutable NativeLayoutHeightIndex             m_nativeLayoutHeightIndex;
+		mutable int                                 m_nativeLayoutExactPrefixCount{0};
+		mutable bool                                m_nativeLayoutCacheValid{false};
+		mutable int                                 m_nativeLayoutCachedWrapWidth{0};
+		mutable int                                 m_nativeLayoutCachedLocalWrapWidth{0};
+		mutable int                                 m_nativeLayoutCachedLineSpacing{0};
+		mutable quint64                             m_nativeLayoutCachedStyleKey{0};
+		mutable qreal                               m_nativeLayoutCachedLineAdvance{0.0};
+		mutable QFont                               m_nativeLayoutCachedFont;
+		mutable quint64                             m_nativeLayoutCachedRenderRevision{0};
+		mutable int                                 m_nativeLayoutCacheResets{0};
+		mutable int                                 m_nativeLayoutRowMeasurements{0};
+		IndexedRingBuffer<WorldRuntime::LineEntry>  m_nativeStandaloneOutputLines;
+		qint64                                      m_nativeStandaloneNextLineNumber{1};
+		bool                                        m_wrapInput{false};
+		int                                         m_inputPixelOffset{0};
+		WorldRuntime                               *m_runtime{nullptr};
+		QFont                                       m_defaultOutputFont;
+		QFont                                       m_defaultInputFont;
+		bool                                        m_displayMyInput{false};
+		bool                                        m_escapeDeletesInput{false};
+		bool                                        m_saveDeletedCommand{false};
+		bool                                        m_confirmOnPaste{false};
+		bool                                        m_ctrlBackspaceDeletesLastWord{false};
+		bool                                        m_arrowsChangeHistory{false};
+		bool                                        m_arrowKeysWrap{false};
+		bool                                        m_arrowRecallsPartial{false};
+		bool                                        m_altArrowRecallsPartial{false};
+		bool                                        m_ctrlZGoesToEndOfBuffer{false};
+		bool                                        m_ctrlPGoesToPreviousCommand{false};
+		bool                                        m_ctrlNGoesToNextCommand{false};
+		bool                                        m_confirmBeforeReplacingTyping{false};
+		bool                                        m_doubleClickInserts{false};
+		bool                                        m_doubleClickSends{false};
+		bool                                        m_showBold{true};
+		bool                                        m_showItalic{true};
+		bool                                        m_showUnderline{true};
+		bool                                        m_alternativeInverse{false};
+		bool                                        m_lineInformation{false};
+		int                                         m_lineSpacing{0};
+		bool                                        m_lowerCaseTabCompletion{false};
+		bool                                        m_tabCompletionSpace{false};
+		bool                                        m_autoRepeat{false};
+		bool                                        m_keepCommandsOnSameLine{false};
+		bool                                        m_noEchoOff{false};
+		bool                                        m_noEcho{false};
+		bool                                        m_alwaysRecordCommandHistory{false};
+		bool                                        m_hyperlinkAddsToCommandHistory{false};
+		bool                                        m_inputChanged{false};
+		bool                                        m_settingText{false};
+		bool                                        m_notifyingPluginCommandChanged{false};
+		bool                                        m_frozen{false};
+		bool                                        m_autoPause{false};
+		QString                                     m_wordDelimiters;
+		QString                                     m_wordDelimitersDblClick;
+		bool                                        m_smoothScrolling{false};
+		bool                                        m_smootherScrolling{false};
+		bool                                        m_allTypingToCommandWindow{false};
+		bool                                        m_autoResizeCommandWindow{false};
+		int                                         m_autoResizeMinimumLines{1};
+		int                                         m_autoResizeMaximumLines{20};
+		int                                         m_tabCompletionLines{200};
+		QString                                     m_tabCompletionDefaults;
+		QString                                     m_tabCompletionCycleTargetLower;
+		int                                         m_tabCompletionCycleStartColumn{-1};
+		int                                         m_tabCompletionCycleEndColumn{-1};
+		int                                         m_tabCompletionCycleLastSource{-2};
+		bool                                        m_tabCompletionCycleActive{false};
+		QSet<QString>                               m_tabCompletionCycleSeenCompletions;
+		int                                         m_fadeOutputBufferAfterSeconds{0};
+		int                                         m_fadeOutputOpacityPercent{100};
+		int                                         m_fadeOutputSeconds{1};
+		QTimer                                     *m_fadeTimer{nullptr};
+		QDateTime                                   m_timeFadeCancelled;
+		bool                                        m_breakBeforeNextServerOutput{false};
+		bool                                        m_keepPauseAtBottom{false};
+		bool                                        m_userScrollAction{false};
+		bool                                        m_startPausedApplied{false};
+		bool                                        m_defaultInputHeightApplied{false};
+		bool                                        m_scrollbackSplitActive{false};
+		int                                         m_lastLiveSplitSize{0};
+		int                                         m_wrapColumn{0};
+		int                                         m_historyLimit{0};
+		bool                                        m_useCustomLinkColour{false};
+		bool                                        m_underlineHyperlinks{true};
+		QColor                                      m_hyperlinkColour;
+		QColor                                      m_outputBackground;
+		QColor                                      m_outputTextColour;
+		TimestampRenderSettings                     m_outputTimestampRenderSettings;
+		TimestampRenderSettings                     m_inputTimestampRenderSettings;
+		TimestampRenderSettings                     m_notesTimestampRenderSettings;
+		bool                                        m_bleedBackground{false};
+		int                                         m_historyIndex{-1};
+		int                                         m_partialIndex{-1};
+		QString                                     m_partialCommand;
+		QString                                     m_lastCommand;
+		QVector<QString>                            m_history;
+		QVector<PendingOutput>                      m_pendingOutput;
+		bool                                        m_flushingPending{false};
+		bool                                        m_hasPartialOutput{false};
+		int                                         m_partialOutputStart{0};
+		int                                         m_partialOutputLength{0};
+		bool                                        m_nativeHasPartialOutput{false};
+		QString                                     m_nativePartialOutputText;
+		QVector<WorldRuntime::StyleSpan>            m_nativePartialOutputSpans;
 		struct OutputFindState;
 		QScopedPointer<OutputFindState>         m_outputFind;
 		QScopedPointer<CommandHistoryFindState> m_commandHistoryFind;

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -1113,6 +1113,16 @@ class WorldView : public QWidget
 				int                        insertedLineCount{0};
 		};
 		/**
+		 * @brief Deferred split-pane head-trim adjustment computed from pre-mutation layout state.
+		 */
+		struct NativeSplitTopHeadTrimAdjustment
+		{
+				bool    valid{false};
+				quint64 revision{0};
+				int     pixels{0};
+				int     lines{0};
+		};
+		/**
 		 * @brief Last fully trusted native-output paint state for one pane.
 		 */
 		struct NativeOutputPanePaintState
@@ -1208,6 +1218,19 @@ class WorldView : public QWidget
 		                                             int wrapWidthPixels, int localWrapWidthPixels,
 		                                             int lineSpacingSetting, const QFont &layoutFont) const;
 		/**
+		 * @brief Returns whether native layout slot/index structures match current render inputs.
+		 * @param lines Current native render lines.
+		 * @param wrapWidthPixels Effective wrap width for runtime output.
+		 * @param localWrapWidthPixels Effective wrap width for local echo/note output.
+		 * @param lineSpacingSetting Current line-spacing percentage delta.
+		 * @param layoutFont Current output font.
+		 * @return `true` when exact range materialization can use the current slot/index structures.
+		 */
+		[[nodiscard]] bool nativeLayoutRangeStateReadyFor(const NativeOutputRenderLines &lines,
+		                                                  int wrapWidthPixels, int localWrapWidthPixels,
+		                                                  int          lineSpacingSetting,
+		                                                  const QFont &layoutFont) const;
+		/**
 		 * @brief Estimates visual rows for a native render line without shaping text.
 		 * @param line Native render line.
 		 * @param effectiveWrapWidth Effective wrap width for the line.
@@ -1231,6 +1254,41 @@ class WorldView : public QWidget
 		bool ensureNativeLayoutRange(const NativeOutputRenderLines &lines, int firstLine, int lastLine,
 		                             int wrapWidthPixels, int localWrapWidthPixels, int lineSpacingSetting,
 		                             const QFont &layoutFont) const;
+		/**
+		 * @brief Prepares native layout slot metadata without exact line shaping.
+		 * @param lines Current native render lines.
+		 * @param wrapWidthPixels Effective wrap width for runtime output.
+		 * @param localWrapWidthPixels Effective wrap width for local echo/note output.
+		 * @param lineSpacingSetting Current line-spacing percentage delta.
+		 * @param layoutFont Current output font.
+		 * @return `true` when range layout may proceed with slot and height metadata.
+		 */
+		bool prepareNativeLayoutRangeState(const NativeOutputRenderLines &lines, int wrapWidthPixels,
+		                                   int localWrapWidthPixels, int lineSpacingSetting,
+		                                   const QFont &layoutFont) const;
+		/**
+		 * @brief Computes split-pane head-trim adjustment from pre-trim layout state.
+		 * @param delta Render cache delta that trimmed head lines.
+		 * @param defaultLineAdvance Fallback line advance for exact-row metadata.
+		 * @param targetRevision Render revision that will consume the adjustment.
+		 * @return Deferred adjustment; invalid when current layout state cannot produce one.
+		 */
+		[[nodiscard]] NativeSplitTopHeadTrimAdjustment
+		nativeSplitTopHeadTrimAdjustmentForDelta(const NativeRenderCacheDelta &delta,
+		                                         qreal defaultLineAdvance, quint64 targetRevision = 0) const;
+		/**
+		 * @brief Clears pending split-pane head-trim compensation.
+		 */
+		void clearNativeSplitTopHeadTrimAdjustment() const;
+		/**
+		 * @brief Clears pending split-pane head-trim compensation for the current render revision.
+		 */
+		void clearCurrentNativeSplitTopHeadTrimAdjustment() const;
+		/**
+		 * @brief Applies a successfully replayed split-pane head-trim adjustment.
+		 * @param adjustment Deferred adjustment to commit.
+		 */
+		void applyNativeSplitTopHeadTrimAdjustment(const NativeSplitTopHeadTrimAdjustment &adjustment) const;
 		int  ensureNativeLineLayout(const NativeOutputRenderLines &lines, int index, int wrapWidthPixels,
 		                            int localWrapWidthPixels, qreal defaultLineAdvance,
 		                            const QFont &layoutFont, quint64 layoutContentSalt) const;
@@ -1421,6 +1479,15 @@ class WorldView : public QWidget
 				quint64                      renderRevision{0};
 		};
 		/**
+		 * @brief Result of resolving stored native output selection against current render lines.
+		 */
+		enum class NativeOutputSelectionResolveResult
+		{
+			Unmapped,
+			MappedCollapsed,
+			MappedSelection,
+		};
+		/**
 		 * @brief Returns the output word at a previously resolved native-output hit position.
 		 * @param position Native output hit position.
 		 * @return Word at @p position, or an empty string when no word is present.
@@ -1433,7 +1500,8 @@ class WorldView : public QWidget
 		 * @param position Output line/column position.
 		 * @param href Optional hyperlink href at hit point.
 		 * @param hint Optional hyperlink hint at hit point.
-		 * @param allowCacheBuild `true` to rebuild layout caches on demand, `false` to query only when cache is ready.
+		 * @param allowCacheBuild `true` to materialize the needed layout range on demand, `false` to
+		 *        query only when cache is ready.
 		 * @param requireTextHit `true` to require the point to fall inside rendered text glyph bounds.
 		 * @param textHit Optional output set to `true` when the point is over rendered text glyph bounds.
 		 * @return `true` when hit maps inside the rendered output surface.
@@ -1468,7 +1536,8 @@ class WorldView : public QWidget
 		 * @param position Output line/column hit position.
 		 * @param href Optional hyperlink href at hit point.
 		 * @param hint Optional hyperlink hint at hit point.
-		 * @param allowCacheBuild `true` to rebuild layout caches on demand, `false` to query only when cache is ready.
+		 * @param allowCacheBuild `true` to materialize the needed layout range on demand, `false` to
+		 *        query only when cache is ready.
 		 * @param textHit Optional output set to `true` when the event point is over rendered text glyph bounds.
 		 * @return `true` when event position maps to native output text.
 		 */
@@ -1485,7 +1554,7 @@ class WorldView : public QWidget
 		 * @param position Output line/column position.
 		 * @param href Optional hyperlink href at hit point.
 		 * @param hint Optional hyperlink hint at hit point.
-		 * @param allowCacheBuild `true` to rebuild layout caches on demand.
+		 * @param allowCacheBuild `true` to materialize the needed layout range on demand.
 		 * @param requireTextHit `true` to require the point to fall inside rendered text glyph bounds.
 		 * @param textHit Optional output set to `true` when the point is over rendered text glyph bounds.
 		 * @return `true` when point maps to native output.
@@ -1505,6 +1574,15 @@ class WorldView : public QWidget
 		 * @param lines Current native render lines.
 		 */
 		void               applyPendingNativeSelectionRenderDelta(const NativeOutputRenderLines &lines);
+		/**
+		 * @brief Resolves current native selection state without mutating stored selection.
+		 * @param lines Current native render lines.
+		 * @param selection Receives resolved selection state.
+		 * @return Resolution status for current render lines.
+		 */
+		[[nodiscard]] NativeOutputSelectionResolveResult
+		resolveNativeOutputSelectionStateForLines(const NativeOutputRenderLines &lines,
+		                                          NativeOutputSelectionState    &selection) const;
 		/**
 		 * @brief Captures stable line identity for a native output position.
 		 * @param lines Current native render lines.
@@ -1540,6 +1618,11 @@ class WorldView : public QWidget
 		                              const NativeOutputPosition &cursor, bool dragging);
 		/**
 		 * @brief Resolves native output selection bounds using legacy API coordinate semantics.
+		 * @param startLine Receives the one-based selection start line.
+		 * @param startColumn Receives the one-based selection start column.
+		 * @param endLine Receives the one-based selection end line.
+		 * @param endColumn Receives the one-based selection end column.
+		 * @return `true` when a native output selection is active.
 		 */
 		[[nodiscard]] bool    nativeOutputSelectionBounds(int &startLine, int &startColumn, int &endLine,
 		                                                  int &endColumn) const;
@@ -1558,9 +1641,15 @@ class WorldView : public QWidget
 		bool                  handleNativeOutputMouseEvent(const QEvent *event, const QWidget *watched);
 		/**
 		 * @brief Applies output-selection changed side effects and notifications.
+		 * @param hasSelection Whether a non-empty output selection is active.
+		 * @param startLine One-based inclusive selection start line.
+		 * @param startColumn One-based inclusive selection start column.
+		 * @param endLine One-based inclusive selection end line.
+		 * @param endColumn One-based exclusive selection end column.
+		 * @param allowClipboardCopy Allow auto-copy side effects for user-initiated selection changes.
 		 */
 		void applyResolvedOutputSelection(bool hasSelection, int startLine, int startColumn, int endLine,
-		                                  int endColumn);
+		                                  int endColumn, bool allowClipboardCopy = true);
 		/**
 		 * @brief Marks that user initiated a manual scroll action.
 		 */
@@ -1760,7 +1849,8 @@ class WorldView : public QWidget
 		 * @param precomputedPosInView Optional viewport-local position for @p precomputedView.
 		 * @param precomputedHit Optional precomputed native-output hit position.
 		 * @param precomputedTextHit Optional precomputed text-hit state for @p precomputedHit.
-		 * @param allowCacheBuild `true` to rebuild layout caches on demand, `false` to query only when cache is ready.
+		 * @param allowCacheBuild `true` to materialize the needed layout range on demand, `false` to
+		 *        query only when cache is ready.
 		 */
 		void              updateLineInformationTooltip(const QWidget *watched, const QMouseEvent *event,
 		                                               const WrapTextBrowser      *precomputedView = nullptr,
@@ -1965,6 +2055,7 @@ class WorldView : public QWidget
 		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailHeadTrimDiag;
 		mutable quint64                             m_nativeSplitTopHeadTrimPixelsRevision{0};
 		mutable int                                 m_nativeSplitTopHeadTrimPixels{0};
+		mutable int                                 m_nativeSplitTopHeadTrimLines{0};
 		mutable quint64                             m_nativeSplitTopHeadTrimAdjustedRevision{0};
 		mutable IndexedRingBuffer<NativeLayoutSlot> m_nativeLayoutSlots;
 		mutable NativeLayoutHeightIndex             m_nativeLayoutHeightIndex;
@@ -1977,6 +2068,8 @@ class WorldView : public QWidget
 		mutable qreal                               m_nativeLayoutCachedLineAdvance{0.0};
 		mutable QFont                               m_nativeLayoutCachedFont;
 		mutable quint64                             m_nativeLayoutCachedRenderRevision{0};
+		mutable quint64                             m_nativeLayoutRangePreparedRevision{0};
+		mutable bool                                m_nativeLayoutRangePreparedOnly{false};
 		mutable int                                 m_nativeLayoutCacheResets{0};
 		mutable int                                 m_nativeLayoutRowMeasurements{0};
 		IndexedRingBuffer<WorldRuntime::LineEntry>  m_nativeStandaloneOutputLines;

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -206,11 +206,13 @@ class WorldView : public QWidget
 		 * @brief Rebuilds visible output from stored line entries.
 		 * @param lines Line entries to render.
 		 */
+		void rebuildOutputFromLines(const IndexedRingBuffer<WorldRuntime::LineEntry> &lines);
 		void rebuildOutputFromLines(const QVector<WorldRuntime::LineEntry> &lines);
 		/**
 		 * @brief Restores persisted output lines into the native output renderer state.
 		 * @param lines Persisted line entries to restore.
 		 */
+		void restoreOutputFromPersistedLines(const IndexedRingBuffer<WorldRuntime::LineEntry> &lines);
 		void restoreOutputFromPersistedLines(const QVector<WorldRuntime::LineEntry> &lines);
 		/**
 		 * @brief Builds runtime render/layout caches for current viewport proactively.
@@ -898,6 +900,7 @@ class WorldView : public QWidget
 	private:
 		friend class WorldOutputCanvas;
 		struct NativeOutputRenderLine;
+		using NativeOutputRenderLines = IndexedRingBuffer<NativeOutputRenderLine>;
 
 		/**
 		 * @brief Miniwindow rendering/input hit-testing and output view internals.
@@ -954,7 +957,7 @@ class WorldView : public QWidget
 		 * @param lines Current native render lines.
 		 * @param allowLayoutBuild Build/rebuild native layout cache when metrics are stale.
 		 */
-		void              syncNativeOutputScrollBarsFromLayout(const QVector<NativeOutputRenderLine> &lines,
+		void              syncNativeOutputScrollBarsFromLayout(const NativeOutputRenderLines &lines,
 		                                                       bool allowLayoutBuild = true) const;
 		/**
 		 * @brief Requests a repaint for the native output canvas.
@@ -976,8 +979,8 @@ class WorldView : public QWidget
 		 * @param repaintRect Output canvas-local dirty rectangle. May be empty when the delta is off-screen.
 		 * @return `true` when the latest delta could be mapped safely, `false` when a full repaint is required.
 		 */
-		[[nodiscard]] bool  nativeOutputDeltaRepaintRect(const QVector<NativeOutputRenderLine> &lines,
-		                                                 QRect &repaintRect) const;
+		[[nodiscard]] bool  nativeOutputDeltaRepaintRect(const NativeOutputRenderLines &lines,
+		                                                 QRect                         &repaintRect) const;
 		/**
 		 * @brief Returns the union of visible native output text panes.
 		 * @return Canvas-local visible text-pane repaint rectangle.
@@ -989,7 +992,7 @@ class WorldView : public QWidget
 		 * @return `true` when the repaint request was handled without a full visible-pane repaint.
 		 */
 		[[nodiscard]] bool
-		requestNativeOutputScrollAwarePresentationRepaint(const QVector<NativeOutputRenderLine> &lines) const;
+		     requestNativeOutputScrollAwarePresentationRepaint(const NativeOutputRenderLines &lines) const;
 		/**
 		 * @brief Requests repaint after native runtime presentation synchronization.
 		 * @param repaintVisiblePanes Repaint full visible text panes instead of latest delta.
@@ -1000,24 +1003,24 @@ class WorldView : public QWidget
 		 * @param repaintVisiblePanes Repaint full visible text panes instead of latest delta.
 		 * @param lines Render lines already synchronized by the caller.
 		 */
-		void requestNativeOutputPresentationRepaint(bool repaintVisiblePanes,
-		                                            const QVector<NativeOutputRenderLine> &lines) const;
+		void requestNativeOutputPresentationRepaint(bool                           repaintVisiblePanes,
+		                                            const NativeOutputRenderLines &lines) const;
 		/**
 		 * @brief Builds an accessible text offset map from native output lines.
 		 * @param lines Native render lines to expose.
 		 * @return Accessible text map over the current logical output.
 		 */
 		[[nodiscard]] static QMudAccessibleTextUtils::LineOffsetMap
-		     accessibleNativeOutputTextMap(const QVector<NativeOutputRenderLine> &lines);
+		                    accessibleNativeOutputTextMap(const NativeOutputRenderLines &lines);
 		/**
 		 * @brief Primes the accessible text length without emitting backlog events.
 		 */
-		void primeAccessibleOutputTextState() const;
+		void                primeAccessibleOutputTextState() const;
 		/**
 		 * @brief Emits active-only accessibility notifications for newly presented native output.
 		 * @param lines Native render lines after presentation synchronization.
 		 */
-		void notifyAccessibleOutputPresented(const QVector<NativeOutputRenderLine> &lines) const;
+		void                notifyAccessibleOutputPresented(const NativeOutputRenderLines &lines) const;
 		[[nodiscard]] QRect nativeOutputPaneRect(const WrapTextBrowser *view) const;
 		/**
 		 * @brief Returns mutable paint state for a native output pane.
@@ -1036,7 +1039,7 @@ class WorldView : public QWidget
 		 */
 		void refreshNativeOutputPanePaintStateFromLayout(const WrapTextBrowser *view, const QRect &paneRect,
 		                                                 int scrollY, int scrollMax,
-		                                                 const QVector<NativeOutputRenderLine> &lines) const;
+		                                                 const NativeOutputRenderLines &lines) const;
 		/**
 		 * @brief Records native output pane geometry after painting.
 		 * @param view Output pane view.
@@ -1048,7 +1051,7 @@ class WorldView : public QWidget
 		 */
 		void updateNativeOutputPanePaintState(const WrapTextBrowser *view, const QRect &paneRect,
 		                                      const QRegion &paintedRegion, int scrollY, int scrollMax,
-		                                      const QVector<NativeOutputRenderLine> &lines) const;
+		                                      const NativeOutputRenderLines &lines) const;
 		[[nodiscard]] bool nativeServerSideWrapActive() const;
 		[[nodiscard]] int  nativeWrapWidthPixels(int viewportWidth, bool wrapEnabled) const;
 		[[nodiscard]] int  nativeLocalWrapWidthPixels(int viewportWidth, bool wrapEnabled) const;
@@ -1074,7 +1077,6 @@ class WorldView : public QWidget
 				QVector<qint64>                  sourceRuntimeLineNumbers;
 				quint64                          sourceRuntimeLineKey{0};
 		};
-		using NativeOutputRenderLines = QVector<NativeOutputRenderLine>;
 		/**
 		 * @brief Cache-delta classification for native render-line revisions.
 		 */
@@ -1181,7 +1183,7 @@ class WorldView : public QWidget
 		                                           bool appendToLastBaseLine) const;
 		void removeNativePartialRenderLineOverlay(bool bumpRevision) const;
 		void applyNativePartialRenderLineOverlay() const;
-		[[nodiscard]] const QVector<NativeOutputRenderLine> &finalizeNativeOutputRenderLines() const;
+		[[nodiscard]] const NativeOutputRenderLines &finalizeNativeOutputRenderLines() const;
 		[[nodiscard]] QVector<QTextLayout::FormatRange>
 		buildNativeFormatRanges(const NativeOutputRenderLine &line, const QFont &layoutFont) const;
 		/**
@@ -1193,7 +1195,7 @@ class WorldView : public QWidget
 		 * @param layoutFont Current output font.
 		 * @return `true` when layout caches can be used without rebuild.
 		 */
-		[[nodiscard]] bool nativeLayoutCacheReadyFor(const QVector<NativeOutputRenderLine> &lines,
+		[[nodiscard]] bool nativeLayoutCacheReadyFor(const NativeOutputRenderLines &lines,
 		                                             int wrapWidthPixels, int localWrapWidthPixels,
 		                                             int lineSpacingSetting, const QFont &layoutFont) const;
 		/**
@@ -1217,27 +1219,30 @@ class WorldView : public QWidget
 		 * @param layoutFont Current output font.
 		 * @return `true` when exact measurement changed cached cumulative heights.
 		 */
-		bool ensureNativeLayoutRange(const QVector<NativeOutputRenderLine> &lines, int firstLine,
-		                             int lastLine, int wrapWidthPixels, int localWrapWidthPixels,
-		                             int lineSpacingSetting, const QFont &layoutFont) const;
-		int  ensureNativeLineLayout(const QVector<NativeOutputRenderLine> &lines, int index,
-		                            int wrapWidthPixels, int localWrapWidthPixels, qreal defaultLineAdvance,
+		bool ensureNativeLayoutRange(const NativeOutputRenderLines &lines, int firstLine, int lastLine,
+		                             int wrapWidthPixels, int localWrapWidthPixels, int lineSpacingSetting,
+		                             const QFont &layoutFont) const;
+		int  ensureNativeLineLayout(const NativeOutputRenderLines &lines, int index, int wrapWidthPixels,
+		                            int localWrapWidthPixels, qreal defaultLineAdvance,
 		                            const QFont &layoutFont) const;
-		void ensureNativeLayoutCaches(const QVector<NativeOutputRenderLine> &lines, int wrapWidthPixels,
+		void ensureNativeLayoutCaches(const NativeOutputRenderLines &lines, int wrapWidthPixels,
 		                              int localWrapWidthPixels, int lineSpacingSetting,
 		                              const QFont &layoutFont) const;
-		[[nodiscard]] const QTextLayout                     *nativeLayoutForLine(int index) const;
+		[[nodiscard]] qreal              nativeLayoutCumulativeHeightAt(int index) const;
+		void                             setNativeLayoutCumulativeHeightAt(int index, qreal value) const;
+		void                             resetNativeLayoutCumulativeHeightOrigin() const;
+		[[nodiscard]] const QTextLayout *nativeLayoutForLine(int index) const;
 		/**
 		 * @brief Builds native-render lines from runtime/standalone line state.
 		 * @return Logical lines with merged soft-returns and style spans.
 		 */
-		[[nodiscard]] const QVector<NativeOutputRenderLine> &nativeOutputRenderLines() const;
+		[[nodiscard]] const NativeOutputRenderLines &nativeOutputRenderLines() const;
 		/**
 		 * @brief Rebuilds native render-line cache from provided runtime entries.
 		 * @param lines Source line entries.
 		 * @param fromRuntimeSource `true` when cache should track live runtime line deltas.
 		 */
-		void rebuildNativeRenderCacheFromLineEntries(const QVector<WorldRuntime::LineEntry> &lines,
+		void rebuildNativeRenderCacheFromLineEntries(const IndexedRingBuffer<WorldRuntime::LineEntry> &lines,
 		                                             bool fromRuntimeSource) const;
 		/**
 		 * @brief Marks the runtime-backed native render tail for local restitching.
@@ -1400,7 +1405,7 @@ class WorldView : public QWidget
 		 * @brief Applies pending head-trim remapping to native selection line indices.
 		 * @param lines Current native render lines.
 		 */
-		void               applyPendingNativeSelectionHeadTrim(const QVector<NativeOutputRenderLine> &lines);
+		void               applyPendingNativeSelectionHeadTrim(const NativeOutputRenderLines &lines);
 		/**
 		 * @brief Applies native selection maintenance after viewport/scroll updates.
 		 * @param view Output view associated with the current selection.
@@ -1734,223 +1739,224 @@ class WorldView : public QWidget
 		 * @brief Captures miniwindow paint bounds for dirty-rect native repainting.
 		 * @return Current miniwindow layer bounds and global-image identity.
 		 */
-		[[nodiscard]] MiniWindowPaintBoundsSnapshot  miniWindowPaintBoundsSnapshot() const;
+		[[nodiscard]] MiniWindowPaintBoundsSnapshot miniWindowPaintBoundsSnapshot() const;
 
-		WrapTextBrowser                             *m_output{nullptr};
-		WrapTextBrowser                             *m_liveOutput{nullptr};
-		InputTextEdit                               *m_input{nullptr};
+		WrapTextBrowser                            *m_output{nullptr};
+		WrapTextBrowser                            *m_liveOutput{nullptr};
+		InputTextEdit                              *m_input{nullptr};
 		/**
 		 * @brief Returns currently active output view (live/split).
 		 * @return Active output view pointer.
 		 */
-		[[nodiscard]] WrapTextBrowser               *activeOutputView() const;
+		[[nodiscard]] WrapTextBrowser              *activeOutputView() const;
 		/**
 		 * @brief Rebuilds miniwindow backing stores when the view DPR changes.
 		 */
-		void                                         syncMiniWindowDevicePixelRatio() const;
-		QSplitter                                   *m_splitter{nullptr};
-		QSplitter                                   *m_outputSplitter{nullptr};
-		QWidget                                     *m_outputContainer{nullptr};
-		QWidget                                     *m_outputStack{nullptr};
-		QWidget                                     *m_miniUnderlay{nullptr};
-		QWidget                                     *m_nativeOutputCanvas{nullptr};
-		QWidget                                     *m_miniOverlay{nullptr};
-		QScrollBar                                  *m_outputScrollBar{nullptr};
-		bool                                         m_outputScrollBarWanted{true};
-		mutable bool                                 m_nativeScrollSyncInPaint{false};
-		mutable bool                                 m_nativeOutputRepaintQueued{false};
-		mutable bool                                 m_nativeOutputRepaintAll{false};
-		mutable QRegion                              m_nativeOutputRepaintRegion;
-		mutable NativeOutputPanePaintState           m_nativePrimaryPaintState;
-		mutable NativeOutputPanePaintState           m_nativeLivePaintState;
-		mutable bool                                 m_nativeOutputScrollBlitPending{false};
-		mutable QRect                                m_nativeOutputScrollBlitExposedRect;
-		quint64                                      m_miniWindowChangeSerial{0};
-		mutable bool                                 m_miniWindowPaintBoundsValid{false};
-		mutable MiniWindowPaintBoundsSnapshot        m_miniWindowPaintBounds;
-		mutable QRegion                              m_pendingMiniWindowUnderlayDirtyRegion;
-		mutable QRegion                              m_pendingMiniWindowOverlayDirtyRegion;
-		mutable bool                                 m_wrapMarginReservationCacheValid{false};
-		mutable QRect                                m_wrapMarginReservationRect;
-		mutable quint64                              m_wrapMarginReservationSerial{0};
-		mutable int                                  m_wrapMarginReservationPixels{0};
-		QSize                                        m_lastQueuedOutputClientSize;
-		bool                                         m_lastQueuedOutputClientSizeValid{false};
-		mutable QVector<NativeOutputRenderLine>      m_nativeRenderLineCache;
-		mutable bool                                 m_nativeRenderLineCacheValid{false};
-		mutable bool                                 m_nativeRenderLineCacheFromRuntime{false};
-		mutable bool                                 m_nativeRuntimeTailRestitchPending{false};
-		mutable int                                  m_nativeRuntimeLineRestitchIndex{-1};
-		mutable int                                  m_nativeRuntimeRangeRestitchStartIndex{-1};
-		mutable quint64                              m_nativeRenderLineCacheRevision{0};
-		mutable NativeRenderCacheDelta               m_nativeRenderCacheDelta;
-		mutable int                                  m_accessibleOutputCharacterCount{-1};
-		mutable quint64                              m_accessibleOutputRevision{0};
-		mutable QString                              m_accessibleOutputText;
-		mutable bool                                 m_accessibleOutputPendingTailAppend{false};
-		mutable bool                                 m_nativePartialRenderLineApplied{false};
-		mutable bool                                 m_nativePartialRenderLineAppended{false};
-		mutable bool                                 m_nativePartialRenderBaseLastHardReturn{true};
-		mutable quint64                              m_nativePartialRenderLineEffectiveRevision{0};
-		mutable NativeOutputRenderLine               m_nativePartialRenderLineBaseTail;
-		mutable QString                              m_nativePartialRenderLineText;
-		mutable QVector<WorldRuntime::StyleSpan>     m_nativePartialRenderLineSpans;
-		mutable int                                  m_nativeCachedRuntimeCount{0};
-		mutable qint64                               m_nativeCachedRuntimeFirstLineNumber{0};
-		mutable qint64                               m_nativeCachedRuntimeLastLineNumber{0};
-		mutable bool                                 m_nativeCachedRuntimeLastHardReturn{true};
-		mutable bool                                 m_nativeCachedRuntimeLineNumbersContiguous{true};
-		mutable WorldRuntime::LineEntry              m_nativeCachedRuntimeFirstEntry;
-		mutable WorldRuntime::LineEntry              m_nativeCachedRuntimeLastEntry;
-		mutable int                                  m_nativeRenderCacheFullRebuilds{0};
-		mutable int                                  m_nativeRenderCacheSoftRebuilds{0};
-		mutable int                                  m_nativeRenderCacheIncrementalUpdates{0};
-		mutable int                                  m_nativeRenderCacheTrimDrops{0};
-		mutable int                                  m_nativeRenderCacheRebuildReasonCacheInvalid{0};
-		mutable int                                  m_nativeRenderCacheRebuildReasonRuntimeDisjoint{0};
-		mutable int                                  m_nativeRenderCacheRebuildReasonNonContigNoOverlap{0};
-		mutable int                                  m_nativeRenderCacheRebuildReasonRestitchFailure{0};
-		mutable int                                  m_nativeRenderCacheRebuildReasonAppendIndex{0};
-		mutable int                                  m_nativeRangeRestitchDiagCount{0};
-		mutable int                                  m_nativeRangeRestitchDiagMinStart{-1};
-		mutable int                                  m_nativeRangeRestitchDiagRebuiltTotal{0};
-		mutable int                                  m_nativeRangeRestitchDiagRebuiltMax{0};
-		mutable int                                  m_nativeRangeRestitchDiagDroppedTotal{0};
-		mutable int                                  m_nativeRangeRestitchDiagDroppedMax{0};
-		mutable NativeAppendDiagnosticBucket         m_nativeTailAppendDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeNonContiguousTailAppendDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeHeadTrimAppendDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeTailRestitchAppendDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRangeRestitchAppendDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeSoftCacheInvalidDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeSoftRuntimeDisjointDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeSoftNonContiguousNoOverlapDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeSoftRestitchFailureDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeSoftAppendStartOutOfRangeDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeFullRebuildAppendDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailRangeHeadTrimDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailRangeEmptyDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailRangeDropMissDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailRangeAppendNoChangeDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailLineHiddenOrOpenDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailLineRenderMissDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailLineCompositeDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailTailIndexMissDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailTailAppendNoChangeDiag;
-		mutable NativeAppendDiagnosticBucket         m_nativeRestitchFailHeadTrimDiag;
-		mutable quint64                              m_nativeSplitTopHeadTrimPixelsRevision{0};
-		mutable int                                  m_nativeSplitTopHeadTrimPixels{0};
-		mutable quint64                              m_nativeSplitTopHeadTrimAdjustedRevision{0};
-		mutable QVector<int>                         m_nativeLayoutVisualRows;
-		mutable QVector<quint64>                     m_nativeLayoutRuntimeLineKeys;
-		mutable QVector<qreal>                       m_nativeLayoutCumulativeHeights;
-		mutable QVector<QSharedPointer<QTextLayout>> m_nativeLayoutLineLayouts;
-		mutable QVector<quint64>                     m_nativeLayoutLineContentHashes;
-		mutable QVector<uchar>                       m_nativeLayoutRowsExact;
-		mutable int                                  m_nativeLayoutCumulativeDirtyFrom{0};
-		mutable bool                                 m_nativeLayoutCacheValid{false};
-		mutable int                                  m_nativeLayoutCachedWrapWidth{0};
-		mutable int                                  m_nativeLayoutCachedLocalWrapWidth{0};
-		mutable int                                  m_nativeLayoutCachedLineSpacing{0};
-		mutable quint64                              m_nativeLayoutCachedStyleKey{0};
-		mutable qreal                                m_nativeLayoutCachedLineAdvance{0.0};
-		mutable QFont                                m_nativeLayoutCachedFont;
-		mutable quint64                              m_nativeLayoutCachedRenderRevision{0};
-		mutable int                                  m_nativeLayoutCacheResets{0};
-		mutable int                                  m_nativeLayoutRowMeasurements{0};
-		QVector<WorldRuntime::LineEntry>             m_nativeStandaloneOutputLines;
-		qint64                                       m_nativeStandaloneNextLineNumber{1};
-		bool                                         m_wrapInput{false};
-		int                                          m_inputPixelOffset{0};
-		WorldRuntime                                *m_runtime{nullptr};
-		QFont                                        m_defaultOutputFont;
-		QFont                                        m_defaultInputFont;
-		bool                                         m_displayMyInput{false};
-		bool                                         m_escapeDeletesInput{false};
-		bool                                         m_saveDeletedCommand{false};
-		bool                                         m_confirmOnPaste{false};
-		bool                                         m_ctrlBackspaceDeletesLastWord{false};
-		bool                                         m_arrowsChangeHistory{false};
-		bool                                         m_arrowKeysWrap{false};
-		bool                                         m_arrowRecallsPartial{false};
-		bool                                         m_altArrowRecallsPartial{false};
-		bool                                         m_ctrlZGoesToEndOfBuffer{false};
-		bool                                         m_ctrlPGoesToPreviousCommand{false};
-		bool                                         m_ctrlNGoesToNextCommand{false};
-		bool                                         m_confirmBeforeReplacingTyping{false};
-		bool                                         m_doubleClickInserts{false};
-		bool                                         m_doubleClickSends{false};
-		bool                                         m_showBold{true};
-		bool                                         m_showItalic{true};
-		bool                                         m_showUnderline{true};
-		bool                                         m_alternativeInverse{false};
-		bool                                         m_lineInformation{false};
-		int                                          m_lineSpacing{0};
-		bool                                         m_lowerCaseTabCompletion{false};
-		bool                                         m_tabCompletionSpace{false};
-		bool                                         m_autoRepeat{false};
-		bool                                         m_keepCommandsOnSameLine{false};
-		bool                                         m_noEchoOff{false};
-		bool                                         m_noEcho{false};
-		bool                                         m_alwaysRecordCommandHistory{false};
-		bool                                         m_hyperlinkAddsToCommandHistory{false};
-		bool                                         m_inputChanged{false};
-		bool                                         m_settingText{false};
-		bool                                         m_notifyingPluginCommandChanged{false};
-		bool                                         m_frozen{false};
-		bool                                         m_autoPause{false};
-		QString                                      m_wordDelimiters;
-		QString                                      m_wordDelimitersDblClick;
-		bool                                         m_smoothScrolling{false};
-		bool                                         m_smootherScrolling{false};
-		bool                                         m_allTypingToCommandWindow{false};
-		bool                                         m_autoResizeCommandWindow{false};
-		int                                          m_autoResizeMinimumLines{1};
-		int                                          m_autoResizeMaximumLines{20};
-		int                                          m_tabCompletionLines{200};
-		QString                                      m_tabCompletionDefaults;
-		QString                                      m_tabCompletionCycleTargetLower;
-		int                                          m_tabCompletionCycleStartColumn{-1};
-		int                                          m_tabCompletionCycleEndColumn{-1};
-		int                                          m_tabCompletionCycleLastSource{-2};
-		bool                                         m_tabCompletionCycleActive{false};
-		QSet<QString>                                m_tabCompletionCycleSeenCompletions;
-		int                                          m_fadeOutputBufferAfterSeconds{0};
-		int                                          m_fadeOutputOpacityPercent{100};
-		int                                          m_fadeOutputSeconds{1};
-		QTimer                                      *m_fadeTimer{nullptr};
-		QDateTime                                    m_timeFadeCancelled;
-		bool                                         m_breakBeforeNextServerOutput{false};
-		bool                                         m_keepPauseAtBottom{false};
-		bool                                         m_userScrollAction{false};
-		bool                                         m_startPausedApplied{false};
-		bool                                         m_defaultInputHeightApplied{false};
-		bool                                         m_scrollbackSplitActive{false};
-		int                                          m_lastLiveSplitSize{0};
-		int                                          m_wrapColumn{0};
-		int                                          m_historyLimit{0};
-		bool                                         m_useCustomLinkColour{false};
-		bool                                         m_underlineHyperlinks{true};
-		QColor                                       m_hyperlinkColour;
-		QColor                                       m_outputBackground;
-		QColor                                       m_outputTextColour;
-		TimestampRenderSettings                      m_outputTimestampRenderSettings;
-		TimestampRenderSettings                      m_inputTimestampRenderSettings;
-		TimestampRenderSettings                      m_notesTimestampRenderSettings;
-		bool                                         m_bleedBackground{false};
-		int                                          m_historyIndex{-1};
-		int                                          m_partialIndex{-1};
-		QString                                      m_partialCommand;
-		QString                                      m_lastCommand;
-		QVector<QString>                             m_history;
-		QVector<PendingOutput>                       m_pendingOutput;
-		bool                                         m_flushingPending{false};
-		bool                                         m_hasPartialOutput{false};
-		int                                          m_partialOutputStart{0};
-		int                                          m_partialOutputLength{0};
-		bool                                         m_nativeHasPartialOutput{false};
-		QString                                      m_nativePartialOutputText;
-		QVector<WorldRuntime::StyleSpan>             m_nativePartialOutputSpans;
+		void                                        syncMiniWindowDevicePixelRatio() const;
+		QSplitter                                  *m_splitter{nullptr};
+		QSplitter                                  *m_outputSplitter{nullptr};
+		QWidget                                    *m_outputContainer{nullptr};
+		QWidget                                    *m_outputStack{nullptr};
+		QWidget                                    *m_miniUnderlay{nullptr};
+		QWidget                                    *m_nativeOutputCanvas{nullptr};
+		QWidget                                    *m_miniOverlay{nullptr};
+		QScrollBar                                 *m_outputScrollBar{nullptr};
+		bool                                        m_outputScrollBarWanted{true};
+		mutable bool                                m_nativeScrollSyncInPaint{false};
+		mutable bool                                m_nativeOutputRepaintQueued{false};
+		mutable bool                                m_nativeOutputRepaintAll{false};
+		mutable QRegion                             m_nativeOutputRepaintRegion;
+		mutable NativeOutputPanePaintState          m_nativePrimaryPaintState;
+		mutable NativeOutputPanePaintState          m_nativeLivePaintState;
+		mutable bool                                m_nativeOutputScrollBlitPending{false};
+		mutable QRect                               m_nativeOutputScrollBlitExposedRect;
+		quint64                                     m_miniWindowChangeSerial{0};
+		mutable bool                                m_miniWindowPaintBoundsValid{false};
+		mutable MiniWindowPaintBoundsSnapshot       m_miniWindowPaintBounds;
+		mutable QRegion                             m_pendingMiniWindowUnderlayDirtyRegion;
+		mutable QRegion                             m_pendingMiniWindowOverlayDirtyRegion;
+		mutable bool                                m_wrapMarginReservationCacheValid{false};
+		mutable QRect                               m_wrapMarginReservationRect;
+		mutable quint64                             m_wrapMarginReservationSerial{0};
+		mutable int                                 m_wrapMarginReservationPixels{0};
+		QSize                                       m_lastQueuedOutputClientSize;
+		bool                                        m_lastQueuedOutputClientSizeValid{false};
+		mutable NativeOutputRenderLines             m_nativeRenderLineCache;
+		mutable bool                                m_nativeRenderLineCacheValid{false};
+		mutable bool                                m_nativeRenderLineCacheFromRuntime{false};
+		mutable bool                                m_nativeRuntimeTailRestitchPending{false};
+		mutable int                                 m_nativeRuntimeLineRestitchIndex{-1};
+		mutable int                                 m_nativeRuntimeRangeRestitchStartIndex{-1};
+		mutable quint64                             m_nativeRenderLineCacheRevision{0};
+		mutable NativeRenderCacheDelta              m_nativeRenderCacheDelta;
+		mutable int                                 m_accessibleOutputCharacterCount{-1};
+		mutable quint64                             m_accessibleOutputRevision{0};
+		mutable QString                             m_accessibleOutputText;
+		mutable bool                                m_accessibleOutputPendingTailAppend{false};
+		mutable bool                                m_nativePartialRenderLineApplied{false};
+		mutable bool                                m_nativePartialRenderLineAppended{false};
+		mutable bool                                m_nativePartialRenderBaseLastHardReturn{true};
+		mutable quint64                             m_nativePartialRenderLineEffectiveRevision{0};
+		mutable NativeOutputRenderLine              m_nativePartialRenderLineBaseTail;
+		mutable QString                             m_nativePartialRenderLineText;
+		mutable QVector<WorldRuntime::StyleSpan>    m_nativePartialRenderLineSpans;
+		mutable int                                 m_nativeCachedRuntimeCount{0};
+		mutable qint64                              m_nativeCachedRuntimeFirstLineNumber{0};
+		mutable qint64                              m_nativeCachedRuntimeLastLineNumber{0};
+		mutable bool                                m_nativeCachedRuntimeLastHardReturn{true};
+		mutable bool                                m_nativeCachedRuntimeLineNumbersContiguous{true};
+		mutable WorldRuntime::LineEntry             m_nativeCachedRuntimeFirstEntry;
+		mutable WorldRuntime::LineEntry             m_nativeCachedRuntimeLastEntry;
+		mutable int                                 m_nativeRenderCacheFullRebuilds{0};
+		mutable int                                 m_nativeRenderCacheSoftRebuilds{0};
+		mutable int                                 m_nativeRenderCacheIncrementalUpdates{0};
+		mutable int                                 m_nativeRenderCacheTrimDrops{0};
+		mutable int                                 m_nativeRenderCacheRebuildReasonCacheInvalid{0};
+		mutable int                                 m_nativeRenderCacheRebuildReasonRuntimeDisjoint{0};
+		mutable int                                 m_nativeRenderCacheRebuildReasonNonContigNoOverlap{0};
+		mutable int                                 m_nativeRenderCacheRebuildReasonRestitchFailure{0};
+		mutable int                                 m_nativeRenderCacheRebuildReasonAppendIndex{0};
+		mutable int                                 m_nativeRangeRestitchDiagCount{0};
+		mutable int                                 m_nativeRangeRestitchDiagMinStart{-1};
+		mutable int                                 m_nativeRangeRestitchDiagRebuiltTotal{0};
+		mutable int                                 m_nativeRangeRestitchDiagRebuiltMax{0};
+		mutable int                                 m_nativeRangeRestitchDiagDroppedTotal{0};
+		mutable int                                 m_nativeRangeRestitchDiagDroppedMax{0};
+		mutable NativeAppendDiagnosticBucket        m_nativeTailAppendDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeNonContiguousTailAppendDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeHeadTrimAppendDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeTailRestitchAppendDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRangeRestitchAppendDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeSoftCacheInvalidDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeSoftRuntimeDisjointDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeSoftNonContiguousNoOverlapDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeSoftRestitchFailureDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeSoftAppendStartOutOfRangeDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeFullRebuildAppendDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailRangeHeadTrimDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailRangeEmptyDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailRangeDropMissDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailRangeAppendNoChangeDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailLineHiddenOrOpenDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailLineRenderMissDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailLineCompositeDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailTailIndexMissDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailTailAppendNoChangeDiag;
+		mutable NativeAppendDiagnosticBucket        m_nativeRestitchFailHeadTrimDiag;
+		mutable quint64                             m_nativeSplitTopHeadTrimPixelsRevision{0};
+		mutable int                                 m_nativeSplitTopHeadTrimPixels{0};
+		mutable quint64                             m_nativeSplitTopHeadTrimAdjustedRevision{0};
+		mutable IndexedRingBuffer<int>              m_nativeLayoutVisualRows;
+		mutable IndexedRingBuffer<quint64>          m_nativeLayoutRuntimeLineKeys;
+		mutable IndexedRingBuffer<qreal>            m_nativeLayoutCumulativeHeights;
+		mutable qreal                               m_nativeLayoutCumulativeHeightOrigin{0.0};
+		mutable IndexedRingBuffer<QSharedPointer<QTextLayout>> m_nativeLayoutLineLayouts;
+		mutable IndexedRingBuffer<quint64>                     m_nativeLayoutLineContentHashes;
+		mutable IndexedRingBuffer<uchar>                       m_nativeLayoutRowsExact;
+		mutable int                                            m_nativeLayoutCumulativeDirtyFrom{0};
+		mutable bool                                           m_nativeLayoutCacheValid{false};
+		mutable int                                            m_nativeLayoutCachedWrapWidth{0};
+		mutable int                                            m_nativeLayoutCachedLocalWrapWidth{0};
+		mutable int                                            m_nativeLayoutCachedLineSpacing{0};
+		mutable quint64                                        m_nativeLayoutCachedStyleKey{0};
+		mutable qreal                                          m_nativeLayoutCachedLineAdvance{0.0};
+		mutable QFont                                          m_nativeLayoutCachedFont;
+		mutable quint64                                        m_nativeLayoutCachedRenderRevision{0};
+		mutable int                                            m_nativeLayoutCacheResets{0};
+		mutable int                                            m_nativeLayoutRowMeasurements{0};
+		IndexedRingBuffer<WorldRuntime::LineEntry>             m_nativeStandaloneOutputLines;
+		qint64                                                 m_nativeStandaloneNextLineNumber{1};
+		bool                                                   m_wrapInput{false};
+		int                                                    m_inputPixelOffset{0};
+		WorldRuntime                                          *m_runtime{nullptr};
+		QFont                                                  m_defaultOutputFont;
+		QFont                                                  m_defaultInputFont;
+		bool                                                   m_displayMyInput{false};
+		bool                                                   m_escapeDeletesInput{false};
+		bool                                                   m_saveDeletedCommand{false};
+		bool                                                   m_confirmOnPaste{false};
+		bool                                                   m_ctrlBackspaceDeletesLastWord{false};
+		bool                                                   m_arrowsChangeHistory{false};
+		bool                                                   m_arrowKeysWrap{false};
+		bool                                                   m_arrowRecallsPartial{false};
+		bool                                                   m_altArrowRecallsPartial{false};
+		bool                                                   m_ctrlZGoesToEndOfBuffer{false};
+		bool                                                   m_ctrlPGoesToPreviousCommand{false};
+		bool                                                   m_ctrlNGoesToNextCommand{false};
+		bool                                                   m_confirmBeforeReplacingTyping{false};
+		bool                                                   m_doubleClickInserts{false};
+		bool                                                   m_doubleClickSends{false};
+		bool                                                   m_showBold{true};
+		bool                                                   m_showItalic{true};
+		bool                                                   m_showUnderline{true};
+		bool                                                   m_alternativeInverse{false};
+		bool                                                   m_lineInformation{false};
+		int                                                    m_lineSpacing{0};
+		bool                                                   m_lowerCaseTabCompletion{false};
+		bool                                                   m_tabCompletionSpace{false};
+		bool                                                   m_autoRepeat{false};
+		bool                                                   m_keepCommandsOnSameLine{false};
+		bool                                                   m_noEchoOff{false};
+		bool                                                   m_noEcho{false};
+		bool                                                   m_alwaysRecordCommandHistory{false};
+		bool                                                   m_hyperlinkAddsToCommandHistory{false};
+		bool                                                   m_inputChanged{false};
+		bool                                                   m_settingText{false};
+		bool                                                   m_notifyingPluginCommandChanged{false};
+		bool                                                   m_frozen{false};
+		bool                                                   m_autoPause{false};
+		QString                                                m_wordDelimiters;
+		QString                                                m_wordDelimitersDblClick;
+		bool                                                   m_smoothScrolling{false};
+		bool                                                   m_smootherScrolling{false};
+		bool                                                   m_allTypingToCommandWindow{false};
+		bool                                                   m_autoResizeCommandWindow{false};
+		int                                                    m_autoResizeMinimumLines{1};
+		int                                                    m_autoResizeMaximumLines{20};
+		int                                                    m_tabCompletionLines{200};
+		QString                                                m_tabCompletionDefaults;
+		QString                                                m_tabCompletionCycleTargetLower;
+		int                                                    m_tabCompletionCycleStartColumn{-1};
+		int                                                    m_tabCompletionCycleEndColumn{-1};
+		int                                                    m_tabCompletionCycleLastSource{-2};
+		bool                                                   m_tabCompletionCycleActive{false};
+		QSet<QString>                                          m_tabCompletionCycleSeenCompletions;
+		int                                                    m_fadeOutputBufferAfterSeconds{0};
+		int                                                    m_fadeOutputOpacityPercent{100};
+		int                                                    m_fadeOutputSeconds{1};
+		QTimer                                                *m_fadeTimer{nullptr};
+		QDateTime                                              m_timeFadeCancelled;
+		bool                                                   m_breakBeforeNextServerOutput{false};
+		bool                                                   m_keepPauseAtBottom{false};
+		bool                                                   m_userScrollAction{false};
+		bool                                                   m_startPausedApplied{false};
+		bool                                                   m_defaultInputHeightApplied{false};
+		bool                                                   m_scrollbackSplitActive{false};
+		int                                                    m_lastLiveSplitSize{0};
+		int                                                    m_wrapColumn{0};
+		int                                                    m_historyLimit{0};
+		bool                                                   m_useCustomLinkColour{false};
+		bool                                                   m_underlineHyperlinks{true};
+		QColor                                                 m_hyperlinkColour;
+		QColor                                                 m_outputBackground;
+		QColor                                                 m_outputTextColour;
+		TimestampRenderSettings                                m_outputTimestampRenderSettings;
+		TimestampRenderSettings                                m_inputTimestampRenderSettings;
+		TimestampRenderSettings                                m_notesTimestampRenderSettings;
+		bool                                                   m_bleedBackground{false};
+		int                                                    m_historyIndex{-1};
+		int                                                    m_partialIndex{-1};
+		QString                                                m_partialCommand;
+		QString                                                m_lastCommand;
+		QVector<QString>                                       m_history;
+		QVector<PendingOutput>                                 m_pendingOutput;
+		bool                                                   m_flushingPending{false};
+		bool                                                   m_hasPartialOutput{false};
+		int                                                    m_partialOutputStart{0};
+		int                                                    m_partialOutputLength{0};
+		bool                                                   m_nativeHasPartialOutput{false};
+		QString                                                m_nativePartialOutputText;
+		QVector<WorldRuntime::StyleSpan>                       m_nativePartialOutputSpans;
 		struct OutputFindState;
 		QScopedPointer<OutputFindState>         m_outputFind;
 		QScopedPointer<CommandHistoryFindState> m_commandHistoryFind;

--- a/src/dialogs/GlobalPreferencesDialog.cpp
+++ b/src/dialogs/GlobalPreferencesDialog.cpp
@@ -143,9 +143,11 @@ GlobalPreferencesDialog::GlobalPreferencesDialog(QWidget *parent) : QDialog(pare
 	root->addLayout(tabRows);
 
 	m_tabs = new QTabWidget(this);
+	m_tabs->setFocusPolicy(Qt::NoFocus);
 	m_tabs->setUsesScrollButtons(false);
 	m_tabs->tabBar()->setExpanding(false);
 	m_tabs->tabBar()->setElideMode(Qt::ElideNone);
+	m_tabs->tabBar()->setFocusPolicy(Qt::NoFocus);
 	m_tabs->tabBar()->hide();
 	m_tabs->addTab(buildWorldsPage(), QStringLiteral("Worlds"));
 	m_tabs->addTab(buildGeneralPage(), QStringLiteral("General"));
@@ -1498,6 +1500,7 @@ QWidget *GlobalPreferencesDialog::buildLuaPage()
 	layout->addWidget(label);
 
 	m_luaScript = new QTextEdit;
+	m_luaScript->setTabChangesFocus(true);
 	layout->addWidget(m_luaScript);
 
 	auto *bottom     = new QHBoxLayout;
@@ -1516,6 +1519,7 @@ QWidget *GlobalPreferencesDialog::buildLuaPage()
 		                 dlg.setWindowTitle(QStringLiteral("Edit Lua Script"));
 		                 auto *layout = new QVBoxLayout(&dlg);
 		                 auto *editor = new QTextEdit(&dlg);
+		                 editor->setTabChangesFocus(true);
 		                 editor->setPlainText(m_luaScript ? m_luaScript->toPlainText() : QString());
 		                 layout->addWidget(editor);
 		                 auto *buttons =

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -9753,10 +9753,10 @@ void WorldPreferencesDialog::calculateMemoryUsage(const bool allowProgress)
 	if (!m_runtime || !m_infoMemoryUsed || !m_infoBufferLines)
 		return;
 
-	const QVector<WorldRuntime::LineEntry> &lines     = m_runtime->lines();
-	const int                               lineCount = saturatingToInt(lines.size());
-	const int                               maxLines  = worldMaxOutputLines(m_runtime->worldAttributes());
-	QProgressDialog                        *progress  = nullptr;
+	const auto      &lines     = m_runtime->lines();
+	const int        lineCount = saturatingToInt(lines.size());
+	const int        maxLines  = worldMaxOutputLines(m_runtime->worldAttributes());
+	QProgressDialog *progress  = nullptr;
 	if (allowProgress && lineCount > 1000)
 	{
 		progress = new QProgressDialog(QStringLiteral("Calculating memory usage..."),
@@ -9972,9 +9972,9 @@ void WorldPreferencesDialog::populateInfo()
 		        ? m_runtime->dateSaved().toString(QStringLiteral("dddd, MMMM dd, yyyy, h:mm AP"))
 		        : QStringLiteral("-"));
 
-	const QVector<WorldRuntime::LineEntry> &lines     = m_runtime->lines();
-	const int                               lineCount = saturatingToInt(lines.size());
-	const int                               maxLines  = worldMaxOutputLines(m_runtime->worldAttributes());
+	const auto &lines     = m_runtime->lines();
+	const int   lineCount = saturatingToInt(lines.size());
+	const int   maxLines  = worldMaxOutputLines(m_runtime->worldAttributes());
 	if (m_infoBufferLines)
 	{
 		if (maxLines > 0)

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -3854,12 +3854,12 @@ void WorldPreferencesDialog::buildUi()
 	customMainRow->addStretch();
 	auto *customButtons     = new QGridLayout();
 	m_customDefaults        = new QPushButton(QStringLiteral("De&faults..."), customColoursPage);
-	m_customInvert          = new QPushButton(QStringLiteral("&Invert"), customColoursPage);
-	m_customRandom          = new QPushButton(QStringLiteral("&Random..."), customColoursPage);
 	m_customLighter         = new QPushButton(QStringLiteral("&Lighter"), customColoursPage);
 	m_customDarker          = new QPushButton(QStringLiteral("&Darker"), customColoursPage);
 	m_customMoreColour      = new QPushButton(QStringLiteral("&More colour"), customColoursPage);
 	m_customLessColour      = new QPushButton(QStringLiteral("L&ess colour"), customColoursPage);
+	m_customInvert          = new QPushButton(QStringLiteral("&Invert"), customColoursPage);
+	m_customRandom          = new QPushButton(QStringLiteral("&Random..."), customColoursPage);
 	auto shrinkCustomButton = [](QPushButton *button)
 	{
 		if (!button)
@@ -3969,7 +3969,15 @@ void WorldPreferencesDialog::buildUi()
 	updateTlsEncryptionState();
 
 	// Logging
-	auto *loggingLayout   = new QGridLayout(loggingPage);
+	auto *loggingLayout = new QGridLayout(loggingPage);
+	m_logFilePreamble   = new QTextEdit(loggingPage);
+	m_substitutionHelp  = new QPushButton(QStringLiteral("?"), loggingPage);
+	m_editPreamble      = new QPushButton(QStringLiteral("..."), loggingPage);
+	m_logFilePostamble  = new QTextEdit(loggingPage);
+	m_editPostamble     = new QPushButton(QStringLiteral("..."), loggingPage);
+	m_standardPreamble  = new QPushButton(QStringLiteral("Standard HTML preamble/postamble"), loggingPage);
+	m_logFilePreamble->setTabChangesFocus(true);
+	m_logFilePostamble->setTabChangesFocus(true);
 	m_logOutput           = new QCheckBox(QStringLiteral("Log Output"), loggingPage);
 	m_logInput            = new QCheckBox(QStringLiteral("Log Commands"), loggingPage);
 	m_logNotes            = new QCheckBox(QStringLiteral("Log Notes"), loggingPage);
@@ -3981,17 +3989,11 @@ void WorldPreferencesDialog::buildUi()
 	m_logRotateGzip       = new QCheckBox(QStringLiteral("Gzip logs on close"), loggingPage);
 	m_autoLogFileName     = new QLineEdit(loggingPage);
 	m_browseLogFile       = new QPushButton(QStringLiteral("&Browse..."), loggingPage);
-	m_logFilePreamble     = new QTextEdit(loggingPage);
-	m_logFilePostamble    = new QTextEdit(loggingPage);
-	m_standardPreamble    = new QPushButton(QStringLiteral("Standard HTML preamble/postamble"), loggingPage);
-	m_editPreamble        = new QPushButton(QStringLiteral("..."), loggingPage);
-	m_editPostamble       = new QPushButton(QStringLiteral("..."), loggingPage);
-	m_substitutionHelp    = new QPushButton(QStringLiteral("?"), loggingPage);
 	m_editPreamble->setFixedWidth(24);
 	m_editPostamble->setFixedWidth(24);
 	m_substitutionHelp->setFixedWidth(24);
 
-	loggingLayout->addWidget(new QLabel(QStringLiteral("File"), loggingPage), 0, 0);
+	loggingLayout->addWidget(new QLabel(QStringLiteral("File Preamble"), loggingPage), 0, 0);
 	loggingLayout->addWidget(m_logFilePreamble, 0, 1);
 	auto *preambleButtons = new QVBoxLayout();
 	preambleButtons->addWidget(m_substitutionHelp);
@@ -3999,7 +4001,7 @@ void WorldPreferencesDialog::buildUi()
 	preambleButtons->addStretch();
 	loggingLayout->addLayout(preambleButtons, 0, 2);
 
-	loggingLayout->addWidget(new QLabel(QStringLiteral("File"), loggingPage), 1, 0);
+	loggingLayout->addWidget(new QLabel(QStringLiteral("File Postamble"), loggingPage), 1, 0);
 	loggingLayout->addWidget(m_logFilePostamble, 1, 1);
 	auto *postambleButtons = new QVBoxLayout();
 	postambleButtons->addWidget(m_editPostamble);
@@ -4493,18 +4495,21 @@ void WorldPreferencesDialog::buildUi()
 				        return;
 			        applyCustomRandom();
 		        });
-	auto *ansiButtons  = new QGridLayout();
-	m_ansiDefaults     = new QPushButton(QStringLiteral("&ANSI colours..."), ansiColoursPage);
-	m_ansiSwap         = new QPushButton(QStringLiteral("<- Swap ->"), ansiColoursPage);
-	m_ansiInvert       = new QPushButton(QStringLiteral("Invert"), ansiColoursPage);
-	m_ansiRandom       = new QPushButton(QStringLiteral("&Random..."), ansiColoursPage);
-	m_ansiLighter      = new QPushButton(QStringLiteral("L&ighter"), ansiColoursPage);
-	m_ansiDarker       = new QPushButton(QStringLiteral("&Darker"), ansiColoursPage);
-	m_ansiMoreColour   = new QPushButton(QStringLiteral("&More colour"), ansiColoursPage);
-	m_ansiLessColour   = new QPushButton(QStringLiteral("L&ess colour"), ansiColoursPage);
-	m_ansiLoad         = new QPushButton(QStringLiteral("&Load..."), ansiColoursPage);
-	m_ansiSave         = new QPushButton(QStringLiteral("&Save..."), ansiColoursPage);
-	m_copyAnsiToCustom = new QPushButton(QStringLiteral("&Copy to custom..."), ansiColoursPage);
+	auto *ansiButtons = new QGridLayout();
+	m_ansiSwap        = new QPushButton(QStringLiteral("<- Swap ->"), ansiColoursPage);
+	m_custom16IsDefaultColour =
+	    new QCheckBox(QStringLiteral("Use Custom Colour 16 as default"), ansiColoursPage);
+	m_useDefaultColours = new QCheckBox(QStringLiteral("Override with default colours"), ansiColoursPage);
+	m_ansiDefaults      = new QPushButton(QStringLiteral("&ANSI colours..."), ansiColoursPage);
+	m_ansiLoad          = new QPushButton(QStringLiteral("&Load..."), ansiColoursPage);
+	m_ansiSave          = new QPushButton(QStringLiteral("&Save..."), ansiColoursPage);
+	m_ansiLighter       = new QPushButton(QStringLiteral("L&ighter"), ansiColoursPage);
+	m_ansiDarker        = new QPushButton(QStringLiteral("&Darker"), ansiColoursPage);
+	m_ansiMoreColour    = new QPushButton(QStringLiteral("&More colour"), ansiColoursPage);
+	m_ansiLessColour    = new QPushButton(QStringLiteral("L&ess colour"), ansiColoursPage);
+	m_copyAnsiToCustom  = new QPushButton(QStringLiteral("&Copy to custom..."), ansiColoursPage);
+	m_ansiInvert        = new QPushButton(QStringLiteral("Invert"), ansiColoursPage);
+	m_ansiRandom        = new QPushButton(QStringLiteral("&Random..."), ansiColoursPage);
 	if (ansiSwatchGrid)
 		ansiSwatchGrid->addWidget(m_ansiSwap, 10, 1, 1, 2, Qt::AlignHCenter);
 	auto shrinkAnsiButton = [](QPushButton *button)
@@ -4539,10 +4544,7 @@ void WorldPreferencesDialog::buildUi()
 	ansiButtonsColumn->addLayout(ansiButtons);
 	ansiButtonsColumn->addStretch();
 	ansiTop->addLayout(ansiButtonsColumn);
-	auto *ansiOptions   = new QVBoxLayout();
-	m_useDefaultColours = new QCheckBox(QStringLiteral("Override with default colours"), ansiColoursPage);
-	m_custom16IsDefaultColour =
-	    new QCheckBox(QStringLiteral("Use Custom Colour 16 as default"), ansiColoursPage);
+	auto *ansiOptions = new QVBoxLayout();
 	if (m_useDefaultColours)
 		connect(m_useDefaultColours, &QCheckBox::toggled, this, [this] { updateDefaultColoursState(); });
 	ansiOptions->setContentsMargins(0, 0, 0, 0);
@@ -4730,6 +4732,7 @@ void WorldPreferencesDialog::buildUi()
 	m_macrosTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
 	m_macrosTable->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_macrosTable->setSelectionMode(QAbstractItemView::SingleSelection);
+	m_macrosTable->setTabKeyNavigation(false);
 	macrosLayout->addWidget(m_macrosTable);
 	auto *macrosHint =
 	    new QLabel(QStringLiteral("Customise output from function keys and \"Game\" menu."), macrosPage);
@@ -5816,6 +5819,7 @@ void WorldPreferencesDialog::buildUi()
 		        detail->setWordWrap(true);
 		        dialogLayout->addWidget(detail);
 		        auto *words = new QTextEdit(&dialog);
+		        words->setTabChangesFocus(true);
 		        if (m_tabCompletionDefaults)
 			        words->setPlainText(m_tabCompletionDefaults->toPlainText());
 		        dialogLayout->addWidget(words, 1);
@@ -5987,11 +5991,13 @@ void WorldPreferencesDialog::buildUi()
 	    });
 
 	// Send to world
-	auto *sendLayout           = new QVBoxLayout(sendToWorldPage);
-	m_sendToWorldFilePreamble  = new QTextEdit(sendToWorldPage);
-	m_sendToWorldFilePostamble = new QTextEdit(sendToWorldPage);
+	auto *sendLayout          = new QVBoxLayout(sendToWorldPage);
+	m_sendToWorldFilePreamble = new QTextEdit(sendToWorldPage);
+	m_sendToWorldFilePreamble->setTabChangesFocus(true);
 	m_sendToWorldLinePreamble  = new QLineEdit(sendToWorldPage);
 	m_sendToWorldLinePostamble = new QLineEdit(sendToWorldPage);
+	m_sendToWorldFilePostamble = new QTextEdit(sendToWorldPage);
+	m_sendToWorldFilePostamble->setTabChangesFocus(true);
 	sendLayout->addWidget(
 	    new QLabel(QStringLiteral("1. Send this at the start of a \"send file to\""), sendToWorldPage));
 	sendLayout->addWidget(m_sendToWorldFilePreamble);
@@ -6025,29 +6031,30 @@ void WorldPreferencesDialog::buildUi()
 	sendLayout->addStretch();
 
 	// Scripting
-	auto *scriptingLayout = new QVBoxLayout(scriptingPage);
-	m_enableScripts       = new QCheckBox(QStringLiteral("Enable scripting"), scriptingPage);
-	m_scriptLanguage      = new QComboBox(scriptingPage);
+	auto *scriptingLayout     = new QVBoxLayout(scriptingPage);
+	m_scriptPrefix            = new QLineEdit(scriptingPage);
+	m_enableScripts           = new QCheckBox(QStringLiteral("Enable scripting"), scriptingPage);
+	m_warnIfScriptingInactive = new QCheckBox(QStringLiteral("Warn if inactive"), scriptingPage);
+	m_scriptIsActive          = new QLabel(QStringLiteral("(inactive)"), scriptingPage);
+	m_scriptLanguage          = new QComboBox(scriptingPage);
 	m_scriptLanguage->addItem(QStringLiteral("Lua"), QStringLiteral("Lua"));
 	m_scriptLanguage->setVisible(false);
-	m_scriptFile         = new QLineEdit(scriptingPage);
-	m_browseScriptFile   = new QPushButton(QStringLiteral("&Browse..."), scriptingPage);
-	m_newScriptFile      = new QPushButton(QStringLiteral("&New..."), scriptingPage);
-	m_editScriptFile     = new QPushButton(QStringLiteral("Edit &Script"), scriptingPage);
-	m_scriptPrefix       = new QLineEdit(scriptingPage);
-	m_scriptEditor       = new QLineEdit(scriptingPage);
-	m_editorWindowName   = new QLineEdit(scriptingPage);
-	m_chooseScriptEditor = new QPushButton(QStringLiteral("Choose &Editor..."), scriptingPage);
+	m_scriptFile       = new QLineEdit(scriptingPage);
+	m_browseScriptFile = new QPushButton(QStringLiteral("&Browse..."), scriptingPage);
+	m_newScriptFile    = new QPushButton(QStringLiteral("&New..."), scriptingPage);
+	m_editScriptFile   = new QPushButton(QStringLiteral("Edit &Script"), scriptingPage);
 	m_editScriptWithNotepad =
 	    new QCheckBox(QStringLiteral("Use inbuilt notepad to edit script"), scriptingPage);
-	m_warnIfScriptingInactive = new QCheckBox(QStringLiteral("Warn if inactive"), scriptingPage);
-	m_scriptErrorsToOutput    = new QCheckBox(QStringLiteral("Note errors"), scriptingPage);
-	m_logScriptErrors         = new QCheckBox(QStringLiteral("Log script errors"), scriptingPage);
-	m_scriptReloadOption      = new QComboBox(scriptingPage);
+	m_chooseScriptEditor   = new QPushButton(QStringLiteral("Choose &Editor..."), scriptingPage);
+	m_scriptEditor         = new QLineEdit(scriptingPage);
+	m_editorWindowName     = new QLineEdit(scriptingPage);
+	m_scriptReloadOption   = new QComboBox(scriptingPage);
+	m_scriptErrorsToOutput = new QCheckBox(QStringLiteral("Note errors"), scriptingPage);
+	m_logScriptErrors      = new QCheckBox(QStringLiteral("Log script errors"), scriptingPage);
+	m_scriptTextColour     = new QComboBox(scriptingPage);
 	m_scriptReloadOption->addItem(QStringLiteral("Confirm"), eReloadConfirm);
 	m_scriptReloadOption->addItem(QStringLiteral("Reload always"), eReloadAlways);
 	m_scriptReloadOption->addItem(QStringLiteral("Reload never"), eReloadNever);
-	m_scriptTextColour = new QComboBox(scriptingPage);
 	m_scriptTextSwatch = new QPushButton(scriptingPage);
 	m_scriptTextSwatch->setFixedSize(16, 16);
 	m_scriptTextSwatch->setFlat(true);
@@ -6058,7 +6065,6 @@ void WorldPreferencesDialog::buildUi()
 	m_scriptBackSwatch->setFlat(true);
 	m_scriptBackSwatch->setEnabled(false);
 	m_scriptBackSwatch->setFocusPolicy(Qt::NoFocus);
-	m_scriptIsActive      = new QLabel(QStringLiteral("(inactive)"), scriptingPage);
 	m_scriptExecutionTime = new QLabel(QStringLiteral("-"), scriptingPage);
 
 	auto *scriptPrefixLabel = new QLabel(QStringLiteral("Script"), scriptingPage);
@@ -6125,19 +6131,20 @@ void WorldPreferencesDialog::buildUi()
 		callbackLayout->addWidget(label, row, 0);
 		callbackLayout->addWidget(edit, row, 1, 1, 2);
 	};
-	m_onWorldOpen       = new QLineEdit(callbackBox);
-	m_onWorldClose      = new QLineEdit(callbackBox);
-	m_onWorldConnect    = new QLineEdit(callbackBox);
-	m_onWorldDisconnect = new QLineEdit(callbackBox);
-	m_onWorldSave       = new QLineEdit(callbackBox);
-	m_onWorldGetFocus   = new QLineEdit(callbackBox);
-	m_onWorldLoseFocus  = new QLineEdit(callbackBox);
-	m_onMxpStart        = new QLineEdit(callbackBox);
-	m_onMxpStop         = new QLineEdit(callbackBox);
-	m_onMxpOpenTag      = new QLineEdit(callbackBox);
-	m_onMxpCloseTag     = new QLineEdit(callbackBox);
-	m_onMxpSetVariable  = new QLineEdit(callbackBox);
-	m_onMxpError        = new QLineEdit(callbackBox);
+	m_onWorldOpen          = new QLineEdit(callbackBox);
+	m_onWorldConnect       = new QLineEdit(callbackBox);
+	m_onWorldGetFocus      = new QLineEdit(callbackBox);
+	m_onWorldLoseFocus     = new QLineEdit(callbackBox);
+	m_onWorldDisconnect    = new QLineEdit(callbackBox);
+	m_onWorldClose         = new QLineEdit(callbackBox);
+	m_onWorldSave          = new QLineEdit(callbackBox);
+	auto *mxpScriptsButton = new QPushButton(QStringLiteral("MXP..."), callbackBox);
+	m_onMxpStart           = new QLineEdit(callbackBox);
+	m_onMxpStop            = new QLineEdit(callbackBox);
+	m_onMxpOpenTag         = new QLineEdit(callbackBox);
+	m_onMxpCloseTag        = new QLineEdit(callbackBox);
+	m_onMxpSetVariable     = new QLineEdit(callbackBox);
+	m_onMxpError           = new QLineEdit(callbackBox);
 	m_onMxpStart->setVisible(false);
 	m_onMxpStop->setVisible(false);
 	m_onMxpOpenTag->setVisible(false);
@@ -6151,7 +6158,6 @@ void WorldPreferencesDialog::buildUi()
 	addCallbackRow(QStringLiteral("Disconnect"), m_onWorldDisconnect, 4);
 	addCallbackRow(QStringLiteral("Close"), m_onWorldClose, 5);
 	addCallbackRow(QStringLiteral("Save"), m_onWorldSave, 6);
-	auto *mxpScriptsButton = new QPushButton(QStringLiteral("MXP..."), callbackBox);
 	auto *mxpHint = new QLabel(QStringLiteral("(Click for MXP-related script handlers)"), callbackBox);
 	callbackLayout->addWidget(mxpScriptsButton, 7, 1, Qt::AlignLeft);
 	callbackLayout->addWidget(mxpHint, 7, 2, Qt::AlignLeft);
@@ -6364,6 +6370,7 @@ void WorldPreferencesDialog::buildUi()
 	// Notes
 	auto *notesLayout = new QVBoxLayout(notesPage);
 	m_notes           = new QTextEdit(notesPage);
+	m_notes->setTabChangesFocus(true);
 	notesLayout->addWidget(m_notes);
 	auto *notesButtons    = new QHBoxLayout();
 	m_loadNotesButton     = new QPushButton(QStringLiteral("&Load..."), notesPage);
@@ -6755,6 +6762,7 @@ void WorldPreferencesDialog::buildUi()
 
 	auto *varsLayout = new QVBoxLayout(variablesPage);
 	m_variablesTable = makeTable(variablesPage, {QStringLiteral("Name"), QStringLiteral("Value")});
+	m_variablesTable->setTabKeyNavigation(false);
 	varsLayout->addWidget(m_variablesTable);
 	auto *variableOptions = new QHBoxLayout();
 	m_variablesCount      = new QLabel(QStringLiteral("0 items."), variablesPage);
@@ -6811,7 +6819,6 @@ void WorldPreferencesDialog::buildUi()
 	};
 	addKeypadField(keypadContent, keypadBlock, QStringLiteral("/"), 0, 0);
 	addKeypadField(keypadContent, keypadBlock, QStringLiteral("*"), 0, 2);
-	addKeypadField(keypadContent, keypadBlock, QStringLiteral("-"), 0, 3);
 	auto *keypadGroup =
 	    new QGroupBox(QStringLiteral("\"NumLock\" must be active for these keys to work"), keypadContent);
 	auto *keypadGrid = new QGridLayout(keypadGroup);
@@ -6826,6 +6833,7 @@ void WorldPreferencesDialog::buildUi()
 	addKeypadField(keypadGroup, keypadGrid, QStringLiteral("3"), 4, 2);
 	addKeypadField(keypadGroup, keypadGrid, QStringLiteral("0"), 6, 0, 2);
 	addKeypadField(keypadGroup, keypadGrid, QStringLiteral("."), 6, 2);
+	addKeypadField(keypadContent, keypadBlock, QStringLiteral("-"), 0, 3);
 	auto *plusWidget = new QWidget(keypadContent);
 	auto *plusGrid   = new QGridLayout(plusWidget);
 	plusGrid->setContentsMargins(0, 0, 0, 0);
@@ -6859,11 +6867,13 @@ void WorldPreferencesDialog::buildUi()
 	        });
 
 	// Paste
-	auto *pasteLayout    = new QVBoxLayout(pastePage);
-	m_pastePreamble      = new QTextEdit(pastePage);
-	m_pastePostamble     = new QTextEdit(pastePage);
+	auto *pasteLayout = new QVBoxLayout(pastePage);
+	m_pastePreamble   = new QTextEdit(pastePage);
+	m_pastePreamble->setTabChangesFocus(true);
 	m_pasteLinePreamble  = new QLineEdit(pastePage);
 	m_pasteLinePostamble = new QLineEdit(pastePage);
+	m_pastePostamble     = new QTextEdit(pastePage);
+	m_pastePostamble->setTabChangesFocus(true);
 	pasteLayout->addWidget(
 	    new QLabel(QStringLiteral("1. Send this at the start of a \"paste to\""), pastePage));
 	pasteLayout->addWidget(m_pastePreamble);
@@ -7260,7 +7270,8 @@ void WorldPreferencesDialog::buildUi()
 	auto *connectTextGroup  = new QGroupBox(QStringLiteral("Connect Text"), connectingPage);
 	auto *connectTextLayout = new QVBoxLayout(connectTextGroup);
 	m_connectText           = new QTextEdit(connectTextGroup);
-	m_connectLineCount      = new QLabel(formatLineCountLabel(0), connectTextGroup);
+	m_connectText->setTabChangesFocus(true);
+	m_connectLineCount = new QLabel(formatLineCountLabel(0), connectTextGroup);
 	m_connectLineCount->setAlignment(Qt::AlignRight);
 	connectTextLayout->addWidget(m_connectText);
 	connectTextLayout->addWidget(m_connectLineCount);

--- a/src/dialogs/WorldPreferencesDialog.cpp
+++ b/src/dialogs/WorldPreferencesDialog.cpp
@@ -5586,7 +5586,7 @@ void WorldPreferencesDialog::buildUi()
 	auto *historyKeepLabel = new QLabel(QStringLiteral("Keep:"), historyBox);
 	historyKeepLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	m_historyLines = new QSpinBox(historyBox);
-	m_historyLines->setRange(20, 5000);
+	m_historyLines->setRange(20, 50000);
 	configureSpinBoxWidthForRange(m_historyLines);
 	historyLayout->addWidget(historyKeepLabel, 0, 0);
 	historyLayout->addWidget(m_historyLines, 0, 1);

--- a/src/helpers/HyperlinkActionUtils.cpp
+++ b/src/helpers/HyperlinkActionUtils.cpp
@@ -37,6 +37,27 @@ namespace
 		    routine, [](const QChar ch)
 		    { return ch.isLetterOrNumber() || ch == QLatin1Char('_') || ch == QLatin1Char('.'); });
 	}
+	template <typename Lines>
+	MxpHyperlinkDispatchPolicy resolveMxpHyperlinkDispatchPolicyForLines(const Lines   &lines,
+	                                                                     const QString &normalizedHref)
+	{
+		for (qsizetype i = lines.size(); i > 0; --i)
+		{
+			const WorldRuntime::LineEntry &line = lines.at(i - 1);
+			for (const WorldRuntime::StyleSpan &span : line.spans)
+			{
+				if (decodeMxpActionText(span.action) != normalizedHref)
+					continue;
+				if (span.actionType == WorldRuntime::ActionPrompt)
+					return MxpHyperlinkDispatchPolicy::PromptInput;
+				if (span.actionType == WorldRuntime::ActionSend && (line.flags & WorldRuntime::LineNote) != 0)
+					return MxpHyperlinkDispatchPolicy::CommandProcessing;
+				break;
+			}
+		}
+
+		return MxpHyperlinkDispatchPolicy::DirectSend;
+	}
 } // namespace
 
 QString decodeMxpActionText(QString text)
@@ -153,20 +174,12 @@ bool parsePluginHyperlinkCall(const QString &action, PluginHyperlinkCall &parsed
 MxpHyperlinkDispatchPolicy resolveMxpHyperlinkDispatchPolicy(const QVector<WorldRuntime::LineEntry> &lines,
                                                              const QString &normalizedHref)
 {
-	for (qsizetype i = lines.size(); i > 0; --i)
-	{
-		const WorldRuntime::LineEntry &line = lines.at(i - 1);
-		for (const WorldRuntime::StyleSpan &span : line.spans)
-		{
-			if (decodeMxpActionText(span.action) != normalizedHref)
-				continue;
-			if (span.actionType == WorldRuntime::ActionPrompt)
-				return MxpHyperlinkDispatchPolicy::PromptInput;
-			if (span.actionType == WorldRuntime::ActionSend && (line.flags & WorldRuntime::LineNote) != 0)
-				return MxpHyperlinkDispatchPolicy::CommandProcessing;
-			break;
-		}
-	}
+	return resolveMxpHyperlinkDispatchPolicyForLines(lines, normalizedHref);
+}
 
-	return MxpHyperlinkDispatchPolicy::DirectSend;
+MxpHyperlinkDispatchPolicy
+resolveMxpHyperlinkDispatchPolicy(const IndexedRingBuffer<WorldRuntime::LineEntry> &lines,
+                                  const QString                                    &normalizedHref)
+{
+	return resolveMxpHyperlinkDispatchPolicyForLines(lines, normalizedHref);
 }

--- a/src/helpers/HyperlinkActionUtils.h
+++ b/src/helpers/HyperlinkActionUtils.h
@@ -72,5 +72,14 @@ enum class MxpHyperlinkDispatchPolicy
 [[nodiscard]] MxpHyperlinkDispatchPolicy
 resolveMxpHyperlinkDispatchPolicy(const QVector<WorldRuntime::LineEntry> &lines,
                                   const QString                          &normalizedHref);
+/**
+ * @brief Chooses hyperlink dispatch policy using indexed rendered line/span context.
+ * @param lines Runtime line buffer.
+ * @param normalizedHref Decoded/trimmed activated href/action.
+ * @return Selected dispatch policy.
+ */
+[[nodiscard]] MxpHyperlinkDispatchPolicy
+resolveMxpHyperlinkDispatchPolicy(const IndexedRingBuffer<WorldRuntime::LineEntry> &lines,
+                                  const QString                                    &normalizedHref);
 
 #endif // QMUD_HYPERLINKACTIONUTILS_H

--- a/src/helpers/IndexedRingBuffer.h
+++ b/src/helpers/IndexedRingBuffer.h
@@ -1,0 +1,524 @@
+#pragma once
+
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QVector>
+#include <QtGlobal>
+
+#include <iterator>
+#include <utility>
+
+/**
+ * @brief Indexed ring buffer with stable logical indexing and cheap head removal.
+ *
+ * The container presents a zero-based logical sequence while storing elements in a
+ * circular backing array. It is intended for bounded output-history data where
+ * `push_back()` plus `remove(0, n)` is common and must not move every retained
+ * element. Iterators walk logical order and never expose physical storage order.
+ *
+ * @tparam T Stored value type. The type must be default-constructible because
+ * released slots are reset to `T{}` so Qt implicitly-shared resources are freed.
+ */
+template <typename T> class IndexedRingBuffer
+{
+	public:
+		using value_type = T;
+		using size_type  = qsizetype;
+
+		template <typename Buffer, typename Reference, typename Pointer> class BasicIterator
+		{
+			public:
+				using difference_type   = qsizetype;
+				using value_type        = T;
+				using reference         = Reference;
+				using pointer           = Pointer;
+				using iterator_concept  = std::random_access_iterator_tag;
+				using iterator_category = std::random_access_iterator_tag;
+
+				BasicIterator() = default;
+				BasicIterator(Buffer *buffer, const size_type index) : m_buffer(buffer), m_index(index)
+				{
+				}
+
+				reference operator*() const
+				{
+					return (*m_buffer)[m_index];
+				}
+				pointer operator->() const
+				{
+					return &(*m_buffer)[m_index];
+				}
+
+				BasicIterator &operator++()
+				{
+					++m_index;
+					return *this;
+				}
+				BasicIterator operator++(int)
+				{
+					BasicIterator copy(*this);
+					++(*this);
+					return copy;
+				}
+				BasicIterator &operator--()
+				{
+					--m_index;
+					return *this;
+				}
+				BasicIterator operator--(int)
+				{
+					BasicIterator copy(*this);
+					--(*this);
+					return copy;
+				}
+				BasicIterator &operator+=(const difference_type offset)
+				{
+					m_index += offset;
+					return *this;
+				}
+				BasicIterator &operator-=(const difference_type offset)
+				{
+					m_index -= offset;
+					return *this;
+				}
+				BasicIterator operator+(const difference_type offset) const
+				{
+					BasicIterator copy(*this);
+					copy += offset;
+					return copy;
+				}
+				friend BasicIterator operator+(const difference_type offset, const BasicIterator &iterator)
+				{
+					return iterator + offset;
+				}
+				BasicIterator operator-(const difference_type offset) const
+				{
+					BasicIterator copy(*this);
+					copy -= offset;
+					return copy;
+				}
+				difference_type operator-(const BasicIterator &other) const
+				{
+					return m_index - other.m_index;
+				}
+				reference operator[](const difference_type offset) const
+				{
+					return *(*this + offset);
+				}
+
+				bool operator==(const BasicIterator &other) const
+				{
+					return m_buffer == other.m_buffer && m_index == other.m_index;
+				}
+				bool operator!=(const BasicIterator &other) const
+				{
+					return !(*this == other);
+				}
+				bool operator<(const BasicIterator &other) const
+				{
+					return m_index < other.m_index;
+				}
+				bool operator>(const BasicIterator &other) const
+				{
+					return other < *this;
+				}
+				bool operator<=(const BasicIterator &other) const
+				{
+					return !(other < *this);
+				}
+				bool operator>=(const BasicIterator &other) const
+				{
+					return !(*this < other);
+				}
+
+				[[nodiscard]] size_type index() const
+				{
+					return m_index;
+				}
+
+			private:
+				Buffer   *m_buffer{nullptr};
+				size_type m_index{0};
+		};
+
+		using iterator       = BasicIterator<IndexedRingBuffer<T>, T &, T *>;
+		using const_iterator = BasicIterator<const IndexedRingBuffer<T>, const T &, const T *>;
+
+		IndexedRingBuffer() = default;
+		explicit IndexedRingBuffer(const size_type count)
+		{
+			resize(count);
+		}
+		IndexedRingBuffer(const size_type count, const T &value)
+		{
+			assign(count, value);
+		}
+		explicit IndexedRingBuffer(const QVector<T> &values)
+		{
+			assign(values);
+		}
+
+		IndexedRingBuffer &operator=(const QVector<T> &values)
+		{
+			assign(values);
+			return *this;
+		}
+
+		[[nodiscard]] size_type size() const
+		{
+			return m_size;
+		}
+		[[nodiscard]] bool isEmpty() const
+		{
+			return m_size == 0;
+		}
+		[[nodiscard]] size_type capacity() const
+		{
+			return m_storage.size();
+		}
+
+		void clear()
+		{
+			m_storage.clear();
+			m_head = 0;
+			m_size = 0;
+		}
+
+		void swap(IndexedRingBuffer &other) noexcept
+		{
+			m_storage.swap(other.m_storage);
+			std::swap(m_head, other.m_head);
+			std::swap(m_size, other.m_size);
+		}
+
+		void reserve(const size_type requestedCapacity)
+		{
+			if (requestedCapacity <= capacity())
+				return;
+			reallocate(qMax<size_type>(requestedCapacity, capacity() == 0 ? 8 : capacity() * 2));
+		}
+
+		void resize(const size_type newSize)
+		{
+			Q_ASSERT(newSize >= 0);
+			if (newSize < m_size)
+			{
+				remove(newSize, m_size - newSize);
+				return;
+			}
+			reserve(newSize);
+			for (size_type index = m_size; index < newSize; ++index)
+				storageAtLogical(index) = T{};
+			m_size = newSize;
+		}
+
+		void assign(const size_type count, const T &value)
+		{
+			clear();
+			reserve(count);
+			for (size_type index = 0; index < count; ++index)
+				storageAtLogical(index) = value;
+			m_size = count;
+		}
+
+		void assign(const QVector<T> &values)
+		{
+			clear();
+			reserve(values.size());
+			for (const T &value : values)
+				push_back(value);
+		}
+
+		[[nodiscard]] T &operator[](const size_type index)
+		{
+			Q_ASSERT(index >= 0 && index < m_size);
+			return storageAtLogical(index);
+		}
+		[[nodiscard]] const T &operator[](const size_type index) const
+		{
+			Q_ASSERT(index >= 0 && index < m_size);
+			return storageAtLogical(index);
+		}
+		[[nodiscard]] T &at(const size_type index)
+		{
+			return (*this)[index];
+		}
+		[[nodiscard]] const T &at(const size_type index) const
+		{
+			return (*this)[index];
+		}
+
+		[[nodiscard]] T &first()
+		{
+			return (*this)[0];
+		}
+		[[nodiscard]] const T &first() const
+		{
+			return (*this)[0];
+		}
+		[[nodiscard]] const T &constFirst() const
+		{
+			return (*this)[0];
+		}
+		[[nodiscard]] T &last()
+		{
+			return (*this)[m_size - 1];
+		}
+		[[nodiscard]] const T &last() const
+		{
+			return (*this)[m_size - 1];
+		}
+		[[nodiscard]] const T &constLast() const
+		{
+			return (*this)[m_size - 1];
+		}
+
+		void push_back(const T &value)
+		{
+			reserve(m_size + 1);
+			storageAtLogical(m_size) = value;
+			++m_size;
+		}
+		void push_back(T &&value)
+		{
+			reserve(m_size + 1);
+			storageAtLogical(m_size) = std::move(value);
+			++m_size;
+		}
+		void append(const T &value)
+		{
+			push_back(value);
+		}
+		void append(T &&value)
+		{
+			push_back(std::move(value));
+		}
+
+		template <typename... Args> T &emplaceBack(Args &&...args)
+		{
+			reserve(m_size + 1);
+			T &slot = storageAtLogical(m_size);
+			slot    = T(std::forward<Args>(args)...);
+			++m_size;
+			return slot;
+		}
+
+		void pop_back()
+		{
+			Q_ASSERT(m_size > 0);
+			storageAtLogical(m_size - 1) = T{};
+			--m_size;
+			if (m_size == 0)
+				m_head = 0;
+		}
+		void removeLast()
+		{
+			pop_back();
+		}
+
+		void pop_front()
+		{
+			remove(0, 1);
+		}
+		void removeFirst()
+		{
+			pop_front();
+		}
+
+		void removeAt(const size_type index)
+		{
+			remove(index, 1);
+		}
+
+		void remove(const size_type index, const size_type count = 1)
+		{
+			if (count <= 0)
+				return;
+			Q_ASSERT(index >= 0 && index <= m_size);
+			const size_type boundedCount = qMin(count, m_size - index);
+			if (boundedCount <= 0)
+				return;
+			if (index == 0)
+			{
+				for (size_type i = 0; i < boundedCount; ++i)
+					storageAtPhysical((m_head + i) % capacity()) = T{};
+				m_head = (m_head + boundedCount) % capacity();
+				m_size -= boundedCount;
+				if (m_size == 0)
+					m_head = 0;
+				return;
+			}
+			if (index + boundedCount == m_size)
+			{
+				for (size_type i = index; i < m_size; ++i)
+					storageAtLogical(i) = T{};
+				m_size = index;
+				return;
+			}
+
+			const size_type prefixCount = index;
+			const size_type suffixCount = m_size - index - boundedCount;
+			if (prefixCount < suffixCount)
+			{
+				for (size_type source = index; source > 0; --source)
+					storageAtLogical(source + boundedCount - 1) = std::move(storageAtLogical(source - 1));
+				for (size_type i = 0; i < boundedCount; ++i)
+					storageAtPhysical((m_head + i) % capacity()) = T{};
+				m_head = (m_head + boundedCount) % capacity();
+			}
+			else
+			{
+				for (size_type source = index + boundedCount; source < m_size; ++source)
+					storageAtLogical(source - boundedCount) = std::move(storageAtLogical(source));
+				for (size_type i = m_size - boundedCount; i < m_size; ++i)
+					storageAtLogical(i) = T{};
+			}
+			m_size -= boundedCount;
+		}
+
+		void insert(const size_type index, const T &value)
+		{
+			insertImpl(index, value);
+		}
+		void insert(const size_type index, T &&value)
+		{
+			insertImpl(index, std::move(value));
+		}
+		iterator insert(const_iterator position, const T &value)
+		{
+			insert(position.index(), value);
+			return iterator(this, position.index());
+		}
+		iterator insert(const_iterator position, T &&value)
+		{
+			insert(position.index(), std::move(value));
+			return iterator(this, position.index());
+		}
+		iterator insert(iterator position, const T &value)
+		{
+			insert(position.index(), value);
+			return iterator(this, position.index());
+		}
+		iterator insert(iterator position, T &&value)
+		{
+			insert(position.index(), std::move(value));
+			return iterator(this, position.index());
+		}
+
+		iterator erase(const_iterator first, const_iterator last)
+		{
+			const size_type index = first.index();
+			remove(index, last.index() - first.index());
+			return iterator(this, index);
+		}
+		iterator erase(const_iterator position)
+		{
+			return erase(position, position + 1);
+		}
+		iterator erase(iterator first, iterator last)
+		{
+			const size_type index = first.index();
+			remove(index, last.index() - first.index());
+			return iterator(this, index);
+		}
+		iterator erase(iterator position)
+		{
+			return erase(position, position + 1);
+		}
+
+		[[nodiscard]] QVector<T> toVector() const
+		{
+			QVector<T> result;
+			result.reserve(m_size);
+			for (size_type index = 0; index < m_size; ++index)
+				result.push_back(at(index));
+			return result;
+		}
+
+		[[nodiscard]] iterator begin()
+		{
+			return iterator(this, 0);
+		}
+		[[nodiscard]] iterator end()
+		{
+			return iterator(this, m_size);
+		}
+		[[nodiscard]] const_iterator begin() const
+		{
+			return const_iterator(this, 0);
+		}
+		[[nodiscard]] const_iterator end() const
+		{
+			return const_iterator(this, m_size);
+		}
+		[[nodiscard]] const_iterator cbegin() const
+		{
+			return const_iterator(this, 0);
+		}
+		[[nodiscard]] const_iterator cend() const
+		{
+			return const_iterator(this, m_size);
+		}
+
+	private:
+		template <typename Value> void insertImpl(const size_type index, Value &&value)
+		{
+			Q_ASSERT(index >= 0 && index <= m_size);
+			if (index == m_size)
+			{
+				push_back(std::forward<Value>(value));
+				return;
+			}
+
+			reserve(m_size + 1);
+			if (index < m_size - index)
+			{
+				const size_type oldHead = m_head;
+				const size_type newHead = (m_head + capacity() - 1) % capacity();
+				for (size_type source = 0; source < index; ++source)
+				{
+					const size_type destinationPhysical    = (newHead + source) % capacity();
+					const size_type sourcePhysical         = (oldHead + source) % capacity();
+					storageAtPhysical(destinationPhysical) = std::move(storageAtPhysical(sourcePhysical));
+				}
+				m_head = newHead;
+			}
+			else
+			{
+				for (size_type target = m_size; target > index; --target)
+					storageAtLogical(target) = std::move(storageAtLogical(target - 1));
+			}
+			storageAtLogical(index) = std::forward<Value>(value);
+			++m_size;
+		}
+
+		void reallocate(const size_type newCapacity)
+		{
+			QVector<T> compact(newCapacity);
+			for (size_type index = 0; index < m_size; ++index)
+				compact[index] = std::move(storageAtLogical(index));
+			m_storage = std::move(compact);
+			m_head    = 0;
+		}
+
+		[[nodiscard]] size_type physicalIndex(const size_type logicalIndex) const
+		{
+			Q_ASSERT(!m_storage.isEmpty());
+			return (m_head + logicalIndex) % m_storage.size();
+		}
+		[[nodiscard]] T &storageAtLogical(const size_type logicalIndex)
+		{
+			return m_storage[physicalIndex(logicalIndex)];
+		}
+		[[nodiscard]] const T &storageAtLogical(const size_type logicalIndex) const
+		{
+			return m_storage[physicalIndex(logicalIndex)];
+		}
+		[[nodiscard]] T &storageAtPhysical(const size_type physicalIndex)
+		{
+			return m_storage[physicalIndex];
+		}
+
+		QVector<T> m_storage;
+		size_type  m_head{0};
+		size_type  m_size{0};
+};

--- a/src/helpers/IndexedRingBuffer.h
+++ b/src/helpers/IndexedRingBuffer.h
@@ -5,6 +5,7 @@
 #include <QtGlobal>
 
 #include <iterator>
+#include <type_traits>
 #include <utility>
 
 /**
@@ -211,6 +212,15 @@ template <typename T> class IndexedRingBuffer
 			m_size = newSize;
 		}
 
+		void truncateBack(const size_type newSize)
+		    requires std::is_trivially_destructible_v<T>
+		{
+			Q_ASSERT(newSize >= 0 && newSize <= m_size);
+			m_size = newSize;
+			if (m_size == 0)
+				m_head = 0;
+		}
+
 		void assign(const size_type count, const T &value)
 		{
 			clear();
@@ -373,6 +383,98 @@ template <typename T> class IndexedRingBuffer
 					storageAtLogical(i) = T{};
 			}
 			m_size -= boundedCount;
+		}
+
+		/**
+		 * @brief Replaces a logical range with repeated values in one structural mutation.
+		 * @param index First logical index to replace.
+		 * @param removeCount Number of existing elements to remove from `index`.
+		 * @param insertCount Number of replacement elements to insert at `index`.
+		 * @param value Value copied into each inserted slot.
+		 *
+		 * This shifts either the retained prefix or retained suffix once, whichever is
+		 * smaller, so middle range replacement does not degrade into repeated
+		 * single-element insert/remove operations.
+		 */
+		void replace(const size_type index, const size_type removeCount, const size_type insertCount,
+		             const T &value)
+		{
+			Q_ASSERT(index >= 0 && index <= m_size);
+			Q_ASSERT(removeCount >= 0);
+			Q_ASSERT(insertCount >= 0);
+
+			const size_type boundedRemoveCount = qBound<size_type>(0, removeCount, m_size - index);
+			const size_type boundedInsertCount = qMax<size_type>(0, insertCount);
+			if (boundedRemoveCount == 0 && boundedInsertCount == 0)
+				return;
+
+			const size_type oldSize     = m_size;
+			const size_type suffixFirst = index + boundedRemoveCount;
+			const size_type suffixCount = oldSize - suffixFirst;
+			const size_type newSize     = oldSize - boundedRemoveCount + boundedInsertCount;
+			reserve(newSize);
+
+			if (boundedInsertCount > boundedRemoveCount)
+			{
+				const size_type growth = boundedInsertCount - boundedRemoveCount;
+				if (index < suffixCount)
+				{
+					const size_type oldHead = m_head;
+					const size_type newHead = (m_head + capacity() - growth % capacity()) % capacity();
+					for (size_type source = 0; source < index; ++source)
+					{
+						const size_type sourcePhysical         = (oldHead + source) % capacity();
+						const size_type destinationPhysical    = (newHead + source) % capacity();
+						storageAtPhysical(destinationPhysical) = std::move(storageAtPhysical(sourcePhysical));
+					}
+					m_head = newHead;
+				}
+				else
+				{
+					for (size_type offset = suffixCount; offset > 0; --offset)
+					{
+						const size_type source            = suffixFirst + offset - 1;
+						storageAtLogical(source + growth) = std::move(storageAtLogical(source));
+					}
+				}
+			}
+			else if (boundedRemoveCount > boundedInsertCount)
+			{
+				const size_type shrink = boundedRemoveCount - boundedInsertCount;
+				if (index < suffixCount)
+				{
+					const size_type oldHead = m_head;
+					for (size_type source = index; source > 0; --source)
+					{
+						const size_type sourceLogical       = source - 1;
+						const size_type sourcePhysical      = (oldHead + sourceLogical) % capacity();
+						const size_type destinationPhysical = (oldHead + sourceLogical + shrink) % capacity();
+						storageAtPhysical(destinationPhysical) = std::move(storageAtPhysical(sourcePhysical));
+					}
+					for (size_type i = 0; i < shrink; ++i)
+						storageAtPhysical((oldHead + i) % capacity()) = T{};
+					m_head = (oldHead + shrink) % capacity();
+				}
+				else
+				{
+					for (size_type offset = 0; offset < suffixCount; ++offset)
+					{
+						const size_type source            = suffixFirst + offset;
+						storageAtLogical(source - shrink) = std::move(storageAtLogical(source));
+					}
+					for (size_type i = newSize; i < oldSize; ++i)
+						storageAtLogical(i) = T{};
+				}
+			}
+
+			m_size = newSize;
+			if (m_size == 0)
+			{
+				m_head = 0;
+				return;
+			}
+			for (size_type i = 0; i < boundedInsertCount; ++i)
+				storageAtLogical(index + i) = value;
 		}
 
 		void insert(const size_type index, const T &value)

--- a/src/helpers/MushclientImportUtils.cpp
+++ b/src/helpers/MushclientImportUtils.cpp
@@ -1,0 +1,1935 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: MushclientImportUtils.cpp
+ * Role: Shared MUSHclient import and legacy path/config migration helper implementations.
+ */
+
+#include "MushclientImportUtils.h"
+
+#include "FileExtensions.h"
+#include "NativePluginRegistry.h"
+#include "PluginPathUtils.h"
+#include "WorldDocument.h"
+
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QHash>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QSet>
+#include <QSettings>
+#include <QStringConverter>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QStringDecoder>
+#include <QVariant>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+#include <QtGlobal>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlError>
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlRecord>
+
+namespace
+{
+	QString relativePathUnderBase(const QString &baseDir, const QString &absolutePath);
+
+	QString normalizePathString(const QString &input)
+	{
+		QString output = input;
+		output.replace(QLatin1Char('\\'), QLatin1Char('/'));
+		return output;
+	}
+
+	QString stripOptionalQuotes(const QString &value)
+	{
+		if (value.size() < 2)
+			return value;
+		if (const QChar first = value.front(), last = value.back();
+		    (first == QLatin1Char('"') && last == QLatin1Char('"')) ||
+		    (first == QLatin1Char('\'') && last == QLatin1Char('\'')))
+			return value.mid(1, value.size() - 2);
+		return value;
+	}
+
+	QString absolutePathFromBase(const QString &baseDir, const QString &path)
+	{
+		auto looksLikeWindowsDrivePath = [](const QString &value, const int offset = 0) -> bool
+		{
+			return value.size() > offset + 1 && value.at(offset).isLetter() &&
+			       value.at(offset + 1) == QLatin1Char(':');
+		};
+
+		QString normalized = normalizePathString(path.trimmed());
+		while (normalized.startsWith(QStringLiteral("./")))
+			normalized = normalized.mid(2);
+		if (normalized.startsWith(QLatin1Char('/')) && looksLikeWindowsDrivePath(normalized, 1))
+			normalized = normalized.mid(1);
+		if (QFileInfo(normalized).isAbsolute() || looksLikeWindowsDrivePath(normalized))
+			return QDir::cleanPath(normalized);
+		return QDir::cleanPath(QDir(baseDir).filePath(normalized));
+	}
+
+	bool hasWindowsDrivePath(const QString &path)
+	{
+		return path.size() > 1 && path.at(0).isLetter() && path.at(1) == QLatin1Char(':');
+	}
+
+	bool hasPathSyntax(const QString &path)
+	{
+		const QString normalized = normalizePathString(path).trimmed();
+		return QFileInfo(normalized).isAbsolute() || hasWindowsDrivePath(normalized) ||
+		       normalized.contains(QLatin1Char('/')) || normalized.startsWith(QLatin1Char('.'));
+	}
+
+	QString resolveExistingPathCaseInsensitive(const QString &path)
+	{
+		QString cleaned = QDir::cleanPath(path);
+		if (cleaned.isEmpty())
+			return {};
+		if (QFileInfo::exists(cleaned))
+			return cleaned;
+#ifdef Q_OS_WIN
+		return {};
+#else
+		if (!QDir::isAbsolutePath(cleaned))
+			return {};
+		QStringList segments = cleaned.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+		QString     current  = QStringLiteral("/");
+		for (const QString &segment : segments)
+		{
+			const QDir      dir(current);
+			const QFileInfo matched = [&]() -> QFileInfo
+			{
+				const QFileInfoList entries =
+				    dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System);
+				for (const QFileInfo &entry : entries)
+				{
+					if (entry.fileName().compare(segment, Qt::CaseInsensitive) == 0)
+						return entry;
+				}
+				return {};
+			}();
+			if (!matched.exists())
+				return {};
+			current = matched.absoluteFilePath();
+		}
+		return QDir::cleanPath(current);
+#endif
+	}
+
+	QString dotRelativeStoragePath(const QString &qmudHome, const QString &value)
+	{
+		QString normalized = QMudFileExtensions::canonicalizePathExtension(normalizePathString(value));
+		if (normalized.trimmed().isEmpty())
+			return {};
+		QString relative = QMudPluginPathUtils::qmudHomeRelativePath(qmudHome, normalized, false);
+		if (relative.isEmpty())
+			return {};
+		if (relative == QLatin1String("."))
+			relative = QStringLiteral("./");
+		if (!relative.startsWith(QStringLiteral("./")) && !relative.startsWith(QStringLiteral("../")))
+			relative.prepend(QStringLiteral("./"));
+		return relative;
+	}
+
+	QString storagePathFromAbsolute(const QString &baseDir, const QString &absolutePath)
+	{
+		return dotRelativeStoragePath(baseDir, absolutePath);
+	}
+
+	QString containedLegacyStoragePath(const QString &destinationBaseDir, const QString &path)
+	{
+		QString normalized = stripOptionalQuotes(normalizePathString(path).trimmed());
+		if (normalized.isEmpty())
+			return normalized;
+
+		if (QFileInfo(normalized).isAbsolute() || hasWindowsDrivePath(normalized))
+		{
+			const QString fileName = QFileInfo(normalized).fileName();
+			if (fileName.isEmpty())
+				return QStringLiteral("./");
+			return dotRelativeStoragePath(destinationBaseDir, QDir(destinationBaseDir).filePath(fileName));
+		}
+
+		const QString portableRelative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(normalized);
+		if (portableRelative.isEmpty() || portableRelative.startsWith(QStringLiteral("../")) ||
+		    QDir::isAbsolutePath(portableRelative))
+		{
+			const QString fileName = QFileInfo(normalized).fileName();
+			if (fileName.isEmpty())
+				return QStringLiteral("./");
+			return dotRelativeStoragePath(destinationBaseDir, QDir(destinationBaseDir).filePath(fileName));
+		}
+
+		return dotRelativeStoragePath(destinationBaseDir,
+		                              QDir(destinationBaseDir).filePath(portableRelative));
+	}
+
+	QString containedPluginStoragePath(const QString &destinationBaseDir, const QString &path)
+	{
+		QString normalized = stripOptionalQuotes(normalizePathString(path).trimmed());
+		if (normalized.isEmpty())
+			return normalized;
+
+		const QString portableRelative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(normalized);
+		if (portableRelative.startsWith(QStringLiteral("worlds/plugins/"), Qt::CaseInsensitive) ||
+		    portableRelative.startsWith(QStringLiteral("plugins/"), Qt::CaseInsensitive))
+		{
+			const QString relative =
+			    portableRelative.startsWith(QStringLiteral("plugins/"), Qt::CaseInsensitive)
+			        ? QStringLiteral("worlds/") + portableRelative
+			        : portableRelative;
+			return dotRelativeStoragePath(destinationBaseDir, QDir(destinationBaseDir).filePath(relative));
+		}
+
+		const QString fileName = QFileInfo(normalized).fileName();
+		if (fileName.isEmpty())
+			return containedLegacyStoragePath(destinationBaseDir, normalized);
+		return dotRelativeStoragePath(
+		    destinationBaseDir,
+		    QDir(destinationBaseDir).filePath(QStringLiteral("worlds/plugins/") + fileName));
+	}
+
+	QString containedWorldStoragePath(const QString &destinationBaseDir, const QString &canonicalPath)
+	{
+		QString normalized = stripOptionalQuotes(normalizePathString(canonicalPath).trimmed());
+		if (normalized.isEmpty())
+			return normalized;
+
+		QString normalizedRelative = normalized;
+		while (normalizedRelative.startsWith(QStringLiteral("./")))
+			normalizedRelative = normalizedRelative.mid(2);
+		if (!QFileInfo(normalizedRelative).isAbsolute() && !hasWindowsDrivePath(normalizedRelative) &&
+		    normalizedRelative.startsWith(QStringLiteral("worlds/"), Qt::CaseInsensitive))
+		{
+			return dotRelativeStoragePath(destinationBaseDir,
+			                              QDir(destinationBaseDir).filePath(normalizedRelative));
+		}
+
+		const QString fileName = QFileInfo(normalized).fileName();
+		if (fileName.isEmpty())
+			return QStringLiteral("./worlds/");
+		return dotRelativeStoragePath(
+		    destinationBaseDir, QDir(destinationBaseDir).filePath(QStringLiteral("worlds/") + fileName));
+	}
+
+	QString containedWorldAbsolutePath(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                   const QString &canonicalPath, const QString &resolvedLegacyPath)
+	{
+		if (!resolvedLegacyPath.isEmpty())
+		{
+			const QString relativeWorld = relativePathUnderBase(
+			    QDir(sourceBaseDir).filePath(QStringLiteral("worlds")), resolvedLegacyPath);
+			if (!relativeWorld.isEmpty())
+			{
+				return QDir(destinationBaseDir)
+				    .filePath(QStringLiteral("worlds/") +
+				              QMudFileExtensions::canonicalizePathExtension(relativeWorld));
+			}
+		}
+
+		const QString storagePath = containedWorldStoragePath(destinationBaseDir, canonicalPath);
+		return absolutePathFromBase(destinationBaseDir, storagePath);
+	}
+
+	QString remapLegacyWindowsWorldPathToBase(const QString &baseDir, const QString &path)
+	{
+		const QString normalized = normalizePathString(path.trimmed());
+		const bool    hasDrive =
+		    normalized.size() > 1 && normalized.at(0).isLetter() && normalized.at(1) == QLatin1Char(':');
+		if (!hasDrive)
+			return {};
+		const qsizetype worldsPos = normalized.indexOf(QStringLiteral("/worlds/"), 0, Qt::CaseInsensitive);
+		if (worldsPos < 0)
+			return {};
+		const QString relativeWorldPath = normalized.mid(worldsPos + 1);
+		return absolutePathFromBase(baseDir, relativeWorldPath);
+	}
+
+	QString archiveRelativePathFor(const QString &baseDir, const QString &absolutePath)
+	{
+		QString relative = QDir(baseDir).relativeFilePath(absolutePath);
+		if (relative == QStringLiteral("..") || relative.startsWith(QStringLiteral("../")) ||
+		    QDir::isAbsolutePath(relative))
+		{
+			relative = QDir::cleanPath(absolutePath);
+#ifdef Q_OS_WIN
+			if (relative.size() > 1 && relative.at(1) == QLatin1Char(':'))
+				relative.replace(1, 1, QStringLiteral("_"));
+#endif
+			while (relative.startsWith(QLatin1Char('/')))
+				relative.remove(0, 1);
+		}
+		return normalizePathString(relative);
+	}
+
+	bool moveFileToArchive(const QString &sourcePath, const QString &targetPath)
+	{
+		const QFileInfo targetInfo(targetPath);
+		if (const QString targetDir = targetInfo.absolutePath(); !QDir().mkpath(targetDir))
+			return false;
+		if (QFileInfo::exists(targetPath) && !QFile::remove(targetPath))
+			return false;
+		if (QFile::rename(sourcePath, targetPath))
+			return true;
+		if (!QFile::copy(sourcePath, targetPath))
+			return false;
+		return QFile::remove(sourcePath);
+	}
+
+	QStringList splitSerializedPathList(const QString &valueList)
+	{
+		if (valueList.trimmed().isEmpty())
+			return {};
+		QString normalized = valueList;
+		normalized.replace(QLatin1Char('\r'), QLatin1Char('\n'));
+		normalized.replace(QLatin1Char('*'), QLatin1Char('\n'));
+
+		QStringList items;
+		for (QString entry : normalized.split(QLatin1Char('\n'), Qt::KeepEmptyParts))
+		{
+			entry = stripOptionalQuotes(entry.trimmed());
+			if (!entry.isEmpty())
+				items.push_back(entry);
+		}
+		return items;
+	}
+
+	QStringList splitSerializedWorldList(const QString &worldList)
+	{
+		return splitSerializedPathList(worldList);
+	}
+
+	QString keyLeafName(const QString &key)
+	{
+		const qsizetype slash = key.lastIndexOf(QLatin1Char('/'));
+		if (slash < 0)
+			return key;
+		return key.mid(slash + 1);
+	}
+
+	bool isPathListKey(const QString &key)
+	{
+		const QString leaf = keyLeafName(key);
+		return leaf.compare(QStringLiteral("WorldList"), Qt::CaseInsensitive) == 0 ||
+		       leaf.compare(QStringLiteral("PluginList"), Qt::CaseInsensitive) == 0;
+	}
+
+	bool shouldNormalizePathKey(const QString &key)
+	{
+		const QString leaf      = keyLeafName(key);
+		const QString lowerLeaf = leaf.toLower();
+		return leaf.contains(QStringLiteral("Directory")) || leaf.contains(QStringLiteral("File")) ||
+		       leaf.contains(QStringLiteral("Path")) || lowerLeaf.contains(QStringLiteral("directory")) ||
+		       lowerLeaf.contains(QStringLiteral("path")) || lowerLeaf == QStringLiteral("file") ||
+		       lowerLeaf.contains(QStringLiteral("_file")) || lowerLeaf.contains(QStringLiteral("file_")) ||
+		       lowerLeaf.contains(QStringLiteral("filename"));
+	}
+
+	using PathTransformFn = QString (*)(const QString &);
+
+	QString transformPathList(const QString &input, const PathTransformFn transform)
+	{
+		if (input.isEmpty())
+			return input;
+		const QStringList items = input.split(QLatin1Char('*'), Qt::KeepEmptyParts);
+		QStringList       transformed;
+		transformed.reserve(items.size());
+		for (const QString &item : items)
+			transformed.push_back(transform(item));
+		return transformed.join(QLatin1Char('*'));
+	}
+
+	QString normalizePathList(const QString &input)
+	{
+		return transformPathList(input, normalizePathString);
+	}
+
+	QString quotedSqlIdentifier(const QString &identifier)
+	{
+		QString quoted = identifier;
+		quoted.replace(QLatin1Char('"'), QStringLiteral("\"\""));
+		return QLatin1Char('"') + quoted + QLatin1Char('"');
+	}
+
+	QString questionPlaceholders(const int count)
+	{
+		QStringList placeholders;
+		placeholders.reserve(count);
+		for (int i = 0; i < count; ++i)
+			placeholders.push_back(QStringLiteral("?"));
+		return placeholders.join(QLatin1Char(','));
+	}
+
+	QString findTopLevelFileWithCaseFallback(const QString &rootDir, const QString &fileName)
+	{
+		QString exactPath = QDir(rootDir).filePath(fileName);
+		if (QFileInfo::exists(exactPath))
+			return exactPath;
+
+		const QFileInfoList entries =
+		    QDir(rootDir).entryInfoList(QDir::Files | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot);
+		for (const QFileInfo &entry : entries)
+		{
+			if (entry.fileName().compare(fileName, Qt::CaseInsensitive) == 0)
+				return entry.absoluteFilePath();
+		}
+		return {};
+	}
+
+	QString decodeBytesWithEncoding(const QByteArray &input, const QStringConverter::Encoding encoding,
+	                                bool &success)
+	{
+		QStringDecoder decoder(encoding);
+		QString        decoded = decoder.decode(input);
+		success                = !decoder.hasError();
+		return decoded;
+	}
+
+	QString decodeLegacyIniText(const QByteArray &input)
+	{
+		if (const auto detectedEncoding = QStringConverter::encodingForData(input);
+		    detectedEncoding.has_value())
+		{
+			bool          success = false;
+			const QString decoded = decodeBytesWithEncoding(input, *detectedEncoding, success);
+			if (success)
+				return decoded;
+		}
+
+		bool    utf8Success = false;
+		QString utf8        = decodeBytesWithEncoding(input, QStringConverter::Utf8, utf8Success);
+		if (utf8Success)
+			return utf8;
+
+		QStringDecoder windowsDecoder(QStringLiteral("windows-1252"));
+		if (windowsDecoder.isValid())
+		{
+			QString decoded = windowsDecoder.decode(input);
+			if (!windowsDecoder.hasError())
+				return decoded;
+		}
+
+		return QString::fromLatin1(input);
+	}
+
+	QHash<QString, QString> parseLegacyIniRawValues(const QString &iniPath)
+	{
+		QHash<QString, QString> values;
+		QFile                   file(iniPath);
+		if (!file.open(QIODevice::ReadOnly))
+			return values;
+
+		QString           currentSection;
+		const QString     content = decodeLegacyIniText(file.readAll());
+		const QStringList lines =
+		    content.split(QRegularExpression(QStringLiteral("[\r\n]+")), Qt::KeepEmptyParts);
+		for (QString line : lines)
+		{
+			line = line.trimmed();
+			if (line.isEmpty())
+				continue;
+			if (line.startsWith(QLatin1Char(';')) || line.startsWith(QLatin1Char('#')))
+				continue;
+			if (line.startsWith(QLatin1Char('[')) && line.endsWith(QLatin1Char(']')) && line.size() >= 2)
+			{
+				currentSection = line.mid(1, line.size() - 2).trimmed();
+				continue;
+			}
+
+			const qsizetype equalsPos = line.indexOf(QLatin1Char('='));
+			if (equalsPos < 0)
+				continue;
+			const QString key   = line.left(equalsPos).trimmed();
+			const QString value = line.mid(equalsPos + 1);
+			if (key.isEmpty())
+				continue;
+			const QString fullKey = currentSection.isEmpty() ? key : currentSection + QLatin1Char('/') + key;
+			values.insert(fullKey, value);
+		}
+		return values;
+	}
+
+	QString migrateLegacyIniPathValueDetailed(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                          const QString &key, const QString &value,
+	                                          bool archiveLegacySource, QStringList *warnings,
+	                                          int *convertedWorlds);
+
+	QVariant migrateLegacyIniValueWithRawSource(const QString &sourceBaseDir,
+	                                            const QString &destinationBaseDir, const QString &key,
+	                                            const QVariant                &value,
+	                                            const QHash<QString, QString> &rawValues,
+	                                            const bool archiveLegacySource, QStringList *warnings,
+	                                            int *convertedWorlds)
+	{
+		if (const QString leaf = keyLeafName(key);
+		    (isPathListKey(leaf) || shouldNormalizePathKey(leaf)) && rawValues.contains(key))
+		{
+			return migrateLegacyIniPathValueDetailed(sourceBaseDir, destinationBaseDir, key,
+			                                         rawValues.value(key), archiveLegacySource, warnings,
+			                                         convertedWorlds);
+		}
+		if (value.canConvert<QStringList>())
+		{
+			const QStringList list = value.toStringList();
+			QStringList       migrated;
+			migrated.reserve(list.size());
+			for (const QString &item : list)
+				migrated.push_back(migrateLegacyIniPathValueDetailed(sourceBaseDir, destinationBaseDir, key,
+				                                                     item, archiveLegacySource, warnings,
+				                                                     convertedWorlds));
+			return {migrated};
+		}
+		if (value.canConvert<QString>())
+		{
+			return migrateLegacyIniPathValueDetailed(sourceBaseDir, destinationBaseDir, key, value.toString(),
+			                                         archiveLegacySource, warnings, convertedWorlds);
+		}
+		return value;
+	}
+
+	void pruneLegacyCtrlBarsGroups(QSettings &modern)
+	{
+		for (const QStringList keys = modern.allKeys(); const QString &key : keys)
+		{
+			if (key.startsWith(QStringLiteral("CtrlBars-Bar"), Qt::CaseInsensitive) ||
+			    key.startsWith(QStringLiteral("CtrlBars-Summary"), Qt::CaseInsensitive))
+			{
+				modern.remove(key);
+			}
+		}
+	}
+
+	void recordImportError(QMudMushclientImportUtils::ImportStats &stats, const QString &message)
+	{
+		++stats.errors;
+		if (stats.errorDetails.size() < 12)
+			stats.errorDetails.push_back(message);
+		qWarning() << "MUSHclient import:" << message;
+	}
+
+	void appendMigrationWarning(QStringList *warnings, const QString &message)
+	{
+		if (message.trimmed().isEmpty())
+			return;
+		if (warnings)
+			warnings->push_back(message);
+		qWarning() << "MUSHclient migration:" << message;
+	}
+
+	void recordImportWarning(QMudMushclientImportUtils::ImportStats &stats, const QString &message)
+	{
+		++stats.warnings;
+		if (stats.warningDetails.size() < 12)
+			stats.warningDetails.push_back(message);
+		qWarning() << "MUSHclient import:" << message;
+	}
+
+	QString importDestinationError(const QString &qmudHome, const QString &destinationPath)
+	{
+		QString resolvedPath;
+		QString error;
+		if (QMudPluginPathUtils::resolveInsideQmudHome(qmudHome, destinationPath, &resolvedPath, &error))
+			return {};
+		return QStringLiteral("Destination is outside QMud home or unsafe: %1 (%2)")
+		    .arg(destinationPath, error);
+	}
+
+	bool validateImportDestination(const QString &qmudHome, const QString &destinationPath,
+	                               QMudMushclientImportUtils::ImportStats &stats)
+	{
+		const QString error = importDestinationError(qmudHome, destinationPath);
+		if (error.isEmpty())
+			return true;
+		recordImportError(stats, error);
+		return false;
+	}
+
+	bool copyFileNoOverwrite(const QString &qmudHome, const QString &sourcePath,
+	                         const QString &destinationPath, QMudMushclientImportUtils::ImportStats &stats)
+	{
+		if (!validateImportDestination(qmudHome, destinationPath, stats))
+			return false;
+
+		if (QFileInfo::exists(destinationPath))
+		{
+			++stats.filesSkippedExisting;
+			return true;
+		}
+
+		const QString destinationDir = QFileInfo(destinationPath).absolutePath();
+		if (!QDir().mkpath(destinationDir))
+		{
+			recordImportError(stats, QStringLiteral("Unable to create directory: %1").arg(destinationDir));
+			return false;
+		}
+
+		if (!QFile::copy(sourcePath, destinationPath))
+		{
+			QString error = QStringLiteral("Unable to copy %1 to %2").arg(sourcePath, destinationPath);
+			if (QFileInfo::exists(destinationPath) && !QFile::remove(destinationPath))
+				error += QStringLiteral("; unable to remove incomplete destination");
+			recordImportError(stats, error);
+			return false;
+		}
+		++stats.filesCopied;
+		return true;
+	}
+
+	QString relativePathUnderBase(const QString &baseDir, const QString &absolutePath)
+	{
+		const QString relative =
+		    QDir(QDir::cleanPath(baseDir)).relativeFilePath(QDir::cleanPath(absolutePath));
+		if (relative == QStringLiteral("..") || relative.startsWith(QStringLiteral("../")) ||
+		    QDir::isAbsolutePath(relative))
+			return {};
+		return normalizePathString(relative);
+	}
+
+	bool isUnderRelativeDirectory(const QString &relativePath, const QString &directoryName)
+	{
+		const QString normalized = normalizePathString(relativePath).trimmed();
+		return normalized.compare(directoryName, Qt::CaseInsensitive) == 0 ||
+		       normalized.startsWith(directoryName + QLatin1Char('/'), Qt::CaseInsensitive);
+	}
+
+	bool isLegacyNonLuaScriptSuffix(const QString &suffix)
+	{
+		static const QStringList legacySuffixes = {
+		    QStringLiteral("vbs"), QStringLiteral("vbe"), QStringLiteral("js"), QStringLiteral("jse"),
+		    QStringLiteral("pl"),  QStringLiteral("py"),  QStringLiteral("pys")};
+		return legacySuffixes.contains(suffix.toLower());
+	}
+
+	bool isImportableLuaPluginXml(const QString &path)
+	{
+		WorldDocument document;
+		if (!document.loadFromPluginFile(path))
+			return false;
+		if (document.plugins().isEmpty())
+			return false;
+
+		const WorldDocument::Plugin &plugin = document.plugins().front();
+		if (plugin.attributes.value(QStringLiteral("language"))
+		        .trimmed()
+		        .compare(QStringLiteral("lua"), Qt::CaseInsensitive) != 0)
+			return false;
+
+		const QString pluginId = plugin.attributes.value(QStringLiteral("id")).trimmed().toLower();
+		return !QMudNativePluginRegistry::isBlacklistedId(pluginId);
+	}
+
+	bool shouldImportWorldsFile(const QString &sourcePath, const QString &relativePath,
+	                            QMudMushclientImportUtils::ImportStats &stats)
+	{
+		if (!isUnderRelativeDirectory(relativePath, QStringLiteral("plugins")))
+			return true;
+
+		const QString suffix = QFileInfo(relativePath).suffix().toLower();
+		if (isLegacyNonLuaScriptSuffix(suffix))
+		{
+			++stats.filesSkippedFiltered;
+			return false;
+		}
+		if (suffix != QStringLiteral("xml"))
+			return true;
+		if (isImportableLuaPluginXml(sourcePath))
+			return true;
+
+		++stats.filesSkippedFiltered;
+		return false;
+	}
+
+	QString mappedSourceTreeStoragePath(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                    const QString &relativeBaseDir, const QString &path)
+	{
+		QString normalized = stripOptionalQuotes(normalizePathString(path).trimmed());
+		if (normalized.isEmpty())
+			return normalized;
+
+		QStringList bases;
+		if (!relativeBaseDir.trimmed().isEmpty())
+			bases.push_back(relativeBaseDir);
+		bases.push_back(sourceBaseDir);
+
+		for (const QString &base : bases)
+		{
+			const QString absolute = absolutePathFromBase(base, normalized);
+			const QString resolved = QFileInfo::exists(absolute)
+			                             ? QDir::cleanPath(absolute)
+			                             : resolveExistingPathCaseInsensitive(absolute);
+			if (resolved.isEmpty())
+				continue;
+
+			const QString relative = relativePathUnderBase(sourceBaseDir, resolved);
+			if (!relative.isEmpty())
+			{
+				return dotRelativeStoragePath(destinationBaseDir,
+				                              QDir(destinationBaseDir).filePath(relative));
+			}
+			if (!relativeBaseDir.trimmed().isEmpty())
+			{
+				const QString localRelative = relativePathUnderBase(relativeBaseDir, resolved);
+				if (!localRelative.isEmpty())
+				{
+					return dotRelativeStoragePath(destinationBaseDir,
+					                              QDir(destinationBaseDir).filePath(localRelative));
+				}
+			}
+		}
+
+		return {};
+	}
+
+	QString mappedSourcePluginStoragePath(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                      const QString &relativeBaseDir, const QString &path)
+	{
+		QString normalized = stripOptionalQuotes(normalizePathString(path).trimmed());
+		if (normalized.isEmpty())
+			return normalized;
+
+		QStringList bases;
+		if (!relativeBaseDir.trimmed().isEmpty())
+			bases.push_back(relativeBaseDir);
+		bases.push_back(sourceBaseDir);
+
+		for (const QString &base : bases)
+		{
+			const QString absolute = absolutePathFromBase(base, normalized);
+			const QString resolved = QFileInfo::exists(absolute)
+			                             ? QDir::cleanPath(absolute)
+			                             : resolveExistingPathCaseInsensitive(absolute);
+			if (resolved.isEmpty())
+				continue;
+
+			const QString relativePlugin = relativePathUnderBase(
+			    QDir(sourceBaseDir).filePath(QStringLiteral("worlds/plugins")), resolved);
+			if (!relativePlugin.isEmpty())
+			{
+				return dotRelativeStoragePath(
+				    destinationBaseDir,
+				    QDir(destinationBaseDir).filePath(QStringLiteral("worlds/plugins/") + relativePlugin));
+			}
+
+			return containedPluginStoragePath(destinationBaseDir, resolved);
+		}
+
+		return containedPluginStoragePath(destinationBaseDir, normalized);
+	}
+
+	QString migratePluginListPathsDetailed(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                       const QString &pluginList, bool *changed = nullptr)
+	{
+		const QStringList items = splitSerializedPathList(pluginList);
+		QStringList       migrated;
+		migrated.reserve(items.size());
+		bool anyChanged = false;
+		for (const QString &item : items)
+		{
+			const QString value = mappedSourcePluginStoragePath(sourceBaseDir, destinationBaseDir, {}, item);
+			if (value != item)
+				anyChanged = true;
+			migrated.push_back(value);
+		}
+		const QString joined = migrated.join(QLatin1Char('*'));
+		if (changed)
+			*changed = anyChanged || (joined != pluginList);
+		return joined;
+	}
+
+	QString legacyWorldPathInputForXmlValue(const QString &sourceBaseDir, const QString &relativeBaseDir,
+	                                        const QString &path)
+	{
+		QString normalized = stripOptionalQuotes(normalizePathString(path).trimmed());
+		if (normalized.isEmpty())
+			return normalized;
+		if (relativeBaseDir.trimmed().isEmpty())
+			return normalized;
+
+		const QString relativeBaseAbsolute = absolutePathFromBase(relativeBaseDir, normalized);
+		if (const QString relative = relativePathUnderBase(sourceBaseDir, relativeBaseAbsolute);
+		    !relative.isEmpty())
+		{
+			return relative;
+		}
+		return normalized;
+	}
+
+	QString migrateLegacyXmlPluginPathValue(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                        const QString &relativeBaseDir, const QString &value)
+	{
+		return mappedSourcePluginStoragePath(sourceBaseDir, destinationBaseDir, relativeBaseDir, value);
+	}
+
+	struct LegacyWorldMigrationResult
+	{
+			QString path;
+			bool    converted{false};
+			bool    skippedExisting{false};
+			QString warning;
+			QString error;
+	};
+
+	LegacyWorldMigrationResult
+	migrateLegacyWorldFilePathDetailed(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                   const QString &path, bool archiveLegacySource,
+	                                   QSet<QString> *activeConversions, QStringList *warnings,
+	                                   int *convertedWorlds);
+
+	QString migrateLegacyXmlPathValue(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                  const QString &relativeBaseDir, const QString &key,
+	                                  const QString &value, const bool archiveLegacySource,
+	                                  QSet<QString> *activeConversions, QStringList *warnings,
+	                                  int *convertedWorlds)
+	{
+		const QString leaf = keyLeafName(key);
+		if (leaf.compare(QStringLiteral("WorldList"), Qt::CaseInsensitive) == 0)
+		{
+			const QStringList items = splitSerializedWorldList(value);
+			QStringList       migrated;
+			migrated.reserve(items.size());
+			for (const QString &item : items)
+			{
+				const LegacyWorldMigrationResult result = migrateLegacyWorldFilePathDetailed(
+				    sourceBaseDir, destinationBaseDir,
+				    legacyWorldPathInputForXmlValue(sourceBaseDir, relativeBaseDir, item),
+				    archiveLegacySource, activeConversions, warnings, convertedWorlds);
+				appendMigrationWarning(warnings, result.warning);
+				if (!result.error.isEmpty())
+					appendMigrationWarning(warnings, result.error);
+				migrated.push_back(result.path);
+			}
+			return migrated.join(QLatin1Char('*'));
+		}
+		if (leaf.compare(QStringLiteral("PluginList"), Qt::CaseInsensitive) == 0)
+		{
+			const QStringList items = splitSerializedPathList(value);
+			QStringList       migrated;
+			migrated.reserve(items.size());
+			for (const QString &item : items)
+				migrated.push_back(migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir,
+				                                                   relativeBaseDir, item));
+			return migrated.join(QLatin1Char('*'));
+		}
+
+		if (const QString suffix = QFileInfo(normalizePathString(value)).suffix().toLower();
+		    QMudFileExtensions::isWorldSuffix(suffix))
+		{
+			const LegacyWorldMigrationResult result = migrateLegacyWorldFilePathDetailed(
+			    sourceBaseDir, destinationBaseDir,
+			    legacyWorldPathInputForXmlValue(sourceBaseDir, relativeBaseDir, value), archiveLegacySource,
+			    activeConversions, warnings, convertedWorlds);
+			appendMigrationWarning(warnings, result.warning);
+			if (!result.error.isEmpty())
+				appendMigrationWarning(warnings, result.error);
+			return result.path;
+		}
+
+		if (const QString mapped =
+		        mappedSourceTreeStoragePath(sourceBaseDir, destinationBaseDir, relativeBaseDir, value);
+		    !mapped.isEmpty())
+		{
+			return mapped;
+		}
+
+		if (hasPathSyntax(value))
+			return containedLegacyStoragePath(destinationBaseDir, value);
+
+		return QMudMushclientImportUtils::migrateLegacyIniPathValue(sourceBaseDir, destinationBaseDir, key,
+		                                                            value, archiveLegacySource);
+	}
+
+	bool xmlBooleanAttributeIsTrue(const QString &value)
+	{
+		const QString normalized = value.trimmed();
+		return normalized.compare(QStringLiteral("y"), Qt::CaseInsensitive) == 0 ||
+		       normalized.compare(QStringLiteral("yes"), Qt::CaseInsensitive) == 0 ||
+		       normalized.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0 ||
+		       normalized == QStringLiteral("1");
+	}
+
+	bool shouldMigrateXmlText(const QString &elementName, const QXmlStreamAttributes &attributes,
+	                          QString &migrationKey)
+	{
+		if (isPathListKey(elementName) || shouldNormalizePathKey(elementName))
+		{
+			migrationKey = elementName;
+			return true;
+		}
+
+		if (elementName.compare(QStringLiteral("variable"), Qt::CaseInsensitive) == 0)
+		{
+			const QString variableName = attributes.value(QLatin1String("name")).toString();
+			if (shouldNormalizePathKey(variableName) || isPathListKey(variableName))
+			{
+				migrationKey = variableName;
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	QString detectXmlEncodingName(const QByteArray &input)
+	{
+		if (input.startsWith("\xEF\xBB\xBF"))
+			return QStringLiteral("UTF-8");
+		if (input.startsWith("\xFF\xFE"))
+			return QStringLiteral("UTF-16LE");
+		if (input.startsWith("\xFE\xFF"))
+			return QStringLiteral("UTF-16BE");
+
+		const QByteArray              prefix      = input.left(512);
+		const QString                 declaration = QString::fromLatin1(prefix);
+		const QRegularExpression      encodingPattern(QStringLiteral(R"(encoding\s*=\s*(['"])([^'"]+)\1)"),
+		                                              QRegularExpression::CaseInsensitiveOption);
+		const QRegularExpressionMatch match = encodingPattern.match(declaration);
+		if (!match.hasMatch())
+			return QStringLiteral("UTF-8");
+		return match.captured(2).trimmed();
+	}
+
+	QString decodeLegacyWorldXml(const QByteArray &input)
+	{
+		const QByteArray encodingName = detectXmlEncodingName(input).toLatin1();
+		if (const auto encoding = QStringConverter::encodingForName(encodingName); encoding.has_value())
+		{
+			QStringDecoder decoder(*encoding);
+			const QString  decoded = decoder.decode(input);
+			if (!decoder.hasError())
+				return decoded;
+		}
+		return QString::fromUtf8(input);
+	}
+
+	bool migrateLegacyWorldXmlData(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                               const QString &relativeBaseDir, const QByteArray &input,
+	                               QByteArray &output, QString &error, const bool archiveLegacySource,
+	                               QSet<QString> *activeConversions, QStringList *warnings,
+	                               int *convertedWorlds)
+	{
+		QXmlStreamReader reader(decodeLegacyWorldXml(input));
+		QByteArray       migrated;
+		QXmlStreamWriter writer(&migrated);
+		writer.setAutoFormatting(true);
+
+		QVector<QString> textMigrationKeys;
+		while (!reader.atEnd())
+		{
+			switch (reader.readNext())
+			{
+			case QXmlStreamReader::StartDocument:
+				writer.writeStartDocument(QStringLiteral("1.0"), reader.isStandaloneDocument());
+				break;
+			case QXmlStreamReader::EndDocument:
+				writer.writeEndDocument();
+				break;
+			case QXmlStreamReader::StartElement:
+			{
+				const QString              elementName = reader.name().toString();
+				const QXmlStreamAttributes attributes  = reader.attributes();
+				const bool                 isPluginInclude =
+				    elementName.compare(QStringLiteral("include"), Qt::CaseInsensitive) == 0 &&
+				    xmlBooleanAttributeIsTrue(attributes.value(QLatin1String("plugin")).toString());
+
+				writer.writeStartElement(reader.qualifiedName().toString());
+				for (const QXmlStreamNamespaceDeclaration &declaration : reader.namespaceDeclarations())
+				{
+					writer.writeNamespace(declaration.namespaceUri().toString(),
+					                      declaration.prefix().toString());
+				}
+
+				for (const QXmlStreamAttribute &attribute : attributes)
+				{
+					const QString attributeName = attribute.name().toString();
+					QString       value         = attribute.value().toString();
+					if (elementName.compare(QStringLiteral("include"), Qt::CaseInsensitive) == 0 &&
+					    attributeName.compare(QStringLiteral("name"), Qt::CaseInsensitive) == 0)
+					{
+						value = isPluginInclude
+						            ? migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir,
+						                                              relativeBaseDir, value)
+						            : migrateLegacyXmlPathValue(sourceBaseDir, destinationBaseDir,
+						                                        relativeBaseDir, QStringLiteral("File"),
+						                                        value, archiveLegacySource, activeConversions,
+						                                        warnings, convertedWorlds);
+					}
+					else if (elementName.compare(QStringLiteral("plugin"), Qt::CaseInsensitive) == 0 &&
+					         attributeName.compare(QStringLiteral("source"), Qt::CaseInsensitive) == 0)
+					{
+						value = migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir,
+						                                        relativeBaseDir, value);
+					}
+					else if (isPathListKey(attributeName) || shouldNormalizePathKey(attributeName))
+					{
+						value = migrateLegacyXmlPathValue(sourceBaseDir, destinationBaseDir, relativeBaseDir,
+						                                  attributeName, value, archiveLegacySource,
+						                                  activeConversions, warnings, convertedWorlds);
+					}
+
+					if (attribute.namespaceUri().isEmpty())
+						writer.writeAttribute(attribute.qualifiedName().toString(), value);
+					else
+						writer.writeAttribute(attribute.namespaceUri().toString(),
+						                      attribute.name().toString(), value);
+				}
+
+				QString textMigrationKey;
+				(void)shouldMigrateXmlText(elementName, attributes, textMigrationKey);
+				textMigrationKeys.push_back(textMigrationKey);
+				break;
+			}
+			case QXmlStreamReader::EndElement:
+				writer.writeEndElement();
+				if (!textMigrationKeys.isEmpty())
+					textMigrationKeys.pop_back();
+				break;
+			case QXmlStreamReader::Characters:
+			{
+				QString text = reader.text().toString();
+				if (!textMigrationKeys.isEmpty() && !textMigrationKeys.back().isEmpty() &&
+				    !text.trimmed().isEmpty())
+				{
+					text = migrateLegacyXmlPathValue(sourceBaseDir, destinationBaseDir, relativeBaseDir,
+					                                 textMigrationKeys.back(), text, archiveLegacySource,
+					                                 activeConversions, warnings, convertedWorlds);
+				}
+				if (reader.isCDATA())
+					writer.writeCDATA(text);
+				else
+					writer.writeCharacters(text);
+				break;
+			}
+			case QXmlStreamReader::Comment:
+				writer.writeComment(reader.text().toString());
+				break;
+			case QXmlStreamReader::DTD:
+				writer.writeDTD(reader.text().toString());
+				break;
+			case QXmlStreamReader::EntityReference:
+				writer.writeEntityReference(reader.name().toString());
+				break;
+			case QXmlStreamReader::ProcessingInstruction:
+				writer.writeProcessingInstruction(reader.processingInstructionTarget().toString(),
+				                                  reader.processingInstructionData().toString());
+				break;
+			case QXmlStreamReader::NoToken:
+			case QXmlStreamReader::Invalid:
+				break;
+			}
+		}
+
+		if (reader.hasError())
+		{
+			error = QStringLiteral("Failed to parse legacy world XML: %1").arg(reader.errorString());
+			return false;
+		}
+
+		output = migrated;
+		return true;
+	}
+
+	LegacyWorldMigrationResult legacyWorldMigrationPath(const QString &path)
+	{
+		LegacyWorldMigrationResult result;
+		result.path = path;
+		return result;
+	}
+
+	LegacyWorldMigrationResult legacyWorldMigrationExisting(const QString &path)
+	{
+		LegacyWorldMigrationResult result = legacyWorldMigrationPath(path);
+		result.skippedExisting            = true;
+		return result;
+	}
+
+	LegacyWorldMigrationResult legacyWorldMigrationError(const QString &path, const QString &error)
+	{
+		LegacyWorldMigrationResult result = legacyWorldMigrationPath(path);
+		result.error                      = error;
+		return result;
+	}
+
+	LegacyWorldMigrationResult migrateLegacyWorldFilePathDetailed(const QString &sourceBaseDir,
+	                                                              const QString &destinationBaseDir,
+	                                                              const QString &path,
+	                                                              const bool     archiveLegacySource,
+	                                                              QSet<QString> *activeConversions,
+	                                                              QStringList *warnings, int *convertedWorlds)
+	{
+		QString normalizedPath = stripOptionalQuotes(normalizePathString(path).trimmed());
+		if (normalizedPath.startsWith(QStringLiteral("./")) && normalizedPath.size() > 3 &&
+		    normalizedPath.at(2).isLetter() && normalizedPath.at(3) == QLatin1Char(':'))
+		{
+			normalizedPath = normalizedPath.mid(2);
+		}
+		if (normalizedPath.startsWith(QLatin1Char('/')) && normalizedPath.size() > 3 &&
+		    normalizedPath.at(1).isLetter() && normalizedPath.at(2) == QLatin1Char(':'))
+		{
+			normalizedPath = normalizedPath.mid(1);
+		}
+		if (normalizedPath.trimmed().isEmpty())
+			return legacyWorldMigrationPath(normalizedPath);
+
+		const QString suffix = QFileInfo(normalizedPath).suffix().toLower();
+		if (!QMudFileExtensions::isWorldSuffix(suffix))
+			return legacyWorldMigrationPath(QMudFileExtensions::canonicalizePathExtension(normalizedPath));
+
+		QString canonicalPath = QMudFileExtensions::canonicalizePathExtension(normalizedPath);
+		if (!QMudFileExtensions::isLegacyWorldSuffix(suffix))
+		{
+			const QString modernAbsolutePath =
+			    containedWorldAbsolutePath(sourceBaseDir, destinationBaseDir, canonicalPath, {});
+			if (QFileInfo::exists(modernAbsolutePath))
+			{
+				return legacyWorldMigrationExisting(
+				    storagePathFromAbsolute(destinationBaseDir, modernAbsolutePath));
+			}
+			if (const QString resolvedModernPath = resolveExistingPathCaseInsensitive(modernAbsolutePath);
+			    !resolvedModernPath.isEmpty())
+			{
+				return legacyWorldMigrationExisting(
+				    storagePathFromAbsolute(destinationBaseDir, resolvedModernPath));
+			}
+			if (const QString legacyFallbackPath =
+			        QMudFileExtensions::replaceOrAppendExtension(normalizedPath, QStringLiteral("mcl"));
+			    QFileInfo(absolutePathFromBase(sourceBaseDir, legacyFallbackPath)).exists() ||
+			    !resolveExistingPathCaseInsensitive(absolutePathFromBase(sourceBaseDir, legacyFallbackPath))
+			         .isEmpty())
+			{
+				return migrateLegacyWorldFilePathDetailed(sourceBaseDir, destinationBaseDir,
+				                                          legacyFallbackPath, archiveLegacySource,
+				                                          activeConversions, warnings, convertedWorlds);
+			}
+			if (const QString destinationRelative =
+			        containedWorldStoragePath(destinationBaseDir, canonicalPath);
+			    !destinationRelative.isEmpty())
+			{
+				return legacyWorldMigrationPath(destinationRelative);
+			}
+			return legacyWorldMigrationPath(containedWorldStoragePath(destinationBaseDir, canonicalPath));
+		}
+
+		const QString legacyAbsolutePath = absolutePathFromBase(sourceBaseDir, normalizedPath);
+		QString       resolvedLegacyPath = QFileInfo::exists(legacyAbsolutePath)
+		                                       ? QDir::cleanPath(legacyAbsolutePath)
+		                                       : resolveExistingPathCaseInsensitive(legacyAbsolutePath);
+		if (resolvedLegacyPath.isEmpty())
+		{
+			if (const QString remappedLegacyPath = resolveExistingPathCaseInsensitive(
+			        remapLegacyWindowsWorldPathToBase(sourceBaseDir, normalizedPath));
+			    !remappedLegacyPath.isEmpty())
+			{
+				resolvedLegacyPath = remappedLegacyPath;
+			}
+		}
+
+		const QString effectiveModernAbsolutePath =
+		    containedWorldAbsolutePath(sourceBaseDir, destinationBaseDir, canonicalPath, resolvedLegacyPath);
+		if (const QString error = importDestinationError(destinationBaseDir, effectiveModernAbsolutePath);
+		    !error.isEmpty())
+		{
+			return legacyWorldMigrationError(containedWorldStoragePath(destinationBaseDir, canonicalPath),
+			                                 error);
+		}
+
+		QString resolvedModernPath = QFileInfo::exists(effectiveModernAbsolutePath)
+		                                 ? QDir::cleanPath(effectiveModernAbsolutePath)
+		                                 : resolveExistingPathCaseInsensitive(effectiveModernAbsolutePath);
+		if (!resolvedModernPath.isEmpty())
+			return legacyWorldMigrationExisting(
+			    storagePathFromAbsolute(destinationBaseDir, resolvedModernPath));
+
+		LegacyWorldMigrationResult result = legacyWorldMigrationPath(
+		    storagePathFromAbsolute(destinationBaseDir, effectiveModernAbsolutePath));
+		if (resolvedLegacyPath.isEmpty())
+		{
+			result.warning =
+			    QStringLiteral("Referenced legacy world file was not found: %1; reference migrated to %2")
+			        .arg(normalizedPath, result.path);
+			return result;
+		}
+
+		if (QFileInfo(resolvedLegacyPath).isSymLink())
+		{
+			result.warning =
+			    QStringLiteral("Referenced legacy world file is a symlink and was not imported: %1; "
+			                   "reference migrated to %2")
+			        .arg(normalizedPath, result.path);
+			return result;
+		}
+
+		if (activeConversions && activeConversions->contains(resolvedLegacyPath))
+			return result;
+
+		if (const QString modernDir = QFileInfo(effectiveModernAbsolutePath).absolutePath();
+		    !QDir().mkpath(modernDir))
+		{
+			result.error = QStringLiteral("Failed to create migrated world directory: %1").arg(modernDir);
+			return result;
+		}
+
+		QFile legacyFile(resolvedLegacyPath);
+		if (!legacyFile.open(QIODevice::ReadOnly))
+		{
+			result.error = QStringLiteral("Failed to read legacy world file: %1").arg(resolvedLegacyPath);
+			return result;
+		}
+		const QByteArray data = legacyFile.readAll();
+		legacyFile.close();
+
+		if (activeConversions)
+			activeConversions->insert(resolvedLegacyPath);
+
+		QByteArray migratedData;
+		QString    xmlError;
+		if (!migrateLegacyWorldXmlData(
+		        sourceBaseDir, destinationBaseDir, QFileInfo(resolvedLegacyPath).absolutePath(), data,
+		        migratedData, xmlError, archiveLegacySource, activeConversions, warnings, convertedWorlds))
+		{
+			if (activeConversions)
+				activeConversions->remove(resolvedLegacyPath);
+			result.error = QStringLiteral("%1: %2").arg(xmlError, resolvedLegacyPath);
+			return result;
+		}
+
+		if (activeConversions)
+			activeConversions->remove(resolvedLegacyPath);
+
+		QSaveFile modernFile(effectiveModernAbsolutePath);
+		if (!modernFile.open(QIODevice::WriteOnly))
+		{
+			result.error =
+			    QStringLiteral("Failed to create migrated world file: %1").arg(effectiveModernAbsolutePath);
+			return result;
+		}
+		if (modernFile.write(migratedData) != migratedData.size() || !modernFile.commit())
+		{
+			result.error =
+			    QStringLiteral("Failed to write migrated world file: %1").arg(effectiveModernAbsolutePath);
+			return result;
+		}
+		result.converted = true;
+		if (convertedWorlds)
+			++*convertedWorlds;
+
+		if (archiveLegacySource)
+		{
+			const QString relativeLegacy = archiveRelativePathFor(destinationBaseDir, resolvedLegacyPath);
+			const QString archivePath =
+			    QDir(destinationBaseDir).filePath(QStringLiteral("migrated/") + relativeLegacy);
+			if (!moveFileToArchive(resolvedLegacyPath, archivePath))
+				qWarning() << "Failed to archive legacy world file:" << resolvedLegacyPath << "->"
+				           << archivePath;
+		}
+
+		return result;
+	}
+
+	QString migrateLegacyIniPathValueDetailed(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                          const QString &key, const QString &value,
+	                                          const bool archiveLegacySource, QStringList *warnings,
+	                                          int *convertedWorlds)
+	{
+		const QString leaf = keyLeafName(key);
+		if (isPathListKey(leaf))
+		{
+			if (leaf.compare(QStringLiteral("WorldList"), Qt::CaseInsensitive) == 0)
+			{
+				const QStringList items = splitSerializedWorldList(value);
+				QStringList       migrated;
+				migrated.reserve(items.size());
+				for (const QString &item : items)
+				{
+					QSet<QString>                    activeConversions;
+					const LegacyWorldMigrationResult result = migrateLegacyWorldFilePathDetailed(
+					    sourceBaseDir, destinationBaseDir, item, archiveLegacySource, &activeConversions,
+					    warnings, convertedWorlds);
+					appendMigrationWarning(warnings, result.warning);
+					if (!result.error.isEmpty())
+						appendMigrationWarning(warnings, result.error);
+					migrated.push_back(result.path);
+				}
+				return migrated.join(QLatin1Char('*'));
+			}
+			if (leaf.compare(QStringLiteral("PluginList"), Qt::CaseInsensitive) == 0)
+				return migratePluginListPathsDetailed(sourceBaseDir, destinationBaseDir, value);
+			return normalizePathList(value);
+		}
+
+		if (!shouldNormalizePathKey(leaf))
+			return value;
+
+		const QString normalized = normalizePathString(value);
+		if (const QString suffix = QFileInfo(normalized).suffix().toLower();
+		    QMudFileExtensions::isWorldSuffix(suffix))
+		{
+			QSet<QString>                    activeConversions;
+			const LegacyWorldMigrationResult result = migrateLegacyWorldFilePathDetailed(
+			    sourceBaseDir, destinationBaseDir, normalized, archiveLegacySource, &activeConversions,
+			    warnings, convertedWorlds);
+			appendMigrationWarning(warnings, result.warning);
+			if (!result.error.isEmpty())
+				appendMigrationWarning(warnings, result.error);
+			return result.path;
+		}
+		if (const QString mapped =
+		        mappedSourceTreeStoragePath(sourceBaseDir, destinationBaseDir, {}, normalized);
+		    !mapped.isEmpty())
+		{
+			return mapped;
+		}
+		if (hasPathSyntax(normalized))
+			return containedLegacyStoragePath(destinationBaseDir, normalized);
+		return QMudFileExtensions::canonicalizePathExtension(normalized);
+	}
+
+	void importWorldsTree(const QString &mushclientRoot, const QString &qmudHome,
+	                      QMudMushclientImportUtils::ImportStats &stats)
+	{
+		const QDir    sourceBase(mushclientRoot);
+		const QDir    destinationBase(qmudHome);
+		const QString sourceWorlds = sourceBase.filePath(QStringLiteral("worlds"));
+		if (!QFileInfo(sourceWorlds).isDir())
+			return;
+
+		QDirIterator iterator(sourceWorlds,
+		                      QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System,
+		                      QDirIterator::Subdirectories);
+		while (iterator.hasNext())
+		{
+			const QString   path = iterator.next();
+			const QFileInfo info = iterator.fileInfo();
+			if (info.isSymLink())
+			{
+				++stats.filesSkippedFiltered;
+				continue;
+			}
+
+			const QString relativePath = normalizePathString(QDir(sourceWorlds).relativeFilePath(path));
+			if (relativePath.isEmpty() || relativePath == QStringLiteral(".") ||
+			    relativePath.startsWith(QStringLiteral("../")))
+			{
+				++stats.filesSkippedFiltered;
+				continue;
+			}
+
+			const QString destinationPath =
+			    QDir(destinationBase.filePath(QStringLiteral("worlds"))).filePath(relativePath);
+			if (info.isDir())
+			{
+				if (!validateImportDestination(qmudHome, destinationPath, stats))
+					continue;
+				if (!QDir().mkpath(destinationPath))
+					recordImportError(stats,
+					                  QStringLiteral("Unable to create directory: %1").arg(destinationPath));
+				continue;
+			}
+			if (!info.isFile())
+			{
+				++stats.filesSkippedFiltered;
+				continue;
+			}
+			if (!shouldImportWorldsFile(path, relativePath, stats))
+				continue;
+
+			if (QMudFileExtensions::isLegacyWorldSuffix(info.suffix().toLower()))
+			{
+				QSet<QString>                    activeConversions;
+				QStringList                      warnings;
+				const LegacyWorldMigrationResult result = migrateLegacyWorldFilePathDetailed(
+				    mushclientRoot, qmudHome, QStringLiteral("worlds/") + relativePath, false,
+				    &activeConversions, &warnings, &stats.worldsConverted);
+				for (const QString &warning : warnings)
+					recordImportWarning(stats, warning);
+				if (!result.warning.isEmpty())
+					recordImportWarning(stats, result.warning);
+				if (!result.error.isEmpty())
+				{
+					recordImportError(stats, result.error);
+				}
+				else if (result.skippedExisting)
+				{
+					++stats.filesSkippedExisting;
+				}
+				continue;
+			}
+
+			(void)copyFileNoOverwrite(qmudHome, path, destinationPath, stats);
+		}
+	}
+
+	using ImportFileFilter = bool (*)(const QString &sourcePath, const QString &relativePath,
+	                                  QMudMushclientImportUtils::ImportStats &stats);
+
+	bool copyAllImportFileFilter(const QString &, const QString &, QMudMushclientImportUtils::ImportStats &)
+	{
+		return true;
+	}
+
+	bool copyLuaImportFileFilter(const QString &, const QString &relativePath,
+	                             QMudMushclientImportUtils::ImportStats &stats)
+	{
+		if (QFileInfo(relativePath).suffix().compare(QStringLiteral("dll"), Qt::CaseInsensitive) != 0)
+			return true;
+		++stats.filesSkippedFiltered;
+		return false;
+	}
+
+	void copyImportDirectoryTree(const QString &qmudHome, const QString &sourceRoot,
+	                             const QString                          &destinationRoot,
+	                             QMudMushclientImportUtils::ImportStats &stats, const ImportFileFilter filter)
+	{
+		if (!QFileInfo(sourceRoot).isDir())
+			return;
+
+		QDirIterator iterator(sourceRoot,
+		                      QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System,
+		                      QDirIterator::Subdirectories);
+		while (iterator.hasNext())
+		{
+			const QString   path = iterator.next();
+			const QFileInfo info = iterator.fileInfo();
+			if (info.isSymLink())
+			{
+				++stats.filesSkippedFiltered;
+				continue;
+			}
+
+			const QString relativePath = normalizePathString(QDir(sourceRoot).relativeFilePath(path));
+			if (relativePath.isEmpty() || relativePath == QStringLiteral(".") ||
+			    relativePath.startsWith(QStringLiteral("../")))
+			{
+				++stats.filesSkippedFiltered;
+				continue;
+			}
+
+			const QString destinationPath = QDir(destinationRoot).filePath(relativePath);
+			if (info.isDir())
+			{
+				if (!validateImportDestination(qmudHome, destinationPath, stats))
+					continue;
+				if (!QDir().mkpath(destinationPath))
+					recordImportError(stats,
+					                  QStringLiteral("Unable to create directory: %1").arg(destinationPath));
+				continue;
+			}
+			if (!info.isFile())
+			{
+				++stats.filesSkippedFiltered;
+				continue;
+			}
+			if (filter && !filter(path, relativePath, stats))
+				continue;
+			(void)copyFileNoOverwrite(qmudHome, path, destinationPath, stats);
+		}
+	}
+
+	void copyTopLevelDatabases(const QString &mushclientRoot, const QString &qmudHome,
+	                           QMudMushclientImportUtils::ImportStats &stats)
+	{
+		const QDir          sourceDir(mushclientRoot);
+		const QFileInfoList entries =
+		    sourceDir.entryInfoList(QDir::Files | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot);
+		for (const QFileInfo &entry : entries)
+		{
+			if (entry.suffix().compare(QStringLiteral("db"), Qt::CaseInsensitive) != 0)
+				continue;
+			if (entry.isSymLink())
+			{
+				++stats.filesSkippedFiltered;
+				continue;
+			}
+			(void)copyFileNoOverwrite(qmudHome, entry.absoluteFilePath(),
+			                          QDir(qmudHome).filePath(entry.fileName()), stats);
+		}
+	}
+
+	QString settingsStatusText(const QSettings::Status status)
+	{
+		switch (status)
+		{
+		case QSettings::NoError:
+			return QStringLiteral("no error");
+		case QSettings::AccessError:
+			return QStringLiteral("access error");
+		case QSettings::FormatError:
+			return QStringLiteral("format error");
+		}
+		return QStringLiteral("unknown error");
+	}
+
+	bool migrateLegacyIniToQmudConfDetailed(const QString &sourceDir, const QString &destinationDir,
+	                                        const bool archiveSource, QString &error, QStringList *warnings,
+	                                        int *convertedWorlds)
+	{
+		const QString sourceBaseDir      = QDir::cleanPath(sourceDir);
+		const QString destinationBaseDir = QDir::cleanPath(destinationDir);
+		const QString legacyPath =
+		    findTopLevelFileWithCaseFallback(sourceBaseDir, QStringLiteral("MUSHclient.ini"));
+		if (legacyPath.isEmpty() || !QFileInfo::exists(legacyPath))
+			return true;
+		if (QFileInfo(legacyPath).isSymLink())
+		{
+			error =
+			    QStringLiteral("Legacy config file is a symlink and was not imported: %1").arg(legacyPath);
+			return false;
+		}
+
+		QFile legacyFile(legacyPath);
+		if (!legacyFile.open(QIODevice::ReadOnly))
+		{
+			error = QStringLiteral("Unable to read legacy config file: %1").arg(legacyPath);
+			return false;
+		}
+		legacyFile.close();
+
+		const QString newPath = QDir(destinationBaseDir).filePath(QStringLiteral("QMud.conf"));
+		if (const QString destinationError = importDestinationError(destinationBaseDir, newPath);
+		    !destinationError.isEmpty())
+		{
+			error = destinationError;
+			return false;
+		}
+		const QSettings               legacy(legacyPath, QSettings::IniFormat);
+		QSettings                     modern(newPath, QSettings::IniFormat);
+		const QHash<QString, QString> rawValues = parseLegacyIniRawValues(legacyPath);
+		const QStringList             keys      = legacy.allKeys();
+		if (legacy.status() != QSettings::NoError)
+		{
+			error = QStringLiteral("Unable to parse legacy config file %1: %2")
+			            .arg(legacyPath, settingsStatusText(legacy.status()));
+			return false;
+		}
+		for (const QString &key : keys)
+		{
+			modern.setValue(key, migrateLegacyIniValueWithRawSource(
+			                         sourceBaseDir, destinationBaseDir, key, legacy.value(key), rawValues,
+			                         archiveSource, warnings, convertedWorlds));
+		}
+		pruneLegacyCtrlBarsGroups(modern);
+		modern.sync();
+		if (modern.status() != QSettings::NoError)
+		{
+			error = QStringLiteral("Unable to write migrated config file %1: %2")
+			            .arg(newPath, settingsStatusText(modern.status()));
+			return false;
+		}
+
+		if (!archiveSource)
+			return true;
+
+		const QString migratedDir = QDir(destinationBaseDir).filePath(QStringLiteral("migrated"));
+		if (!QDir().mkpath(migratedDir))
+		{
+			error = QStringLiteral("Failed to create migrated directory: %1").arg(migratedDir);
+			return false;
+		}
+
+		const QString migratedPath = QDir(migratedDir).filePath(QStringLiteral("MUSHclient.ini"));
+		if (QFileInfo::exists(migratedPath) && !QFile::remove(migratedPath))
+		{
+			error = QStringLiteral("Failed to replace archived legacy config file: %1").arg(migratedPath);
+			return false;
+		}
+		if (!QFile::rename(legacyPath, migratedPath))
+		{
+			error = QStringLiteral("Failed to archive legacy config file: %1 -> %2")
+			            .arg(legacyPath, migratedPath);
+			return false;
+		}
+		return true;
+	}
+
+	struct SourcePreferenceTable
+	{
+			QString name;
+			QString createSql;
+	};
+
+	bool copyOpenPreferencesDatabase(const QSqlDatabase &sourceDb, QSqlDatabase &destinationDb,
+	                                 QMudMushclientImportUtils::ImportStats &stats)
+	{
+		QSqlQuery tableQuery(sourceDb);
+		if (!tableQuery.exec(QStringLiteral("SELECT name, sql FROM sqlite_master WHERE type = 'table' "
+		                                    "AND name NOT LIKE 'sqlite_%' ORDER BY name")))
+		{
+			recordImportError(stats, QStringLiteral("Unable to inspect MUSHclient preferences database: %1")
+			                             .arg(tableQuery.lastError().text()));
+			return false;
+		}
+
+		QVector<SourcePreferenceTable> sourceTables;
+		while (tableQuery.next())
+			sourceTables.push_back({tableQuery.value(0).toString(), tableQuery.value(1).toString()});
+
+		if (sourceTables.isEmpty())
+		{
+			recordImportError(stats,
+			                  QStringLiteral("MUSHclient preferences database has no importable tables."));
+			return false;
+		}
+
+		if (!destinationDb.transaction())
+		{
+			recordImportError(stats, QStringLiteral("Unable to begin QMud preferences import transaction: %1")
+			                             .arg(destinationDb.lastError().text()));
+			return false;
+		}
+
+		auto failTransaction = [&](const QString &message)
+		{
+			(void)destinationDb.rollback();
+			recordImportError(stats, message);
+			return false;
+		};
+
+		QSqlQuery destinationQuery(destinationDb);
+		auto      dropDestinationObjects = [&](const QString &type, const QString &dropKeyword) -> bool
+		{
+			QSqlQuery objectQuery(destinationDb);
+			if (!objectQuery.exec(QStringLiteral("SELECT name FROM sqlite_master WHERE type = '%1' "
+			                                     "AND name NOT LIKE 'sqlite_%' ORDER BY name")
+			                          .arg(type)))
+			{
+				return failTransaction(QStringLiteral("Unable to inspect QMud preferences %1 objects: %2")
+				                           .arg(type, objectQuery.lastError().text()));
+			}
+
+			QStringList names;
+			while (objectQuery.next())
+				names.push_back(objectQuery.value(0).toString());
+
+			for (const QString &name : names)
+			{
+				if (!destinationQuery.exec(
+				        QStringLiteral("DROP %1 IF EXISTS %2").arg(dropKeyword, quotedSqlIdentifier(name))))
+				{
+					return failTransaction(QStringLiteral("Unable to clear QMud preferences %1 %2: %3")
+					                           .arg(type, name, destinationQuery.lastError().text()));
+				}
+			}
+			return true;
+		};
+
+		if (!dropDestinationObjects(QStringLiteral("trigger"), QStringLiteral("TRIGGER")) ||
+		    !dropDestinationObjects(QStringLiteral("view"), QStringLiteral("VIEW")) ||
+		    !dropDestinationObjects(QStringLiteral("index"), QStringLiteral("INDEX")) ||
+		    !dropDestinationObjects(QStringLiteral("table"), QStringLiteral("TABLE")))
+		{
+			return false;
+		}
+
+		for (const SourcePreferenceTable &table : sourceTables)
+		{
+			if (table.createSql.trimmed().isEmpty() || !destinationQuery.exec(table.createSql))
+			{
+				return failTransaction(QStringLiteral("Unable to create QMud preferences table %1: %2")
+				                           .arg(table.name, destinationQuery.lastError().text()));
+			}
+
+			QSqlQuery sourceRows(sourceDb);
+			if (!sourceRows.exec(QStringLiteral("SELECT * FROM %1").arg(quotedSqlIdentifier(table.name))))
+			{
+				return failTransaction(QStringLiteral("Unable to read MUSHclient preferences table %1: %2")
+				                           .arg(table.name, sourceRows.lastError().text()));
+			}
+
+			const QSqlRecord record = sourceRows.record();
+			if (record.count() == 0)
+				continue;
+
+			QStringList columnNames;
+			columnNames.reserve(record.count());
+			for (int column = 0; column < record.count(); ++column)
+				columnNames.push_back(quotedSqlIdentifier(record.fieldName(column)));
+
+			QSqlQuery insertQuery(destinationDb);
+			if (!insertQuery.prepare(QStringLiteral("INSERT INTO %1 (%2) VALUES (%3)")
+			                             .arg(quotedSqlIdentifier(table.name),
+			                                  columnNames.join(QLatin1Char(',')),
+			                                  questionPlaceholders(record.count()))))
+			{
+				return failTransaction(
+				    QStringLiteral("Unable to prepare QMud preferences import for table %1: %2")
+				        .arg(table.name, insertQuery.lastError().text()));
+			}
+
+			while (sourceRows.next())
+			{
+				for (int column = 0; column < record.count(); ++column)
+					insertQuery.bindValue(column, sourceRows.value(column));
+				if (!insertQuery.exec())
+				{
+					return failTransaction(QStringLiteral("Unable to import QMud preferences table %1: %2")
+					                           .arg(table.name, insertQuery.lastError().text()));
+				}
+			}
+		}
+
+		QSqlQuery schemaQuery(sourceDb);
+		if (!schemaQuery.exec(QStringLiteral("SELECT sql FROM sqlite_master WHERE type IN "
+		                                     "('index', 'trigger', 'view') AND sql IS NOT NULL "
+		                                     "ORDER BY type, name")))
+		{
+			return failTransaction(QStringLiteral("Unable to inspect MUSHclient preferences schema: %1")
+			                           .arg(schemaQuery.lastError().text()));
+		}
+		while (schemaQuery.next())
+		{
+			if (!destinationQuery.exec(schemaQuery.value(0).toString()))
+			{
+				return failTransaction(QStringLiteral("Unable to import MUSHclient preferences schema: %1")
+				                           .arg(destinationQuery.lastError().text()));
+			}
+		}
+
+		if (!destinationDb.commit())
+		{
+			recordImportError(stats, QStringLiteral("Unable to commit QMud preferences import: %1")
+			                             .arg(destinationDb.lastError().text()));
+			(void)destinationDb.rollback();
+			return false;
+		}
+
+		return true;
+	}
+} // namespace
+
+namespace QMudMushclientImportUtils
+{
+	QString migrateLegacyWorldFilePath(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                   const QString &path, const bool archiveLegacySource)
+	{
+		QSet<QString>                    activeConversions;
+		const LegacyWorldMigrationResult result =
+		    migrateLegacyWorldFilePathDetailed(sourceBaseDir, destinationBaseDir, path, archiveLegacySource,
+		                                       &activeConversions, nullptr, nullptr);
+		appendMigrationWarning(nullptr, result.warning);
+		if (!result.error.isEmpty())
+			qWarning() << result.error;
+		return result.path;
+	}
+
+	QString migrateWorldListPaths(const QString &baseDir, const QString &worldList, bool *changed)
+	{
+		const QStringList items = splitSerializedWorldList(worldList);
+		QStringList       migrated;
+		migrated.reserve(items.size());
+		bool anyChanged = false;
+		for (const QString &item : items)
+		{
+			const QString value = migrateLegacyWorldFilePath(baseDir, baseDir, item, true);
+			if (value != item)
+				anyChanged = true;
+			migrated.push_back(value);
+		}
+		const QString joined = migrated.join(QLatin1Char('*'));
+		if (changed)
+			*changed = anyChanged || (joined != worldList);
+		return joined;
+	}
+
+	QString canonicalizeWorldListForRuntime(const QString &worldList)
+	{
+		return splitSerializedWorldList(worldList).join(QLatin1Char('*'));
+	}
+
+	QString migrateLegacyPluginFilePath(const QString &baseDir, const QString &path)
+	{
+		QString normalizedPath = stripOptionalQuotes(normalizePathString(path).trimmed());
+		if (normalizedPath.startsWith(QStringLiteral("./")) && normalizedPath.size() > 3 &&
+		    normalizedPath.at(2).isLetter() && normalizedPath.at(3) == QLatin1Char(':'))
+		{
+			normalizedPath = normalizedPath.mid(2);
+		}
+		if (normalizedPath.startsWith(QLatin1Char('/')) && normalizedPath.size() > 3 &&
+		    normalizedPath.at(1).isLetter() && normalizedPath.at(2) == QLatin1Char(':'))
+		{
+			normalizedPath = normalizedPath.mid(1);
+		}
+		if (normalizedPath.trimmed().isEmpty())
+			return normalizedPath;
+
+		const QString defaultAbsolutePath = absolutePathFromBase(baseDir, normalizedPath);
+		if (const QString resolvedPath = QFileInfo::exists(defaultAbsolutePath)
+		                                     ? QDir::cleanPath(defaultAbsolutePath)
+		                                     : resolveExistingPathCaseInsensitive(defaultAbsolutePath);
+		    !resolvedPath.isEmpty())
+		{
+			return containedPluginStoragePath(baseDir, resolvedPath);
+		}
+
+		if (const QString remappedPath = resolveExistingPathCaseInsensitive(
+		        remapLegacyWindowsWorldPathToBase(baseDir, normalizedPath));
+		    !remappedPath.isEmpty())
+		{
+			return containedPluginStoragePath(baseDir, remappedPath);
+		}
+
+		return containedPluginStoragePath(baseDir, normalizedPath);
+	}
+
+	QString migratePluginListPaths(const QString &baseDir, const QString &pluginList, bool *changed)
+	{
+		return migratePluginListPathsDetailed(baseDir, baseDir, pluginList, changed);
+	}
+
+	QString canonicalizePluginListForRuntime(const QString &pluginList)
+	{
+		return splitSerializedPathList(pluginList).join(QLatin1Char('*'));
+	}
+
+	void migrateLegacyWorldTree(const QString &baseDir, const QString &worldDirectory)
+	{
+		const QString normalizedWorldDir = normalizePathString(worldDirectory.trimmed());
+		if (normalizedWorldDir.isEmpty())
+			return;
+
+		const QString absoluteWorldDir = absolutePathFromBase(baseDir, normalizedWorldDir);
+		const QDir    rootDir(absoluteWorldDir);
+		if (!rootDir.exists())
+			return;
+
+		QStringList  legacyWorldFiles;
+		QDirIterator iterator(rootDir.absolutePath(),
+		                      QDir::Files | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System,
+		                      QDirIterator::Subdirectories);
+		while (iterator.hasNext())
+		{
+			const QString filePath = iterator.next();
+			const QString suffix   = iterator.fileInfo().suffix().toLower();
+			if (!QMudFileExtensions::isLegacyWorldSuffix(suffix))
+				continue;
+			legacyWorldFiles.push_back(QDir::cleanPath(filePath));
+		}
+
+		for (const QString &legacyAbsolutePath : legacyWorldFiles)
+		{
+			const QString migrationInput = archiveRelativePathFor(baseDir, legacyAbsolutePath);
+			(void)migrateLegacyWorldFilePath(baseDir, baseDir, migrationInput, true);
+		}
+	}
+
+	QString migrateLegacyIniPathValue(const QString &baseDir, const QString &key, const QString &value)
+	{
+		return migrateLegacyIniPathValue(baseDir, baseDir, key, value, true);
+	}
+
+	QString migrateLegacyIniPathValue(const QString &sourceBaseDir, const QString &destinationBaseDir,
+	                                  const QString &key, const QString &value,
+	                                  const bool archiveLegacySource)
+	{
+		return migrateLegacyIniPathValueDetailed(sourceBaseDir, destinationBaseDir, key, value,
+		                                         archiveLegacySource, nullptr, nullptr);
+	}
+
+	void migrateLegacyIniToQmudConf(const QString &sourceDir, const QString &destinationDir,
+	                                const bool archiveSource)
+	{
+		QString error;
+		if (!migrateLegacyIniToQmudConfDetailed(sourceDir, destinationDir, archiveSource, error, nullptr,
+		                                        nullptr))
+			qWarning() << error;
+	}
+
+	bool isLikelyCorruptedRelativeWorldPath(const QString &path)
+	{
+		const QString normalized = normalizePathString(path.trimmed());
+		if (normalized.isEmpty())
+			return false;
+		if (const QString suffix = QFileInfo(normalized).suffix().toLower();
+		    !QMudFileExtensions::isWorldSuffix(suffix))
+			return false;
+		if (!normalized.startsWith(QLatin1Char('.')))
+			return false;
+		return !normalized.contains(QLatin1Char('/'));
+	}
+
+	ImportStats importDirectory(const QString &mushclientRoot, const QString &qmudHome)
+	{
+		ImportStats stats;
+
+		importWorldsTree(mushclientRoot, qmudHome, stats);
+		copyImportDirectoryTree(qmudHome, QDir(mushclientRoot).filePath(QStringLiteral("lua")),
+		                        QDir(qmudHome).filePath(QStringLiteral("lua")), stats,
+		                        copyLuaImportFileFilter);
+		copyImportDirectoryTree(qmudHome, QDir(mushclientRoot).filePath(QStringLiteral("scripts")),
+		                        QDir(qmudHome).filePath(QStringLiteral("scripts")), stats,
+		                        copyAllImportFileFilter);
+		copyImportDirectoryTree(qmudHome, QDir(mushclientRoot).filePath(QStringLiteral("logs")),
+		                        QDir(qmudHome).filePath(QStringLiteral("logs")), stats,
+		                        copyAllImportFileFilter);
+
+		if (!findTopLevelFileWithCaseFallback(mushclientRoot, QStringLiteral("MUSHclient.ini")).isEmpty())
+		{
+			QString     error;
+			QStringList warnings;
+			if (migrateLegacyIniToQmudConfDetailed(mushclientRoot, qmudHome, false, error, &warnings,
+			                                       &stats.worldsConverted))
+			{
+				for (const QString &warning : warnings)
+					recordImportWarning(stats, warning);
+				++stats.configsImported;
+			}
+			else
+			{
+				for (const QString &warning : warnings)
+					recordImportWarning(stats, warning);
+				recordImportError(stats, error);
+			}
+		}
+		copyTopLevelDatabases(mushclientRoot, qmudHome, stats);
+
+		return stats;
+	}
+
+	void importPreferencesDatabase(const QString &mushclientRoot, QSqlDatabase &destinationDb,
+	                               ImportStats &stats)
+	{
+		const QString sourcePath =
+		    findTopLevelFileWithCaseFallback(mushclientRoot, QStringLiteral("mushclient_prefs.sqlite"));
+		if (sourcePath.isEmpty() || !QFileInfo(sourcePath).isFile())
+			return;
+		if (QFileInfo(sourcePath).isSymLink())
+		{
+			++stats.filesSkippedFiltered;
+			return;
+		}
+		if (!destinationDb.isOpen())
+		{
+			recordImportError(stats, QStringLiteral("QMud preferences database is not open."));
+			return;
+		}
+
+		const QString sourceConnectionName =
+		    QStringLiteral("qmud_mushclient_prefs_import_%1").arg(reinterpret_cast<quintptr>(&stats));
+		QSqlDatabase sourceDb = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), sourceConnectionName);
+		sourceDb.setDatabaseName(sourcePath);
+		sourceDb.setConnectOptions(QStringLiteral("QSQLITE_OPEN_READONLY"));
+		if (!sourceDb.open())
+		{
+			recordImportError(stats, QStringLiteral("Unable to open MUSHclient preferences database: %1")
+			                             .arg(sourceDb.lastError().text()));
+			sourceDb.close();
+			sourceDb = QSqlDatabase();
+			QSqlDatabase::removeDatabase(sourceConnectionName);
+			return;
+		}
+
+		if (copyOpenPreferencesDatabase(sourceDb, destinationDb, stats))
+			++stats.preferenceDatabasesImported;
+
+		sourceDb.close();
+		sourceDb = QSqlDatabase();
+		QSqlDatabase::removeDatabase(sourceConnectionName);
+	}
+} // namespace QMudMushclientImportUtils

--- a/src/helpers/MushclientImportUtils.h
+++ b/src/helpers/MushclientImportUtils.h
@@ -1,0 +1,143 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: MushclientImportUtils.h
+ * Role: Shared MUSHclient import and legacy path/config migration helper APIs.
+ */
+
+#ifndef QMUD_MUSHCLIENTIMPORTUTILS_H
+#define QMUD_MUSHCLIENTIMPORTUTILS_H
+
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QString>
+#include <QStringList>
+
+class QSqlDatabase;
+
+namespace QMudMushclientImportUtils
+{
+	/**
+	 * @brief Summary counters returned by an explicit MUSHclient directory import.
+	 */
+	struct ImportStats
+	{
+			int         filesCopied{0};
+			int         filesSkippedExisting{0};
+			int         filesSkippedFiltered{0};
+			int         worldsConverted{0};
+			int         configsImported{0};
+			int         preferenceDatabasesImported{0};
+			int         warnings{0};
+			int         errors{0};
+			QStringList warningDetails;
+			QStringList errorDetails;
+	};
+
+	/**
+	 * @brief Migrates one legacy or modern world path to QMud storage form.
+	 * @param sourceBaseDir Directory where legacy source files are resolved.
+	 * @param destinationBaseDir Directory where migrated QMud files are written.
+	 * @param path Legacy path value to migrate.
+	 * @param archiveLegacySource Move the legacy source to destination `migrated/` after conversion.
+	 * @return QMud storage path for world values, even when the referenced source cannot be read.
+	 */
+	[[nodiscard]] QString migrateLegacyWorldFilePath(const QString &sourceBaseDir,
+	                                                 const QString &destinationBaseDir, const QString &path,
+	                                                 bool archiveLegacySource);
+	/**
+	 * @brief Migrates a serialized world-list path value.
+	 * @param baseDir QMUD_HOME/source root for startup migration.
+	 * @param worldList Serialized `*`-delimited world-list value.
+	 * @param changed Optional output indicating whether the serialized value changed.
+	 * @return Migrated serialized world-list value.
+	 */
+	[[nodiscard]] QString migrateWorldListPaths(const QString &baseDir, const QString &worldList,
+	                                            bool *changed = nullptr);
+	/**
+	 * @brief Canonicalizes a serialized world list for runtime use.
+	 * @param worldList Serialized world-list value.
+	 * @return Canonical serialized value.
+	 */
+	[[nodiscard]] QString canonicalizeWorldListForRuntime(const QString &worldList);
+	/**
+	 * @brief Migrates one legacy plugin path to QMud storage form.
+	 * @param baseDir QMUD_HOME/source root for startup migration.
+	 * @param path Legacy plugin path value.
+	 * @return QMud storage path for plugin values.
+	 */
+	[[nodiscard]] QString migrateLegacyPluginFilePath(const QString &baseDir, const QString &path);
+	/**
+	 * @brief Migrates a serialized plugin-list path value.
+	 * @param baseDir QMUD_HOME/source root for startup migration.
+	 * @param pluginList Serialized `*`-delimited plugin-list value.
+	 * @param changed Optional output indicating whether the serialized value changed.
+	 * @return Migrated serialized plugin-list value.
+	 */
+	[[nodiscard]] QString migratePluginListPaths(const QString &baseDir, const QString &pluginList,
+	                                             bool *changed = nullptr);
+	/**
+	 * @brief Canonicalizes a serialized plugin list for runtime use.
+	 * @param pluginList Serialized plugin-list value.
+	 * @return Canonical serialized value.
+	 */
+	[[nodiscard]] QString canonicalizePluginListForRuntime(const QString &pluginList);
+	/**
+	 * @brief Migrates all legacy `.mcl` files under a world directory.
+	 * @param baseDir QMUD_HOME/source root for startup migration.
+	 * @param worldDirectory World directory setting value.
+	 */
+	void                  migrateLegacyWorldTree(const QString &baseDir, const QString &worldDirectory);
+	/**
+	 * @brief Migrates a single MUSHclient INI path value.
+	 * @param baseDir QMUD_HOME/source root for startup migration.
+	 * @param key INI key name.
+	 * @param value INI value.
+	 * @return Migrated value.
+	 */
+	[[nodiscard]] QString migrateLegacyIniPathValue(const QString &baseDir, const QString &key,
+	                                                const QString &value);
+	/**
+	 * @brief Migrates a single MUSHclient INI path value with separate source/destination roots.
+	 * @param sourceBaseDir Directory where legacy source paths are resolved.
+	 * @param destinationBaseDir QMUD_HOME where migrated paths are stored.
+	 * @param key INI key name.
+	 * @param value INI value.
+	 * @param archiveLegacySource Move legacy world files after conversion when `true`.
+	 * @return Migrated value.
+	 */
+	[[nodiscard]] QString migrateLegacyIniPathValue(const QString &sourceBaseDir,
+	                                                const QString &destinationBaseDir, const QString &key,
+	                                                const QString &value, bool archiveLegacySource);
+	/**
+	 * @brief Imports/converts MUSHclient.ini to QMud.conf.
+	 * @param sourceDir Directory containing MUSHclient.ini.
+	 * @param destinationDir QMUD_HOME where QMud.conf is written.
+	 * @param archiveSource Move source INI into `migrated/` after conversion.
+	 */
+	void                  migrateLegacyIniToQmudConf(const QString &sourceDir, const QString &destinationDir,
+	                                                 bool archiveSource);
+	/**
+	 * @brief Checks the legacy corrupted relative world path shape.
+	 * @param path Path value to inspect.
+	 * @return `true` for the known `.world`/`.mcl` corruption shape.
+	 */
+	[[nodiscard]] bool    isLikelyCorruptedRelativeWorldPath(const QString &path);
+	/**
+	 * @brief Imports an explicit MUSHclient root directory into QMUD_HOME.
+	 * @param mushclientRoot Selected MUSHclient root, treated read-only.
+	 * @param qmudHome QMud data root destination.
+	 * @return Import counters and errors.
+	 */
+	[[nodiscard]] ImportStats importDirectory(const QString &mushclientRoot, const QString &qmudHome);
+	/**
+	 * @brief Migrates MUSHclient preference database content into an already-open QMud database.
+	 * @param mushclientRoot Selected MUSHclient root, treated read-only.
+	 * @param destinationDb Open QMud preferences database connection to flush and populate.
+	 * @param stats Import counters updated with success or failure details.
+	 */
+	void importPreferencesDatabase(const QString &mushclientRoot, QSqlDatabase &destinationDb,
+	                               ImportStats &stats);
+} // namespace QMudMushclientImportUtils
+
+#endif // QMUD_MUSHCLIENTIMPORTUTILS_H

--- a/src/helpers/SoundFileRoutingUtils.cpp
+++ b/src/helpers/SoundFileRoutingUtils.cpp
@@ -1,0 +1,129 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: SoundFileRoutingUtils.cpp
+ * Role: Sound backend routing helpers for file-based playback.
+ */
+
+#include "SoundFileRoutingUtils.h"
+
+#include <QByteArray>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QFile>
+#include <QFileInfo>
+#include <QIODevice>
+
+#include <algorithm>
+#include <array>
+
+namespace
+{
+	/**
+	 * @brief Reads an unsigned 16-bit little-endian integer from byte data.
+	 * @param data Source byte data.
+	 * @return Decoded integer.
+	 */
+	quint16 littleEndianUInt16(const QByteArray &data)
+	{
+		return static_cast<quint16>(static_cast<quint8>(data.at(0))) |
+		       static_cast<quint16>(static_cast<quint8>(data.at(1)) << 8U);
+	}
+
+	/**
+	 * @brief Reads an unsigned 32-bit little-endian integer from WAVE chunk-header size bytes.
+	 * @param data Source byte data.
+	 * @return Decoded integer.
+	 */
+	quint32 littleEndianChunkSize(const QByteArray &data)
+	{
+		return static_cast<quint32>(static_cast<quint8>(data.at(4))) |
+		       (static_cast<quint32>(static_cast<quint8>(data.at(5))) << 8U) |
+		       (static_cast<quint32>(static_cast<quint8>(data.at(6))) << 16U) |
+		       (static_cast<quint32>(static_cast<quint8>(data.at(7))) << 24U);
+	}
+
+	/**
+	 * @brief Checks if a WAVE fmt chunk represents a simple QSoundEffect-friendly format.
+	 * @param formatChunk WAVE fmt chunk payload.
+	 * @return `true` when the format should remain on QSoundEffect.
+	 */
+	bool waveFormatChunkUsesSoundEffect(const QByteArray &formatChunk)
+	{
+		constexpr quint16              kWaveFormatPcm                 = 0x0001;
+		constexpr quint16              kWaveFormatExtensible          = 0xFFFE;
+		constexpr qsizetype            kWaveExtensibleSubFormatOffset = 24;
+		constexpr std::array<char, 16> kPcmSubFormatGuid{'\x01', '\x00', '\x00',
+		                                                 '\x00', '\x00', '\x00',
+		                                                 '\x10', '\x00', static_cast<char>(0x80),
+		                                                 '\x00', '\x00', static_cast<char>(0xAA),
+		                                                 '\x00', '\x38', static_cast<char>(0x9B),
+		                                                 '\x71'};
+
+		if (formatChunk.size() < 2)
+			return false;
+
+		const quint16 formatTag = littleEndianUInt16(formatChunk);
+		if (formatTag == kWaveFormatPcm)
+			return true;
+		if (formatTag != kWaveFormatExtensible)
+			return false;
+		if (formatChunk.size() <
+		    kWaveExtensibleSubFormatOffset + static_cast<qsizetype>(kPcmSubFormatGuid.size()))
+			return false;
+
+		return std::equal(kPcmSubFormatGuid.cbegin(), kPcmSubFormatGuid.cend(),
+		                  formatChunk.constData() + kWaveExtensibleSubFormatOffset);
+	}
+
+	/**
+	 * @brief Checks if a WAVE file should use QSoundEffect.
+	 * @param fileName Absolute file path to inspect.
+	 * @return `true` when QSoundEffect is appropriate.
+	 */
+	bool waveFileUsesSoundEffect(const QString &fileName)
+	{
+		QFile file(fileName);
+		if (!file.open(QIODevice::ReadOnly))
+			return false;
+
+		const QByteArray riffHeader = file.read(12);
+		if (riffHeader.size() != 12 || riffHeader.first(4) != QByteArrayLiteral("RIFF") ||
+		    riffHeader.sliced(8, 4) != QByteArrayLiteral("WAVE"))
+			return false;
+
+		const qint64 fileSize = file.size();
+		while (file.pos() + 8 <= fileSize)
+		{
+			const QByteArray chunkHeader = file.read(8);
+			if (chunkHeader.size() != 8)
+				return false;
+
+			const QByteArray chunkId   = chunkHeader.first(4);
+			const quint32    chunkSize = littleEndianChunkSize(chunkHeader);
+			if (chunkId == QByteArrayLiteral("fmt "))
+			{
+				const qint64     bytesToRead = qMin<qint64>(chunkSize, 40);
+				const QByteArray formatChunk = file.read(bytesToRead);
+				return waveFormatChunkUsesSoundEffect(formatChunk);
+			}
+
+			const qint64 nextChunkPosition = file.pos() + static_cast<qint64>(chunkSize) + (chunkSize % 2U);
+			if (nextChunkPosition < file.pos() || nextChunkPosition > fileSize ||
+			    !file.seek(nextChunkPosition))
+				return false;
+		}
+
+		return false;
+	}
+} // namespace
+
+SoundFilePlaybackBackend soundFilePlaybackBackendForFile(const QString &fileName)
+{
+	const QString suffix = QFileInfo(fileName).suffix().toLower();
+	if (suffix != QStringLiteral("wav") && suffix != QStringLiteral("wave"))
+		return SoundFilePlaybackBackend::QMediaPlayer;
+
+	return waveFileUsesSoundEffect(fileName) ? SoundFilePlaybackBackend::QSoundEffect
+	                                         : SoundFilePlaybackBackend::QMediaPlayer;
+}

--- a/src/helpers/SoundFileRoutingUtils.h
+++ b/src/helpers/SoundFileRoutingUtils.h
@@ -1,0 +1,30 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: SoundFileRoutingUtils.h
+ * Role: Sound backend routing helpers for file-based playback.
+ */
+
+#ifndef QMUD_SOUNDFILEROUTINGUTILS_H
+#define QMUD_SOUNDFILEROUTINGUTILS_H
+
+#include <QString>
+
+/**
+ * @brief Playback backend selected for a sound file.
+ */
+enum class SoundFilePlaybackBackend
+{
+	QSoundEffect,
+	QMediaPlayer
+};
+
+/**
+ * @brief Chooses the Qt playback backend for a sound file.
+ * @param fileName Absolute file path to inspect.
+ * @return Backend appropriate for the file format.
+ */
+[[nodiscard]] SoundFilePlaybackBackend soundFilePlaybackBackendForFile(const QString &fileName);
+
+#endif // QMUD_SOUNDFILEROUTINGUTILS_H

--- a/src/helpers/UpdateCheckUtils.cpp
+++ b/src/helpers/UpdateCheckUtils.cpp
@@ -293,7 +293,9 @@ namespace QMudUpdateCheck
 		}
 		result.releaseVersion = releaseVersionCore;
 
-		if (compareVersions(releaseVersionCore, currentVersionCore) <= 0)
+		const int  versionComparison = compareVersions(releaseVersionCore, currentVersionCore);
+		const bool currentIsCiBuild  = currentVersion.contains(QStringLiteral("-ci"), Qt::CaseInsensitive);
+		if (versionComparison < 0 || (versionComparison == 0 && !currentIsCiBuild))
 		{
 			result.status = ReleaseEvaluationStatus::UpToDate;
 			return result;

--- a/src/helpers/WorldSessionStateUtils.cpp
+++ b/src/helpers/WorldSessionStateUtils.cpp
@@ -36,7 +36,7 @@ namespace
 	constexpr qint64  kInvalidTimeMarker             = std::numeric_limits<qint64>::min();
 	constexpr quint32 kMaxPersistedOutputLineCount   = 500000u;
 	constexpr quint32 kMaxPersistedSpanCountPerLine  = 100000u;
-	constexpr quint32 kMaxPersistedHistoryEntryCount = 5000u;
+	constexpr quint32 kMaxPersistedHistoryEntryCount = 50000u;
 	constexpr quint32 kMaxPersistedCustomMxpElements = 2048u;
 
 	quint32           crc32ForBytes(const QByteArray &bytes)

--- a/src/helpers/WorldSessionStateUtils.h
+++ b/src/helpers/WorldSessionStateUtils.h
@@ -21,14 +21,14 @@ namespace QMudWorldSessionState
 	 */
 	struct WorldSessionStateData
 	{
-			bool                                      hasOutputBuffer{false};
-			bool                                      hasCommandHistory{false};
-			bool                                      hasCustomMxpElements{false};
-			bool                                      hasMxpSessionState{false};
-			QVector<WorldRuntime::LineEntry>          outputLines;
-			QStringList                               commandHistory;
-			QList<TelnetProcessor::CustomElementInfo> customMxpElements;
-			TelnetProcessor::MxpSessionState          mxpSessionState;
+			bool                                       hasOutputBuffer{false};
+			bool                                       hasCommandHistory{false};
+			bool                                       hasCustomMxpElements{false};
+			bool                                       hasMxpSessionState{false};
+			IndexedRingBuffer<WorldRuntime::LineEntry> outputLines;
+			QStringList                                commandHistory;
+			QList<TelnetProcessor::CustomElementInfo>  customMxpElements;
+			TelnetProcessor::MxpSessionState           mxpSessionState;
 	};
 
 	/**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,12 @@ qmud_add_qtest(tst_EncodingUtils
         LABELS
         unit)
 
+qmud_add_qtest(tst_IndexedRingBuffer
+        SOURCES
+        unit/tst_IndexedRingBuffer.cpp
+        LABELS
+        unit)
+
 qmud_add_qtest(tst_OutputWrapUtils
         SOURCES
         unit/tst_OutputWrapUtils.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,6 +271,15 @@ qmud_add_qtest(tst_WorldSessionStateUtils
         LABELS
         unit)
 
+qmud_add_qtest(tst_WorldRuntime_OutputBufferSeal
+        GUI
+        SOURCES
+        unit/tst_WorldRuntime_OutputBufferSeal.cpp
+        LIBRARIES
+        qmud_app_core
+        LABELS
+        unit)
+
 qmud_add_qtest(tst_WorldSessionRestoreFlowUtils
         SOURCES
         unit/tst_WorldSessionRestoreFlowUtils.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -381,6 +381,13 @@ qmud_add_qtest(tst_WorldRuntimeAttributeUtils
         LABELS
         unit)
 
+qmud_add_qtest(tst_SoundFileRoutingUtils
+        SOURCES
+        unit/tst_SoundFileRoutingUtils.cpp
+        "${CMAKE_SOURCE_DIR}/src/helpers/SoundFileRoutingUtils.cpp"
+        LABELS
+        unit)
+
 qmud_add_qtest(tst_StartTlsFallbackUtils
         SOURCES
         unit/tst_StartTlsFallbackUtils.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -511,6 +511,23 @@ qmud_add_qtest(tst_ReloadIntegration
         TIMEOUT
         20)
 
+qmud_add_qtest(tst_MushclientImportUtils
+        SOURCES
+        integration/tst_MushclientImportUtils.cpp
+        "${CMAKE_SOURCE_DIR}/src/helpers/MushclientImportUtils.cpp"
+        "${CMAKE_SOURCE_DIR}/src/helpers/PluginPathUtils.cpp"
+        "${CMAKE_SOURCE_DIR}/src/WorldDocument.cpp"
+        "${CMAKE_SOURCE_DIR}/src/NativePluginRegistry.cpp"
+        LIBRARIES
+        Qt6::Sql
+        LABELS
+        integration
+        TIMEOUT
+        20)
+target_compile_definitions(tst_MushclientImportUtils
+        PRIVATE
+        QMUD_NATIVEPLUGINREGISTRY_METADATA_ONLY)
+
 qmud_add_qtest(tst_LuaBridgeDispatcherIntegration
         SOURCES
         integration/tst_LuaBridgeDispatcherIntegration.cpp

--- a/tests/gui/tst_Dialog_GlobalPreferencesUpdates.cpp
+++ b/tests/gui/tst_Dialog_GlobalPreferencesUpdates.cpp
@@ -23,6 +23,9 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QSpinBox>
+#include <QTabBar>
+#include <QTabWidget>
+#include <QTextEdit>
 #include <QWidget>
 #include <QtTest/QTest>
 
@@ -392,6 +395,49 @@ class tst_Dialog_GlobalPreferencesUpdates : public QObject
 			QVERIFY(enableReload->isEnabled());
 			QVERIFY(timeoutSpin->isEnabled());
 			QCOMPARE(autoCheck->toolTip(), QStringLiteral("Updates are disabled."));
+		}
+
+		/**
+		 * @brief Verifies hidden tab container does not trap keyboard focus traversal.
+		 */
+		void hiddenTabContainerIsNotFocusable()
+		{
+			resetStubState();
+
+			GlobalPreferencesDialog dialog;
+
+			auto                   *tabs = dialog.findChild<QTabWidget *>();
+			QVERIFY(tabs);
+			QCOMPARE(tabs->focusPolicy(), Qt::NoFocus);
+			QVERIFY(tabs->tabBar());
+			QCOMPARE(tabs->tabBar()->focusPolicy(), Qt::NoFocus);
+		}
+
+		/**
+		 * @brief Verifies Lua page script editor passes Tab to focus traversal.
+		 */
+		void luaScriptEditorAllowsTabFocusTraversal()
+		{
+			resetStubState();
+			stubState().globalOptions.insert(QStringLiteral("LuaScript"),
+			                                 QStringLiteral("test-lua-script-editor-tab-focus"));
+
+			GlobalPreferencesDialog dialog;
+
+			const auto              editors = dialog.findChildren<QTextEdit *>();
+			QTextEdit              *luaEditor{nullptr};
+			for (QTextEdit *editor : editors)
+			{
+				if (editor &&
+				    editor->toPlainText().contains(QStringLiteral("test-lua-script-editor-tab-focus")))
+				{
+					luaEditor = editor;
+					break;
+				}
+			}
+
+			QVERIFY(luaEditor);
+			QVERIFY(luaEditor->tabChangesFocus());
 		}
 
 		/**

--- a/tests/gui/tst_Dialog_WorldPreferences.cpp
+++ b/tests/gui/tst_Dialog_WorldPreferences.cpp
@@ -233,6 +233,67 @@ class tst_Dialog_WorldPreferences : public QObject
 			}
 		}
 
+		void listedEditorsAndTablesAllowTabFocusTraversal()
+		{
+			const QString sourcePath =
+			    QDir(QStringLiteral(QMUD_TEST_SOURCE_DIR))
+			        .filePath(QStringLiteral("src/dialogs/WorldPreferencesDialog.cpp"));
+			QFile sourceFile(sourcePath);
+			QVERIFY2(sourceFile.open(QIODevice::ReadOnly | QIODevice::Text),
+			         qPrintable(QStringLiteral("Failed to open %1").arg(sourcePath)));
+			const QString sourceText = QString::fromUtf8(sourceFile.readAll());
+
+			auto          firstMatchLine = [&sourceText](const QString &pattern) -> int
+			{
+				const QRegularExpression      regex(pattern);
+				const QRegularExpressionMatch match = regex.match(sourceText);
+				if (!match.hasMatch())
+					return -1;
+				return static_cast<int>(sourceText.left(match.capturedStart()).count(QLatin1Char('\n'))) + 1;
+			};
+
+			const QStringList textEditNames = {QStringLiteral("m_connectText"),
+			                                   QStringLiteral("m_logFilePreamble"),
+			                                   QStringLiteral("m_logFilePostamble"),
+			                                   QStringLiteral("m_notes"),
+			                                   QStringLiteral("m_pastePreamble"),
+			                                   QStringLiteral("m_pastePostamble"),
+			                                   QStringLiteral("m_sendToWorldFilePreamble"),
+			                                   QStringLiteral("m_sendToWorldFilePostamble")};
+			for (const QString &editName : textEditNames)
+			{
+				const QString escaped = QRegularExpression::escape(editName);
+				const int createLine  = firstMatchLine(QStringLiteral("\\b%1\\s*=\\s*new\\b").arg(escaped));
+				const int tabLine     = firstMatchLine(
+				    QStringLiteral("\\b%1\\s*->\\s*setTabChangesFocus\\s*\\(\\s*true\\s*\\)").arg(escaped));
+
+				QVERIFY2(createLine > 0,
+				         qPrintable(QStringLiteral("No construction found for %1").arg(editName)));
+				QVERIFY2(
+				    tabLine > createLine,
+				    qPrintable(
+				        QStringLiteral("No setTabChangesFocus(true) after %1 construction.").arg(editName)));
+			}
+			QVERIFY2(sourceText.contains(QStringLiteral("words->setTabChangesFocus(true);")),
+			         "Expected Tab Completion word list editor to pass Tab to focus traversal.");
+
+			const QStringList tableNames = {QStringLiteral("m_macrosTable"),
+			                                QStringLiteral("m_variablesTable")};
+			for (const QString &tableName : tableNames)
+			{
+				const QString escaped    = QRegularExpression::escape(tableName);
+				const int     createLine = firstMatchLine(QStringLiteral("\\b%1\\s*=").arg(escaped));
+				const int     tabLine    = firstMatchLine(
+				    QStringLiteral("\\b%1\\s*->\\s*setTabKeyNavigation\\s*\\(\\s*false\\s*\\)").arg(escaped));
+
+				QVERIFY2(createLine > 0,
+				         qPrintable(QStringLiteral("No construction found for %1").arg(tableName)));
+				QVERIFY2(tabLine > createLine,
+				         qPrintable(QStringLiteral("No setTabKeyNavigation(false) after %1 construction.")
+				                        .arg(tableName)));
+			}
+		}
+
 		void scriptingNoteColourApplyUpdatesRuntimeState()
 		{
 			const QString sourcePath =

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -2373,21 +2373,30 @@ class tst_WorldView_Basic : public QObject
 			QCOMPARE(view.inputText(), QStringLiteral("look"));
 			QCOMPARE(input->textCursor().position(), view.inputText().size());
 
-			const auto sawDialog = std::make_shared<bool>(false);
-			scheduleDialogInteraction(
-			    [](const QDialog *dialog)
-			    {
-				    const auto *messageBox = qobject_cast<const QMessageBox *>(dialog);
-				    return messageBox &&
-				           messageBox->text().contains(QStringLiteral("Replace your typing of"));
-			    },
-			    [sawDialog](const QDialog *dialog)
-			    {
-				    *sawDialog = true;
-				    const_cast<QDialog *>(dialog)->reject();
-			    });
+			const auto sawDialog    = std::make_shared<bool>(false);
+			const auto keepWatching = std::make_shared<bool>(true);
+			auto       watcher      = std::make_shared<std::function<void()>>();
+			*watcher                = [watcher, sawDialog, keepWatching]
+			{
+				if (!*keepWatching)
+					return;
+				for (QWidget *widget : QApplication::topLevelWidgets())
+				{
+					auto *messageBox = qobject_cast<QMessageBox *>(widget);
+					if (!messageBox || !messageBox->text().contains(QStringLiteral("Replace your typing of")))
+						continue;
+					*sawDialog    = true;
+					*keepWatching = false;
+					messageBox->reject();
+					return;
+				}
+				QTimer::singleShot(10, qApp, [watcher] { (*watcher)(); });
+			};
+			QTimer::singleShot(0, qApp, [watcher] { (*watcher)(); });
 
 			QTest::keyClick(input, Qt::Key_F3);
+			QCoreApplication::processEvents();
+			*keepWatching = false;
 			QCoreApplication::processEvents();
 
 			QVERIFY(!*sawDialog);

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -60,45 +60,45 @@ namespace
 	using QMudOutputWrapUtils::splitOutputTextAtLineBreaks;
 	using QMudOutputWrapUtils::wrapPlainLineForColumn;
 	using QMudOutputWrapUtils::wrapStyledLineForColumn;
-	QMap<QString, QString>              g_worldAttrs;
-	QMap<QString, QString>              g_worldMultilineAttrs;
-	QMap<QString, QVariant>             g_globalOptions;
-	QVector<WorldRuntime::LineEntry>    g_runtimeLines;
-	QList<WorldRuntime::Macro>          g_testMacros;
-	WorldRuntime::TextRectangleSettings g_textRectangle;
-	int                                 g_outputFontHeight{0};
-	int                                 g_drawOutputNotifyCount{0};
-	int                                 g_lastDrawOutputFirstLine{0};
-	int                                 g_lastDrawOutputAdjustedScroll{0};
-	int                                 g_worldOutputResizedNotifyCount{0};
-	QVector<MiniWindow>                 g_testMiniWindows;
-	int                                 g_worldHotspotCallbackCount{0};
-	QString                             g_lastWorldHotspotFunction;
-	QString                             g_lastWorldHotspotId;
-	long                                g_lastWorldHotspotFlags{0};
-	bool                                g_lastWorldHotspotQueueWhenBusy{false};
-	QVector<QString>                    g_worldHotspotCallbackFunctions;
-	QVector<bool>                       g_worldHotspotCallbackQueueWhenBusy;
-	QPoint                              g_lastResizeHotspotPressOffset;
-	QSize                               g_expectedReleaseResizeSize;
-	QPoint                              g_expectedReleaseMousePosition;
-	int                                 g_resizeMoveCallbackCount{0};
-	bool                                g_releaseCallbackSawFlushedResize{false};
-	WorldView                          *g_runtimeView{nullptr};
-	unsigned short                      g_currentActionSource{WorldRuntime::eUnknownActionSource};
-	bool                                g_connected{false};
-	bool                                g_nawsNegotiated{false};
-	bool                                g_useFakeAppController{false};
-	bool                                g_hasMushReaderLiveSpeechOwner{false};
-	QHash<quint64, quint16>             g_virtualKeyMap;
-	QHash<qint64, int>                  g_acceleratorCommands;
-	int                                 g_acceleratorExecutionCount{0};
-	int                                 g_lastExecutedAcceleratorCommand{-1};
-	int                                 g_sendCommandCount{0};
-	int                                 g_executeCommandCount{0};
-	QString                             g_lastExecutedCommand;
-	bool                                g_lastUserMacroHistory{false};
-	unsigned short                      g_actionSourceDuringExecute{WorldRuntime::eUnknownActionSource};
+	QMap<QString, QString>                     g_worldAttrs;
+	QMap<QString, QString>                     g_worldMultilineAttrs;
+	QMap<QString, QVariant>                    g_globalOptions;
+	IndexedRingBuffer<WorldRuntime::LineEntry> g_runtimeLines;
+	QList<WorldRuntime::Macro>                 g_testMacros;
+	WorldRuntime::TextRectangleSettings        g_textRectangle;
+	int                                        g_outputFontHeight{0};
+	int                                        g_drawOutputNotifyCount{0};
+	int                                        g_lastDrawOutputFirstLine{0};
+	int                                        g_lastDrawOutputAdjustedScroll{0};
+	int                                        g_worldOutputResizedNotifyCount{0};
+	QVector<MiniWindow>                        g_testMiniWindows;
+	int                                        g_worldHotspotCallbackCount{0};
+	QString                                    g_lastWorldHotspotFunction;
+	QString                                    g_lastWorldHotspotId;
+	long                                       g_lastWorldHotspotFlags{0};
+	bool                                       g_lastWorldHotspotQueueWhenBusy{false};
+	QVector<QString>                           g_worldHotspotCallbackFunctions;
+	QVector<bool>                              g_worldHotspotCallbackQueueWhenBusy;
+	QPoint                                     g_lastResizeHotspotPressOffset;
+	QSize                                      g_expectedReleaseResizeSize;
+	QPoint                                     g_expectedReleaseMousePosition;
+	int                                        g_resizeMoveCallbackCount{0};
+	bool                                       g_releaseCallbackSawFlushedResize{false};
+	WorldView                                 *g_runtimeView{nullptr};
+	unsigned short                             g_currentActionSource{WorldRuntime::eUnknownActionSource};
+	bool                                       g_connected{false};
+	bool                                       g_nawsNegotiated{false};
+	bool                                       g_useFakeAppController{false};
+	bool                                       g_hasMushReaderLiveSpeechOwner{false};
+	QHash<quint64, quint16>                    g_virtualKeyMap;
+	QHash<qint64, int>                         g_acceleratorCommands;
+	int                                        g_acceleratorExecutionCount{0};
+	int                                        g_lastExecutedAcceleratorCommand{-1};
+	int                                        g_sendCommandCount{0};
+	int                                        g_executeCommandCount{0};
+	QString                                    g_lastExecutedCommand;
+	bool                                       g_lastUserMacroHistory{false};
+	unsigned short g_actionSourceDuringExecute{WorldRuntime::eUnknownActionSource};
 
 	struct AccessibleTextInsertRecord
 	{
@@ -208,7 +208,7 @@ namespace
 		return attrs;
 	}
 
-	const QVector<WorldRuntime::LineEntry> &lineStorage()
+	const IndexedRingBuffer<WorldRuntime::LineEntry> &lineStorage()
 	{
 		return g_runtimeLines;
 	}
@@ -973,7 +973,7 @@ int WorldRuntime::foregroundImageMode() const
 	return 0;
 }
 
-const QVector<WorldRuntime::LineEntry> &WorldRuntime::lines() const
+const IndexedRingBuffer<WorldRuntime::LineEntry> &WorldRuntime::lines() const
 {
 	return lineStorage();
 }
@@ -6079,6 +6079,83 @@ class tst_WorldView_Basic : public QObject
 			    measuredDelta <= 64,
 			    qPrintable(
 			        QStringLiteral("Expected local layout remeasure only, delta=%1").arg(measuredDelta)));
+			resetTestState();
+		}
+
+		void nativeOutputRendererHeadTrimKeepsLayoutGeometryAligned()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("max_output_lines"), QStringLiteral("12"));
+			g_worldAttrs.insert(QStringLiteral("wrap"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("auto_wrap_window_width"), QStringLiteral("1"));
+
+			WorldView view;
+			view.resize(420, 360);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			QCoreApplication::processEvents();
+
+			auto *nativeCanvas = view.findChild<QWidget *>(QStringLiteral("worldOutputNativeCanvas"));
+			QVERIFY(nativeCanvas);
+
+			QString firstRemainingHref;
+			for (int i = 0; i < 12; ++i)
+			{
+				const QString lineText = QStringLiteral("trim-geometry-%1 ").arg(i, 2, 10, QLatin1Char('0')) +
+				                         QString(190, QLatin1Char('g'));
+				const QString href =
+				    QStringLiteral("https://example.org/trim-geometry/%1").arg(i, 2, 10, QLatin1Char('0'));
+				if (i == 1)
+					firstRemainingHref = href;
+				WorldRuntime::StyleSpan span;
+				span.length     = boundedSizeToInt(lineText.size());
+				span.actionType = WorldRuntime::ActionHyperlink;
+				span.action     = href;
+				view.appendOutputTextStyled(lineText, {span}, true);
+			}
+
+			QTextBrowser *browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QScrollBar *scrollBar = browser->verticalScrollBar();
+			QVERIFY(scrollBar);
+			scrollBar->setValue(0);
+			nativeCanvas->update();
+			QCoreApplication::processEvents();
+
+			QTRY_COMPARE(nativeCanvas->property("qmud_native_plain_line_count").toInt(), 12);
+			const int     rebuildsBefore  = nativeCanvas->property("qmud_native_cache_full_rebuilds").toInt();
+			const int     trimDropsBefore = nativeCanvas->property("qmud_native_cache_trim_drops").toInt();
+
+			const QString tailText = QStringLiteral("trim-geometry-tail ") + QString(190, QLatin1Char('t'));
+			WorldRuntime::StyleSpan tailSpan;
+			tailSpan.length     = boundedSizeToInt(tailText.size());
+			tailSpan.actionType = WorldRuntime::ActionHyperlink;
+			tailSpan.action     = QStringLiteral("https://example.org/trim-geometry/tail");
+			view.appendOutputTextStyled(tailText, {tailSpan}, true);
+
+			scrollBar->setValue(0);
+			nativeCanvas->update();
+			QCoreApplication::processEvents();
+
+			QTRY_COMPARE(nativeCanvas->property("qmud_native_plain_line_count").toInt(), 12);
+			QTRY_COMPARE(nativeCanvas->property("qmud_native_cache_full_rebuilds").toInt(), rebuildsBefore);
+			QTRY_VERIFY(nativeCanvas->property("qmud_native_cache_trim_drops").toInt() > trimDropsBefore);
+			QVERIFY(!view.outputLines().contains(QStringLiteral("trim-geometry-00 ") +
+			                                     QString(190, QLatin1Char('g'))));
+			QVERIFY(view.outputLines().contains(QStringLiteral("trim-geometry-01 ") +
+			                                    QString(190, QLatin1Char('g'))));
+
+			const QPoint firstRemainingPoint = findHyperlinkPoint(view, *browser, firstRemainingHref);
+			QVERIFY2(firstRemainingPoint.x() >= 0 && firstRemainingPoint.y() >= 0,
+			         "Expected first remaining wrapped hyperlink to stay hittable after native head trim.");
+
+			QSignalSpy activatedSpy(&view, &WorldView::hyperlinkActivated);
+			QTest::mouseClick(browser->viewport(), Qt::LeftButton, Qt::NoModifier, firstRemainingPoint);
+			QTRY_COMPARE(activatedSpy.count(), 1);
+			QCOMPARE(QUrl::fromPercentEncoding(activatedSpy.at(0).at(0).toString().toUtf8()),
+			         firstRemainingHref);
+
 			resetTestState();
 		}
 

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -126,7 +126,14 @@ namespace
 	QVector<AccessibleAnnouncementRecord> g_accessibleAnnouncementRecords;
 	int                                   g_accessibleValueChangedCount{0};
 
-	void                                  captureAccessibleUpdate(QAccessibleEvent *event)
+	int                                   sizeToInt(const qsizetype value)
+	{
+		constexpr qsizetype kMin = 0;
+		constexpr qsizetype kMax = std::numeric_limits<int>::max();
+		return static_cast<int>(qBound(kMin, value, kMax));
+	}
+
+	void captureAccessibleUpdate(QAccessibleEvent *event)
 	{
 		if (!event)
 			return;
@@ -1405,6 +1412,310 @@ class tst_WorldView_Basic : public QObject
 				QVERIFY(!view.outputLines().isEmpty());
 
 			resetTestState();
+		}
+
+		void nativeLayoutHeightIndexRangeUpdateMaintainsBlockSums()
+		{
+			WorldView::NativeLayoutHeightIndex heightIndex;
+			constexpr int                      blockSize   = WorldView::NativeLayoutHeightIndex::kBlockSize;
+			constexpr int                      lineCount   = blockSize * 2 + 17;
+			constexpr qreal                    lineAdvance = 10.0;
+			IndexedRingBuffer<WorldView::NativeLayoutSlot> layoutSlots(lineCount);
+			for (WorldView::NativeLayoutSlot &slot : layoutSlots)
+				slot.visualRows = 1;
+
+			heightIndex.assign(lineCount, lineAdvance);
+			QCOMPARE(heightIndex.totalHeight(), static_cast<qreal>(lineCount) * lineAdvance);
+
+			for (int line = 8; line < 14; ++line)
+				layoutSlots[line].visualRows = 2;
+			heightIndex.setLayoutSlotHeightRange(8, 14, layoutSlots, lineAdvance);
+			QCOMPARE(heightIndex.heightAt(7), lineAdvance);
+			QCOMPARE(heightIndex.heightAt(8), lineAdvance * 2.0);
+			QCOMPARE(heightIndex.prefixHeightAt(14), (static_cast<qreal>(14) + 6.0) * lineAdvance);
+
+			const qreal afterSingleBlockUpdate = heightIndex.totalHeight();
+			heightIndex.setLayoutSlotHeightRange(8, 14, layoutSlots, lineAdvance);
+			QCOMPARE(heightIndex.totalHeight(), afterSingleBlockUpdate);
+
+			for (int line = blockSize - 2; line < blockSize + 3; ++line)
+				layoutSlots[line].visualRows = 3;
+			heightIndex.setLayoutSlotHeightRange(blockSize - 2, blockSize + 3, layoutSlots, lineAdvance);
+			QCOMPARE(heightIndex.heightAt(blockSize - 3), lineAdvance);
+			QCOMPARE(heightIndex.heightAt(blockSize - 2), lineAdvance * 3.0);
+			QCOMPARE(heightIndex.heightAt(blockSize + 2), lineAdvance * 3.0);
+
+			for (int line = blockSize + 10; line < blockSize + 14; ++line)
+				layoutSlots[line].visualRows = 4;
+			heightIndex.setLayoutSlotHeightRange(blockSize + 11, blockSize + 13, layoutSlots, lineAdvance);
+			QCOMPARE(heightIndex.heightAt(blockSize + 10), lineAdvance);
+			QCOMPARE(heightIndex.heightAt(blockSize + 11), lineAdvance * 4.0);
+			QCOMPARE(heightIndex.heightAt(blockSize + 12), lineAdvance * 4.0);
+			QCOMPARE(heightIndex.heightAt(blockSize + 13), lineAdvance);
+
+			qreal expectedTotal = static_cast<qreal>(lineCount) * lineAdvance;
+			expectedTotal += 6.0 * lineAdvance;
+			expectedTotal += 5.0 * 2.0 * lineAdvance;
+			expectedTotal += 2.0 * 3.0 * lineAdvance;
+			QCOMPARE(heightIndex.totalHeight(), expectedTotal);
+			QCOMPARE(heightIndex.lineAtY(heightIndex.prefixHeightAt(blockSize + 12)), blockSize + 12);
+		}
+
+		void nativeLayoutHeightIndexRemoveFrontMaintainsBlockSums()
+		{
+			WorldView::NativeLayoutHeightIndex heightIndex;
+			constexpr int                      blockSize   = WorldView::NativeLayoutHeightIndex::kBlockSize;
+			constexpr int                      lineCount   = blockSize * 3 + 19;
+			constexpr qreal                    lineAdvance = 10.0;
+			heightIndex.assign(lineCount, lineAdvance);
+			heightIndex.removeFront(blockSize + 7);
+
+			constexpr int expectedCount = lineCount - blockSize - 7;
+			QCOMPARE(sizeToInt(heightIndex.size()), expectedCount);
+			QCOMPARE(heightIndex.totalHeight(), static_cast<qreal>(expectedCount) * lineAdvance);
+			QCOMPARE(heightIndex.prefixHeightAt(17), 17.0 * lineAdvance);
+			QCOMPARE(heightIndex.lineAtY(heightIndex.prefixHeightAt(blockSize + 3)), blockSize + 3);
+
+			heightIndex.removeFront(blockSize - 11);
+			constexpr int secondExpectedCount = expectedCount - blockSize + 11;
+			QCOMPARE(sizeToInt(heightIndex.size()), secondExpectedCount);
+			QCOMPARE(heightIndex.totalHeight(), static_cast<qreal>(secondExpectedCount) * lineAdvance);
+			QCOMPARE(heightIndex.prefixHeightAt(secondExpectedCount), heightIndex.totalHeight());
+		}
+
+		void nativeLayoutConsumesQueuedRenderDeltasWithoutReset()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("queued-delta-0"), 1));
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("queued-delta-1"), 2));
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("queued-delta-2"), 3));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 3);
+
+			view.m_nativeLayoutSlots[0].rowsExact = 1;
+
+			int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("queued-delta-3"), 4));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::TailAppend,
+			                                       oldLineCount);
+			oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("queued-delta-4"), 5));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::TailAppend,
+			                                       oldLineCount);
+
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 2);
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 0);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 5);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(0).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutSlots.at(3).runtimeLineKey,
+			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(3)));
+			QCOMPARE(view.m_nativeLayoutSlots.at(4).runtimeLineKey,
+			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(4)));
+		}
+
+		void nativeLayoutConsumesQueuedRuntimeRangeRestitchWithoutReset()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 6; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("range-restitch-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 6);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[1].visualRows = 11;
+			view.m_nativeLayoutSlots[2].visualRows = 12;
+			view.m_nativeLayoutSlots[5].visualRows = 15;
+			view.m_nativeLayoutHeightIndex.setHeight(1, 11.0 * lineAdvance);
+			view.m_nativeLayoutHeightIndex.setHeight(2, 12.0 * lineAdvance);
+			view.m_nativeLayoutHeightIndex.setHeight(5, 15.0 * lineAdvance);
+
+			const int                          oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			WorldView::NativeOutputRenderLines restitchedLines;
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-old-1"), 2));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-old-2"), 3));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-new"), 99));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-old-5"), 6));
+			view.m_nativeRenderLineCache = std::move(restitchedLines);
+			view.bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(oldLineCount, true, 1, 2, false, 2, 2,
+			                                                           1);
+
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 1);
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 0);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 4);
+			QCOMPARE(view.m_nativeLayoutSlots.at(0).visualRows, 11);
+			QCOMPARE(view.m_nativeLayoutSlots.at(1).visualRows, 12);
+			QCOMPARE(view.m_nativeLayoutSlots.at(3).visualRows, 15);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(0), 11.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(1), 12.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(3), 15.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutSlots.at(2).runtimeLineKey,
+			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(2)));
+		}
+
+		void nativeLayoutConsumesQueuedRuntimeLineRestitchWithoutReset()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("line-restitch-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 5);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[1].visualRows = 11;
+			view.m_nativeLayoutSlots[1].rowsExact  = 1;
+			view.m_nativeLayoutSlots[3].visualRows = 13;
+			view.m_nativeLayoutSlots[3].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(1, 11.0 * lineAdvance);
+			view.m_nativeLayoutHeightIndex.setHeight(3, 13.0 * lineAdvance);
+
+			const int oldLineCount               = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache[2].text = QStringLiteral("line-restitch-new");
+			view.m_nativeRenderLineCache[2].firstRuntimeLineNumber = 30;
+			view.m_nativeRenderLineCache[2].lastRuntimeLineNumber  = 30;
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::RuntimeLineRestitch,
+			                                       oldLineCount, false, 0, 2);
+
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 1);
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 0);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 5);
+			QCOMPARE(view.m_nativeLayoutSlots.at(1).visualRows, 11);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(1).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutSlots.at(3).visualRows, 13);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(3).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(1), 11.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(3), 13.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutSlots.at(2).runtimeLineKey,
+			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(2)));
+			QCOMPARE(view.m_nativeLayoutSlots.at(2).visualRows, 1);
+		}
+
+		void nativeLayoutConsumesMixedQueuedDeltasWithoutReset()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 6; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("mixed-delta-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 6);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[2].visualRows = 12;
+			view.m_nativeLayoutSlots[2].rowsExact  = 1;
+			view.m_nativeLayoutSlots[3].visualRows = 13;
+			view.m_nativeLayoutSlots[3].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(2, 12.0 * lineAdvance);
+			view.m_nativeLayoutHeightIndex.setHeight(3, 13.0 * lineAdvance);
+
+			int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 2);
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("mixed-delta-tail-6"), 7));
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("mixed-delta-tail-7"), 8));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 2);
+
+			oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			WorldView::NativeOutputRenderLines restitchedLines;
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("mixed-delta-old-2"), 3));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("mixed-delta-old-3"), 4));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("mixed-delta-new-a"), 90));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("mixed-delta-new-b"), 91));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("mixed-delta-new-c"), 92));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("mixed-delta-tail-6"), 7));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("mixed-delta-tail-7"), 8));
+			view.m_nativeRenderLineCache = std::move(restitchedLines);
+			view.bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(oldLineCount, false, 0, 2, false, 2, 2,
+			                                                           3);
+
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 2);
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 0);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 7);
+			QCOMPARE(view.m_nativeLayoutSlots.at(0).visualRows, 12);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(0).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutSlots.at(1).visualRows, 13);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(1).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(0), 12.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(1), 13.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutSlots.at(2).runtimeLineKey,
+			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(2)));
+			QCOMPARE(view.m_nativeLayoutSlots.at(5).runtimeLineKey,
+			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(5)));
+			QCOMPARE(view.m_nativeLayoutSlots.at(6).runtimeLineKey,
+			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(6)));
 		}
 
 		void constructAndBasicInputOutputSmoke()
@@ -3377,6 +3688,122 @@ class tst_WorldView_Basic : public QObject
 
 			const QString afterAnchorWord = selectAnchorWord();
 			QCOMPARE(afterAnchorWord, beforeAnchorWord);
+			resetTestState();
+		}
+
+		void selectionPersistsDuringCappedPluginPromptCycles()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("max_output_lines"), QStringLiteral("80"));
+
+			WorldView view;
+			view.resize(540, 420);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			QCoreApplication::processEvents();
+
+			for (int i = 0; i < 80; ++i)
+				view.appendOutputText(QStringLiteral("select-plugin-anchor-%1").arg(i), true);
+			QCoreApplication::processEvents();
+
+			const QStringList lines = view.outputLines();
+			QVERIFY(lines.size() >= 68);
+			constexpr int  selectedLineIndex = 64;
+			const QString &selectedText      = lines.at(selectedLineIndex);
+			view.selectOutputRange(selectedLineIndex, 0, sizeToInt(selectedText.size()));
+			QTRY_COMPARE(view.outputSelectionText(), selectedText);
+
+			for (int cycle = 0; cycle < 6; ++cycle)
+			{
+				view.appendOutputText(QStringLiteral("select-plugin-room-%1").arg(cycle), true);
+				view.updatePartialOutputText(QStringLiteral("<select-plugin-prompt-%1> ").arg(cycle));
+				view.appendNoteText(QStringLiteral("W"), false);
+				view.appendNoteText(QStringLiteral(" <---("), false);
+				view.appendNoteText(QStringLiteral("M"), false);
+				view.appendNoteText(QStringLiteral(")---> "), false);
+				view.appendNoteText(QStringLiteral("E"), true);
+				view.updatePartialOutputText(QStringLiteral("<select-plugin-prompt-%1> ").arg(cycle));
+				view.appendOutputText(QStringLiteral("<select-plugin-prompt-%1> look").arg(cycle), true);
+				QCoreApplication::processEvents();
+			}
+
+			QTRY_VERIFY(view.hasOutputSelection());
+			QTRY_COMPARE(view.outputSelectionText(), selectedText);
+			QVERIFY(view.outputLines().contains(selectedText));
+			resetTestState();
+		}
+
+		void splitTopSelectionPersistsDuringCappedPluginPromptCycles()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("auto_pause"), QStringLiteral("1"));
+			g_worldAttrs.insert(QStringLiteral("max_output_lines"), QStringLiteral("80"));
+
+			WorldView view;
+			view.resize(540, 420);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			QCoreApplication::processEvents();
+
+			for (int i = 0; i < 80; ++i)
+				view.appendOutputText(QStringLiteral("split-select-plugin-anchor-%1").arg(i), true);
+			QCoreApplication::processEvents();
+
+			QTextBrowser *topBrowser = findVisibleOutputBrowser(view);
+			QVERIFY(topBrowser);
+			const QPointF localPos(topBrowser->viewport()->rect().center());
+			const QPointF globalPos(topBrowser->viewport()->mapToGlobal(localPos.toPoint()));
+			QWheelEvent   wheelUp(localPos, globalPos, QPoint(0, 0), QPoint(0, 120), Qt::NoButton,
+			                      Qt::NoModifier, Qt::NoScrollPhase, false);
+			QCoreApplication::sendEvent(topBrowser->viewport(), &wheelUp);
+			QCoreApplication::processEvents();
+			QTRY_VERIFY(view.isScrollbackSplitActive());
+
+			const auto [splitTop, splitBottom] = findSplitOutputBrowsers(view);
+			QVERIFY(splitTop);
+			QVERIFY(splitBottom);
+			QScrollBar *topBar = splitTop->verticalScrollBar();
+			QVERIFY(topBar);
+			topBar->setValue(topBar->maximum());
+			QCoreApplication::processEvents();
+
+			const QVector<QPoint> points{
+			    QPoint(24, qMax(8, splitTop->viewport()->rect().height() / 4)),
+			    splitTop->viewport()->rect().center(),
+			    QPoint(24, qMax(8, (splitTop->viewport()->rect().height() * 3) / 4)),
+			};
+			QString selectedText;
+			for (const QPoint &point : points)
+			{
+				QTest::mouseDClick(splitTop->viewport(), Qt::LeftButton, Qt::NoModifier, point);
+				QCoreApplication::processEvents();
+				if (view.outputSelectionText().startsWith(QStringLiteral("split-select-plugin-anchor-")))
+				{
+					selectedText = view.outputSelectionText();
+					break;
+				}
+			}
+			QVERIFY(selectedText.startsWith(QStringLiteral("split-select-plugin-anchor-")));
+
+			for (int cycle = 0; cycle < 6; ++cycle)
+			{
+				view.appendOutputText(QStringLiteral("split-select-plugin-room-%1").arg(cycle), true);
+				view.updatePartialOutputText(QStringLiteral("<split-select-plugin-prompt-%1> ").arg(cycle));
+				view.appendNoteText(QStringLiteral("W"), false);
+				view.appendNoteText(QStringLiteral(" <---("), false);
+				view.appendNoteText(QStringLiteral("M"), false);
+				view.appendNoteText(QStringLiteral(")---> "), false);
+				view.appendNoteText(QStringLiteral("E"), true);
+				view.updatePartialOutputText(QStringLiteral("<split-select-plugin-prompt-%1> ").arg(cycle));
+				view.appendOutputText(QStringLiteral("<split-select-plugin-prompt-%1> look").arg(cycle),
+				                      true);
+				QCoreApplication::processEvents();
+			}
+
+			QTRY_VERIFY(view.hasOutputSelection());
+			QTRY_COMPARE(view.outputSelectionText(), selectedText);
 			resetTestState();
 		}
 
@@ -5892,6 +6319,60 @@ class tst_WorldView_Basic : public QObject
 				QTRY_COMPARE(nativeCanvas->property("qmud_native_plain_last_line").toString(),
 				             QStringLiteral("<partial-prompt-%1> look").arg(cycle));
 			}
+			resetTestState();
+		}
+
+		void nativeOutputPaintSynchronizesPendingPromptPluginRestitch()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("max_output_lines"), QStringLiteral("14"));
+
+			WorldView view;
+			view.resize(700, 420);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.applyRuntimeSettings();
+			QCoreApplication::processEvents();
+
+			auto *nativeCanvas = view.findChild<QWidget *>(QStringLiteral("worldOutputNativeCanvas"));
+			QVERIFY(nativeCanvas);
+
+			for (int i = 0; i < 14; ++i)
+				view.appendOutputText(QStringLiteral("paint-sync-primer-%1").arg(i), true);
+			QCoreApplication::processEvents();
+			QVERIFY(!nativeCanvas->grab().isNull());
+			QTRY_COMPARE(nativeCanvas->property("qmud_native_plain_last_line").toString(),
+			             QStringLiteral("paint-sync-primer-13"));
+
+			view.appendOutputText(QStringLiteral("paint-sync-room"), true);
+			view.appendOutputText(QStringLiteral("<paint-sync-prompt> look"), true);
+			QCoreApplication::processEvents();
+			QVERIFY(!nativeCanvas->grab().isNull());
+			QTRY_COMPARE(nativeCanvas->property("qmud_native_plain_last_line").toString(),
+			             QStringLiteral("<paint-sync-prompt> look"));
+
+			const int promptIndex = sizeToInt(g_runtimeLines.size()) - 1;
+			QVERIFY(promptIndex >= 0);
+
+			WorldRuntime::LineEntry compassLine;
+			compassLine.text       = QStringLiteral("W <---(M)---> E");
+			compassLine.flags      = WorldRuntime::LineNote;
+			compassLine.hardReturn = true;
+			compassLine.time       = QDateTime::currentDateTime();
+			compassLine.lineNumber = g_runtimeLines.constLast().lineNumber + 1;
+			g_runtimeLines.insert(g_runtimeLines.begin() + promptIndex, compassLine);
+			const int insertedCount = sizeToInt(g_runtimeLines.size());
+			enforceFakeOutputLineLimit();
+			const int removedHeadCount = qMax(0, insertedCount - sizeToInt(g_runtimeLines.size()));
+			const int changedIndex =
+			    qBound(0, promptIndex - removedHeadCount, sizeToInt(g_runtimeLines.size()) - 1);
+			view.notifyRuntimeOutputRangeChanged(changedIndex);
+
+			QVERIFY(!nativeCanvas->grab().isNull());
+			const QStringList tailLines =
+			    nativeCanvas->property("qmud_native_plain_tail_lines").toStringList();
+			QVERIFY(tailLines.contains(QStringLiteral("W <---(M)---> E")));
+			QCOMPARE(tailLines.constLast(), QStringLiteral("<paint-sync-prompt> look"));
 			resetTestState();
 		}
 

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -99,6 +99,8 @@ namespace
 	QString                                    g_lastExecutedCommand;
 	bool                                       g_lastUserMacroHistory{false};
 	unsigned short g_actionSourceDuringExecute{WorldRuntime::eUnknownActionSource};
+	QString        g_wordUnderMenu;
+	bool           g_wordUnderMenuResolved{false};
 
 	struct AccessibleTextInsertRecord
 	{
@@ -272,6 +274,8 @@ namespace
 		g_lastExecutedCommand.clear();
 		g_lastUserMacroHistory      = false;
 		g_actionSourceDuringExecute = WorldRuntime::eUnknownActionSource;
+		g_wordUnderMenu.clear();
+		g_wordUnderMenuResolved = false;
 		g_accessibleTextInsertRecords.clear();
 		g_accessibleTextUpdateRecords.clear();
 		g_accessibleAnnouncementRecords.clear();
@@ -1016,6 +1020,20 @@ WorldView *WorldRuntime::view() const
 	return g_runtimeView;
 }
 
+WorldRuntime::CommandUiSnapshot WorldRuntime::commandUiSnapshot(bool, bool, bool) const
+{
+	CommandUiSnapshot snapshot;
+	if (!g_runtimeView)
+		return snapshot;
+
+	snapshot.hasView                    = true;
+	snapshot.outputSelectionEndColumn   = g_runtimeView->outputSelectionEndColumn();
+	snapshot.outputSelectionEndLine     = g_runtimeView->outputSelectionEndLine();
+	snapshot.outputSelectionStartColumn = g_runtimeView->outputSelectionStartColumn();
+	snapshot.outputSelectionStartLine   = g_runtimeView->outputSelectionStartLine();
+	return snapshot;
+}
+
 void WorldRuntime::installPendingPlugins()
 {
 }
@@ -1126,8 +1144,20 @@ bool WorldRuntime::callWorldHotspotFunction(const QString &functionName, long fl
 	return true;
 }
 
-void WorldRuntime::setWordUnderMenu(const QString &, bool)
+void WorldRuntime::setWordUnderMenu(const QString &value, const bool resolved)
 {
+	g_wordUnderMenu         = value;
+	g_wordUnderMenuResolved = resolved;
+}
+
+QString WorldRuntime::wordUnderMenu() const
+{
+	return g_wordUnderMenu;
+}
+
+bool WorldRuntime::wordUnderMenuResolved() const
+{
+	return g_wordUnderMenuResolved;
 }
 
 void WorldRuntime::notifyMiniWindowMouseMoved(int, int, const QString &)
@@ -1590,6 +1620,66 @@ class tst_WorldView_Basic : public QObject
 			         WorldView::nativeRuntimeLineKey(view.m_nativeRenderLineCache.at(2)));
 		}
 
+		void nativeLayoutRejectsInvalidRangePreparedRuntimeRangeRestitch()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 6; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("range-restitch-invalid-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[0].visualRows = 9;
+			view.m_nativeLayoutSlots[0].rowsExact  = 1;
+			view.m_nativeLayoutSlots[1].visualRows = 11;
+			view.m_nativeLayoutSlots[1].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(0, 9.0 * lineAdvance);
+			view.m_nativeLayoutHeightIndex.setHeight(1, 11.0 * lineAdvance);
+
+			const int                          oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			WorldView::NativeOutputRenderLines restitchedLines;
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-invalid-old-1"), 2));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-invalid-old-2"), 3));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-invalid-new"), 99));
+			restitchedLines.push_back(makeRenderLine(QStringLiteral("range-restitch-invalid-old-5"), 6));
+			view.m_nativeRenderLineCache = std::move(restitchedLines);
+			view.bumpNativeRuntimeRangeRestitchRenderLineCacheRevision(oldLineCount, false, 1, 1, false, 1, 1,
+			                                                           1);
+			view.m_nativeSplitTopHeadTrimPixelsRevision = view.m_nativeRenderLineCacheRevision;
+			view.m_nativeSplitTopHeadTrimPixels         = 123;
+			view.m_nativeSplitTopHeadTrimLines          = 1;
+
+			QVERIFY(
+			    view.prepareNativeLayoutRangeState(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont));
+
+			QVERIFY(view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(view.m_nativeLayoutRangePreparedRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(sizeToInt(view.m_nativeLayoutHeightIndex.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(view.m_nativeLayoutSlots.at(0).visualRows, -1);
+			QCOMPARE(view.m_nativeLayoutSlots.at(1).visualRows, -1);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
 		void nativeLayoutConsumesQueuedRuntimeLineRestitchWithoutReset()
 		{
 			WorldView view;
@@ -1646,6 +1736,832 @@ class tst_WorldView_Basic : public QObject
 			QCOMPARE(view.m_nativeLayoutSlots.at(2).visualRows, 1);
 		}
 
+		void nativeOutputSelectionBoundsRemapPendingRenderDeltasWithoutLayoutSync()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.appendOutputText(QStringLiteral("selection-snapshot-old-%1").arg(i), true);
+			static_cast<void>(view.nativeOutputRenderLines());
+
+			view.selectOutputRange(2, 0, 24);
+			QCOMPARE(view.outputSelectionStartLine(), 3);
+			QCOMPARE(view.outputSelectionEndLine(), 3);
+
+			const int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 2);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("selection-snapshot-tail-5"), 6));
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("selection-snapshot-tail-6"), 7));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 2);
+
+			const quint64 layoutRevisionBefore = view.m_nativeLayoutCachedRenderRevision;
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 2);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 1);
+
+			QSignalSpy selectionChangedSpy(&view, &WorldView::outputSelectionChanged);
+			QCOMPARE(view.outputSelectionStartLine(), 1);
+			QCOMPARE(view.outputSelectionEndLine(), 1);
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 2);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 1);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, layoutRevisionBefore);
+			QCOMPARE(view.outputSelectionText(), QStringLiteral("selection-snapshot-old-2"));
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 2);
+			QCOMPARE(selectionChangedSpy.size(), 0);
+
+			static_cast<void>(view.synchronizeNativeRuntimeOutputPresentation(false, false));
+			QCOMPARE(selectionChangedSpy.size(), 1);
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 0);
+			QCOMPARE(view.outputSelectionStartLine(), 1);
+			QCOMPARE(view.outputSelectionEndLine(), 1);
+			QCOMPARE(view.outputSelectionText(), QStringLiteral("selection-snapshot-old-2"));
+		}
+
+		void nativeOutputSelectionCollapseAfterRemapCommitsNoSelection()
+		{
+			WorldView view;
+
+			for (int i = 0; i < 5; ++i)
+				view.appendOutputText(QStringLiteral("selection-collapse-old-%1").arg(i), true);
+			static_cast<void>(view.nativeOutputRenderLines());
+
+			view.selectOutputRange(2, 4, 18);
+			QCOMPARE(view.outputSelectionStartLine(), 3);
+			QCOMPARE(view.outputSelectionEndLine(), 3);
+			QCOMPARE(view.m_hasOutputSelection, true);
+
+			const int oldLineCount               = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache[2].text = QStringLiteral("x");
+			view.m_nativeRenderLineCache[2].spans.clear();
+			view.m_nativeRenderLineCache[2].visualHash = 0;
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::RuntimeLineRestitch,
+			                                       oldLineCount, false, 0, 2);
+
+			QSignalSpy selectionChangedSpy(&view, &WorldView::outputSelectionChanged);
+			static_cast<void>(view.synchronizeNativeRuntimeOutputPresentation(false, false));
+
+			QCOMPARE(selectionChangedSpy.size(), 1);
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 0);
+			QCOMPARE(view.m_nativeOutputSelection.hasSelection, false);
+			QCOMPARE(view.m_hasOutputSelection, false);
+			QCOMPARE(view.outputSelectionStartLine(), 0);
+			QCOMPARE(view.outputSelectionEndLine(), 0);
+			QCOMPARE(view.outputSelectionText(), QString());
+		}
+
+		void commandUiSnapshotSelectionBoundsRemapPendingRenderDeltasWithoutLayoutSync()
+		{
+			WorldView view;
+			fakeRuntimePointer()->setView(&view);
+			auto makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.appendOutputText(QStringLiteral("runtime-selection-snapshot-old-%1").arg(i), true);
+			static_cast<void>(view.nativeOutputRenderLines());
+
+			view.selectOutputRange(2, 0, 32);
+			const WorldRuntime::CommandUiSnapshot initialSnapshot =
+			    fakeRuntimePointer()->commandUiSnapshot(false, false, false);
+			QVERIFY(initialSnapshot.hasView);
+			QCOMPARE(initialSnapshot.outputSelectionStartLine, 3);
+			QCOMPARE(initialSnapshot.outputSelectionEndLine, 3);
+
+			const int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 2);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("runtime-selection-snapshot-tail-5"), 6));
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("runtime-selection-snapshot-tail-6"), 7));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 2);
+
+			const quint64 layoutRevisionBefore = view.m_nativeLayoutCachedRenderRevision;
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 2);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 1);
+
+			const WorldRuntime::CommandUiSnapshot pendingSnapshot =
+			    fakeRuntimePointer()->commandUiSnapshot(false, false, false);
+			QVERIFY(pendingSnapshot.hasView);
+			QCOMPARE(pendingSnapshot.outputSelectionStartLine, 1);
+			QCOMPARE(pendingSnapshot.outputSelectionEndLine, 1);
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 2);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 1);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, layoutRevisionBefore);
+			QCOMPARE(view.outputSelectionText(), QStringLiteral("runtime-selection-snapshot-old-2"));
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 2);
+
+			static_cast<void>(view.synchronizeNativeRuntimeOutputPresentation(false, false));
+			const WorldRuntime::CommandUiSnapshot remappedSnapshot =
+			    fakeRuntimePointer()->commandUiSnapshot(false, false, false);
+			QCOMPARE(view.m_nativeSelectionPendingHeadTrimLines, 0);
+			QCOMPARE(remappedSnapshot.outputSelectionStartLine, 1);
+			QCOMPARE(remappedSnapshot.outputSelectionEndLine, 1);
+			QCOMPARE(view.outputSelectionText(), QStringLiteral("runtime-selection-snapshot-old-2"));
+			fakeRuntimePointer()->setView(nullptr);
+		}
+
+		void nativeOutputHitTestUsesRangeLayoutWithoutFullCacheSync()
+		{
+			resetTestState();
+
+			WorldView view;
+			view.resize(720, 420);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			QCoreApplication::processEvents();
+
+			for (int i = 0; i < 96; ++i)
+				view.appendOutputText(
+				    QStringLiteral("hit-test-range-layout-%1").arg(i, 3, 10, QLatin1Char('0')), true);
+
+			const WorldView::NativeOutputRenderLines &initialLines = view.nativeOutputRenderLines();
+			QVERIFY(!initialLines.isEmpty());
+			auto *const browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QVERIFY(browser->viewport());
+
+			QRect viewportRect = browser->viewport()->rect();
+			QVERIFY(!viewportRect.isEmpty());
+			constexpr bool wrapEnabled     = true;
+			int            wrapWidthPixels = view.nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
+			int localWrapWidthPixels = view.nativeLocalWrapWidthPixels(viewportRect.width(), wrapEnabled);
+			const int   lineSpacing  = qMax(0, view.m_lineSpacing);
+			const QFont layoutFont   = browser->font();
+
+			view.ensureNativeLayoutCaches(initialLines, wrapWidthPixels, localWrapWidthPixels, lineSpacing,
+			                              layoutFont);
+			static_cast<void>(view.ensureNativeLayoutRange(initialLines, 0, 8, wrapWidthPixels,
+			                                               localWrapWidthPixels, lineSpacing, layoutFont));
+			QVERIFY(view.m_nativeLayoutSlots.at(0).rowsExact != 0);
+			QVERIFY(view.nativeLayoutCacheReadyFor(initialLines, wrapWidthPixels, localWrapWidthPixels,
+			                                       lineSpacing, layoutFont));
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), sizeToInt(initialLines.size()));
+
+			const int                         resetsBefore         = view.m_nativeLayoutCacheResets;
+			const int                         measurementsBefore   = view.m_nativeLayoutRowMeasurements;
+			const quint64                     cachedRevisionBefore = view.m_nativeLayoutCachedRenderRevision;
+			WorldView::NativeOutputRenderLine tailLine;
+			tailLine.text                   = QStringLiteral("hit-test-range-layout-tail");
+			tailLine.opacity                = 1.0;
+			tailLine.firstRuntimeLineNumber = 97;
+			tailLine.lastRuntimeLineNumber  = 97;
+			tailLine.flags                  = WorldRuntime::LineOutput;
+			const int oldLineCount          = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 2);
+			view.m_nativeRenderLineCache.push_back(std::move(tailLine));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 2);
+			QCOMPARE(view.m_nativeRenderCacheDelta.fromRevision, cachedRevisionBefore);
+			QCOMPARE(view.m_nativeRenderCacheDelta.oldLineCount, oldLineCount);
+			QCOMPARE(view.m_nativeRenderCacheDelta.newLineCount, oldLineCount - 1);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), oldLineCount);
+
+			WorldView::NativeOutputPosition position;
+			const QPoint                    hitPoint = viewportRect.center();
+			QVERIFY(view.nativeOutputHitTest(reinterpret_cast<WrapTextBrowser *>(browser), hitPoint, position,
+			                                 nullptr, nullptr, true));
+
+			QCOMPARE(view.m_nativeLayoutCacheResets, resetsBefore);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, cachedRevisionBefore);
+			QCOMPARE(view.m_nativeLayoutRangePreparedRevision, view.m_nativeRenderLineCacheRevision);
+			QVERIFY(view.m_nativeLayoutRangePreparedOnly);
+			QVERIFY(!view.m_nativeRenderCacheDeltas.isEmpty());
+			QVERIFY(view.m_nativeLayoutRowMeasurements <= measurementsBefore + 6);
+			QVERIFY(position.line >= 0);
+			QVERIFY(position.line < view.m_nativeRenderLineCache.size());
+
+			wrapWidthPixels               = view.m_nativeLayoutCachedWrapWidth;
+			localWrapWidthPixels          = view.m_nativeLayoutCachedLocalWrapWidth;
+			const QFont rangePreparedFont = view.m_nativeLayoutCachedFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, wrapWidthPixels, localWrapWidthPixels,
+			                              lineSpacing, rangePreparedFont);
+			QCOMPARE(view.m_nativeLayoutCacheResets, resetsBefore);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QVERIFY(!view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void nativeOutputCharacterRectUsesRangeLayoutWithoutFullCacheSync()
+		{
+			resetTestState();
+
+			WorldView view;
+			view.resize(720, 420);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			QCoreApplication::processEvents();
+
+			for (int i = 0; i < 24; ++i)
+				view.appendOutputText(
+				    QStringLiteral("character-rect-range-layout-%1").arg(i, 2, 10, QLatin1Char('0')), true);
+
+			const WorldView::NativeOutputRenderLines &initialLines = view.nativeOutputRenderLines();
+			QVERIFY(!initialLines.isEmpty());
+			auto *const browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QVERIFY(browser->viewport());
+
+			const QRect viewportRect = browser->viewport()->rect();
+			QVERIFY(!viewportRect.isEmpty());
+			constexpr bool wrapEnabled     = true;
+			const int      wrapWidthPixels = view.nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
+			const int      localWrapWidthPixels =
+			    view.nativeLocalWrapWidthPixels(viewportRect.width(), wrapEnabled);
+			const int   lineSpacing = qMax(0, view.m_lineSpacing);
+			const QFont layoutFont  = browser->font();
+			view.ensureNativeLayoutCaches(initialLines, wrapWidthPixels, localWrapWidthPixels, lineSpacing,
+			                              layoutFont);
+			QVERIFY(view.nativeLayoutCacheReadyFor(initialLines, wrapWidthPixels, localWrapWidthPixels,
+			                                       lineSpacing, layoutFont));
+
+			WorldView::NativeOutputRenderLine tailLine;
+			tailLine.text                      = QStringLiteral("character-rect-range-layout-tail");
+			tailLine.opacity                   = 1.0;
+			tailLine.firstRuntimeLineNumber    = 25;
+			tailLine.lastRuntimeLineNumber     = 25;
+			tailLine.flags                     = WorldRuntime::LineOutput;
+			const int     oldLineCount         = sizeToInt(view.m_nativeRenderLineCache.size());
+			const int     resetsBefore         = view.m_nativeLayoutCacheResets;
+			const quint64 cachedRevisionBefore = view.m_nativeLayoutCachedRenderRevision;
+			view.m_nativeRenderLineCache.push_back(std::move(tailLine));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::TailAppend,
+			                                       oldLineCount, false);
+
+			QRect globalRect;
+			QVERIFY(view.nativeOutputCharacterRect(reinterpret_cast<WrapTextBrowser *>(browser), {0, 0},
+			                                       globalRect));
+			QVERIFY(!globalRect.isEmpty());
+			QCOMPARE(view.m_nativeLayoutCacheResets, resetsBefore);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, cachedRevisionBefore);
+			QVERIFY(view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(view.m_nativeLayoutRangePreparedRevision, view.m_nativeRenderLineCacheRevision);
+
+			resetTestState();
+		}
+
+		void nativeLayoutReplaysFromRangePreparedRevisionWithoutReset()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 6; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("range-prepared-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 6);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[2].visualRows = 12;
+			view.m_nativeLayoutSlots[2].rowsExact  = 1;
+			view.m_nativeLayoutSlots[3].visualRows = 13;
+			view.m_nativeLayoutSlots[3].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(2, 12.0 * lineAdvance);
+			view.m_nativeLayoutHeightIndex.setHeight(3, 13.0 * lineAdvance);
+			const int expectedHeadTrimPixels =
+			    qMax(1, static_cast<int>(std::round(view.nativeLayoutCumulativeHeightAt(2))));
+
+			const quint64 exactRevisionBeforeRangePrep = view.m_nativeLayoutCachedRenderRevision;
+			const int     resetsBefore                 = view.m_nativeLayoutCacheResets;
+			int           oldLineCount                 = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 2);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("range-prepared-tail-6"), 7));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 2);
+
+			QVERIFY(
+			    view.prepareNativeLayoutRangeState(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont));
+			QVERIFY(view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, exactRevisionBeforeRangePrep);
+			QCOMPARE(view.m_nativeLayoutRangePreparedRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 5);
+			QCOMPARE(view.m_nativeLayoutSlots.at(0).visualRows, 12);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(0).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(0), 12.0 * lineAdvance);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, expectedHeadTrimPixels);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 2);
+
+			const quint64 rangePreparedRevision = view.m_nativeLayoutRangePreparedRevision;
+			oldLineCount                        = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("range-prepared-tail-7"), 8));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::TailAppend,
+			                                       oldLineCount);
+			QCOMPARE(view.m_nativeLayoutRangePreparedRevision, rangePreparedRevision);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, expectedHeadTrimPixels);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 2);
+			QCOMPARE(view.m_nativeRenderCacheDelta.headTrimCount, 0);
+
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+
+			QCOMPARE(view.m_nativeLayoutCacheResets, resetsBefore);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QVERIFY(!view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 0);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 6);
+			QCOMPARE(view.m_nativeLayoutSlots.at(0).visualRows, 12);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(0).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutSlots.at(1).visualRows, 13);
+			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(1).rowsExact), 1);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(0), 12.0 * lineAdvance);
+			QCOMPARE(view.m_nativeLayoutHeightIndex.heightAt(1), 13.0 * lineAdvance);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, expectedHeadTrimPixels);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 2);
+		}
+
+		void nativeSplitTopHeadTrimPixelsDoNotCarryAcrossFullReset()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("full-reset-old-0"), 1));
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("full-reset-old-1"), 2));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, QFont{});
+			int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("full-reset-old-2"), 3));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::TailAppend,
+			                                       oldLineCount);
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, QFont{});
+
+			QVERIFY(view.m_nativeRenderLineCacheRevision > 0);
+			QVERIFY(view.m_nativeLayoutCachedRenderRevision > 0);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimAdjustedRevision, quint64{0});
+			view.m_nativeSplitTopHeadTrimPixelsRevision = view.m_nativeRenderLineCacheRevision;
+			view.m_nativeSplitTopHeadTrimPixels         = 42;
+			view.m_nativeSplitTopHeadTrimLines          = 2;
+
+			oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.clear();
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(QStringLiteral("full-reset-new-0"), 100));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::FullReset,
+			                                       oldLineCount);
+
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void nativeSplitTopHeadTrimPixelsClearWhenReplayHitsFullReset()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("full-reset-replay-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[2].visualRows = 12;
+			view.m_nativeLayoutSlots[2].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(2, 12.0 * lineAdvance);
+
+			int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 2);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("full-reset-replay-tail-5"), 6));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 2);
+
+			oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.clear();
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("full-reset-replay-new"), 100));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::FullReset,
+			                                       oldLineCount);
+
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 2);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void nativeSplitTopHeadTrimPixelsClearWhenRangeReplayFails()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("range-replay-fail-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[0].visualRows = 7;
+			view.m_nativeLayoutSlots[0].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(0, 7.0 * lineAdvance);
+
+			const int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 1);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("range-replay-fail-tail"), 6));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 1);
+			view.m_nativeRenderCacheDelta.newLineCount         = oldLineCount - 1;
+			view.m_nativeRenderCacheDeltas.last().newLineCount = oldLineCount - 1;
+			view.m_nativeSplitTopHeadTrimPixelsRevision        = view.m_nativeRenderLineCacheRevision;
+			view.m_nativeSplitTopHeadTrimPixels                = 123;
+			view.m_nativeSplitTopHeadTrimLines                 = 1;
+
+			QVERIFY(
+			    view.prepareNativeLayoutRangeState(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont));
+
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(sizeToInt(view.m_nativeLayoutHeightIndex.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void nativeSplitTopHeadTrimPixelsClearWhenFullReplayFails()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("full-replay-fail-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[0].visualRows = 7;
+			view.m_nativeLayoutSlots[0].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(0, 7.0 * lineAdvance);
+
+			const int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 1);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("full-replay-fail-tail"), 6));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 1);
+			view.m_nativeRenderCacheDelta.newLineCount         = oldLineCount - 1;
+			view.m_nativeRenderCacheDeltas.last().newLineCount = oldLineCount - 1;
+			view.m_nativeSplitTopHeadTrimPixelsRevision        = view.m_nativeRenderLineCacheRevision;
+			view.m_nativeSplitTopHeadTrimPixels                = 123;
+			view.m_nativeSplitTopHeadTrimLines                 = 1;
+
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(sizeToInt(view.m_nativeLayoutHeightIndex.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void nativeSplitTopHeadTrimPixelsDoNotCommitAcrossRangeKeyMismatch()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("range-key-mismatch-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[0].visualRows = 9;
+			view.m_nativeLayoutSlots[0].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(0, 9.0 * lineAdvance);
+
+			const int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 1);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("range-key-mismatch-tail"), 6));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 1);
+
+			QVERIFY(
+			    view.prepareNativeLayoutRangeState(view.m_nativeRenderLineCache, 420, 420, 0, layoutFont));
+
+			QVERIFY(view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(view.m_nativeLayoutRangePreparedRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(view.m_nativeLayoutSlots.at(0).visualRows, -1);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void nativeSplitTopHeadTrimPixelsDoNotCommitAcrossFullCacheKeyMismatch()
+		{
+			WorldView view;
+			auto      makeRenderLine = [](const QString &text, const qint64 lineNumber)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = WorldRuntime::LineOutput;
+				return line;
+			};
+
+			for (int i = 0; i < 5; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("full-key-mismatch-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 400, 0, layoutFont);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[0].visualRows = 9;
+			view.m_nativeLayoutSlots[0].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(0, 9.0 * lineAdvance);
+
+			const int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 1);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("full-key-mismatch-tail"), 6));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 1);
+
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 420, 420, 0, layoutFont);
+
+			QVERIFY(!view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void nativeSplitTopHeadTrimPixelsDoNotCommitAcrossFullCacheLocalWrapMismatch()
+		{
+			WorldView view;
+			auto      makeRenderLine =
+			    [](const QString &text, const qint64 lineNumber, const int flags = WorldRuntime::LineOutput)
+			{
+				WorldView::NativeOutputRenderLine line;
+				line.text                   = text;
+				line.opacity                = 1.0;
+				line.firstRuntimeLineNumber = lineNumber;
+				line.lastRuntimeLineNumber  = lineNumber;
+				line.flags                  = flags;
+				return line;
+			};
+
+			view.m_nativeRenderLineCache.push_back(makeRenderLine(
+			    QStringLiteral("full-local-wrap-mismatch-old-local-line-with-enough-text-to-wrap"), 1,
+			    WorldRuntime::LineNote));
+			for (int i = 1; i < 5; ++i)
+				view.m_nativeRenderLineCache.push_back(
+				    makeRenderLine(QStringLiteral("full-local-wrap-mismatch-old-%1").arg(i), i + 1));
+			view.m_nativeRenderLineCacheValid       = true;
+			view.m_nativeRenderLineCacheFromRuntime = true;
+			const QFont layoutFont;
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 140, 0, layoutFont);
+			const qreal lineAdvance = view.m_nativeLayoutCachedLineAdvance;
+			QVERIFY(lineAdvance > 0.0);
+			view.m_nativeLayoutSlots[0].visualRows = 4;
+			view.m_nativeLayoutSlots[0].rowsExact  = 1;
+			view.m_nativeLayoutHeightIndex.setHeight(0, 4.0 * lineAdvance);
+
+			const int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.remove(0, 1);
+			view.m_nativeRenderLineCache.push_back(
+			    makeRenderLine(QStringLiteral("full-local-wrap-mismatch-tail"), 6));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::HeadTrimTailAppend,
+			                                       oldLineCount, false, 1);
+
+			view.ensureNativeLayoutCaches(view.m_nativeRenderLineCache, 400, 220, 0, layoutFont);
+
+			QVERIFY(!view.m_nativeLayoutRangePreparedOnly);
+			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(view.m_nativeLayoutCachedLocalWrapWidth, 220);
+			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()),
+			         sizeToInt(view.m_nativeRenderLineCache.size()));
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, quint64{0});
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 0);
+		}
+
+		void hoverRefreshResolvesNativeOutputStateDeterministically()
+		{
+			resetTestState();
+
+			WorldView view;
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			QCoreApplication::processEvents();
+
+			view.appendOutputText(QStringLiteral("cached passive hover"), true);
+			static_cast<void>(view.nativeOutputRenderLines());
+			QTextBrowser *const browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QVERIFY(browser->viewport());
+			QCursor::setPos(browser->viewport()->mapToGlobal(browser->viewport()->rect().center()));
+
+			view.m_nativeRenderLineCacheValid  = false;
+			const quint64 renderRevisionBefore = view.m_nativeRenderLineCacheRevision;
+
+			view.applyHoveredHyperlink(QStringLiteral("https://example.invalid/cached"));
+			QVERIFY(view.hyperlinkHoverActive());
+			QCOMPARE(view.currentHoveredHyperlink(), QStringLiteral("https://example.invalid/cached"));
+			view.refreshHoveredHyperlinkFromCursor();
+			QVERIFY(!view.hyperlinkHoverActive());
+			QCOMPARE(view.currentHoveredHyperlink(), QString());
+			QVERIFY(view.m_nativeRenderLineCacheRevision > renderRevisionBefore);
+			QVERIFY(view.m_nativeRenderLineCacheValid);
+
+			resetTestState();
+		}
+
+		void nativeMouseMoveResolvesWordUnderMenuWithRangeLayout()
+		{
+			resetTestState();
+
+			WorldView view;
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.resize(640, 360);
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			QCoreApplication::processEvents();
+
+			view.appendOutputText(QStringLiteral("hoverword marker"), true);
+			const WorldView::NativeOutputRenderLines &initialLines = view.nativeOutputRenderLines();
+			QVERIFY(!initialLines.isEmpty());
+
+			QTextBrowser *const browser = findVisibleOutputBrowser(view);
+			QVERIFY(browser);
+			QVERIFY(browser->viewport());
+
+			const QRect viewportRect = browser->viewport()->rect();
+			QVERIFY(!viewportRect.isEmpty());
+			constexpr bool wrapEnabled     = true;
+			const int      wrapWidthPixels = view.nativeWrapWidthPixels(viewportRect.width(), wrapEnabled);
+			const int      localWrapWidthPixels =
+			    view.nativeLocalWrapWidthPixels(viewportRect.width(), wrapEnabled);
+			const int   lineSpacing = qMax(0, view.m_lineSpacing);
+			const QFont layoutFont  = browser->font();
+			view.ensureNativeLayoutCaches(initialLines, wrapWidthPixels, localWrapWidthPixels, lineSpacing,
+			                              layoutFont);
+
+			QPoint hoverPoint{-1, -1};
+			for (int y = viewportRect.top(); y <= viewportRect.bottom() && hoverPoint.x() < 0; y += 2)
+			{
+				for (int x = viewportRect.left(); x <= viewportRect.right(); x += 2)
+				{
+					WorldView::NativeOutputPosition position;
+					bool                            textHit = false;
+					if (!view.nativeOutputHitTest(reinterpret_cast<WrapTextBrowser *>(browser), {x, y},
+					                              position, nullptr, nullptr, true, true, &textHit) ||
+					    !textHit)
+					{
+						continue;
+					}
+					if (view.wordAtNativeOutputPosition(position) == QStringLiteral("hoverword"))
+					{
+						hoverPoint = {x, y};
+						break;
+					}
+				}
+			}
+			QVERIFY2(hoverPoint.x() >= 0 && hoverPoint.y() >= 0, "Expected point over hoverword.");
+
+			WorldView::NativeOutputRenderLine tailLine;
+			tailLine.text                   = QStringLiteral("mouse-move-range-tail");
+			tailLine.opacity                = 1.0;
+			tailLine.firstRuntimeLineNumber = 2;
+			tailLine.lastRuntimeLineNumber  = 2;
+			tailLine.flags                  = WorldRuntime::LineOutput;
+			const int oldLineCount          = sizeToInt(view.m_nativeRenderLineCache.size());
+			view.m_nativeRenderLineCache.push_back(std::move(tailLine));
+			view.bumpNativeRenderLineCacheRevision(WorldView::NativeRenderCacheDeltaKind::TailAppend,
+			                                       oldLineCount, false);
+			const int resetsBefore = view.m_nativeLayoutCacheResets;
+			g_wordUnderMenu.clear();
+			g_wordUnderMenuResolved = false;
+
+			const QPoint globalHoverPoint = browser->viewport()->mapToGlobal(hoverPoint);
+			QMouseEvent  moveEvent(QEvent::MouseMove, QPointF(hoverPoint), QPointF(hoverPoint),
+			                       QPointF(globalHoverPoint), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+			view.eventFilter(browser->viewport(), &moveEvent);
+			QCoreApplication::processEvents();
+
+			QCOMPARE(view.m_nativeLayoutCacheResets, resetsBefore);
+			QVERIFY(fakeRuntimePointer()->wordUnderMenuResolved());
+			QCOMPARE(fakeRuntimePointer()->wordUnderMenu(), QStringLiteral("hoverword"));
+			fakeRuntimePointer()->setView(nullptr);
+			resetTestState();
+		}
+
 		void nativeLayoutConsumesMixedQueuedDeltasWithoutReset()
 		{
 			WorldView view;
@@ -1677,6 +2593,8 @@ class tst_WorldView_Basic : public QObject
 			view.m_nativeLayoutSlots[3].rowsExact  = 1;
 			view.m_nativeLayoutHeightIndex.setHeight(2, 12.0 * lineAdvance);
 			view.m_nativeLayoutHeightIndex.setHeight(3, 13.0 * lineAdvance);
+			const int expectedHeadTrimPixels =
+			    qMax(1, static_cast<int>(std::round(view.nativeLayoutCumulativeHeightAt(2))));
 
 			int oldLineCount = sizeToInt(view.m_nativeRenderLineCache.size());
 			view.m_nativeRenderLineCache.remove(0, 2);
@@ -1703,6 +2621,9 @@ class tst_WorldView_Basic : public QObject
 
 			QCOMPARE(view.m_nativeLayoutCachedRenderRevision, view.m_nativeRenderLineCacheRevision);
 			QCOMPARE(sizeToInt(view.m_nativeRenderCacheDeltas.size()), 0);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixelsRevision, view.m_nativeRenderLineCacheRevision);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimPixels, expectedHeadTrimPixels);
+			QCOMPARE(view.m_nativeSplitTopHeadTrimLines, 2);
 			QCOMPARE(sizeToInt(view.m_nativeLayoutSlots.size()), 7);
 			QCOMPARE(view.m_nativeLayoutSlots.at(0).visualRows, 12);
 			QCOMPARE(static_cast<int>(view.m_nativeLayoutSlots.at(0).rowsExact), 1);

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -88,6 +88,7 @@ namespace
 	bool                                g_connected{false};
 	bool                                g_nawsNegotiated{false};
 	bool                                g_useFakeAppController{false};
+	bool                                g_hasMushReaderLiveSpeechOwner{false};
 	QHash<quint64, quint16>             g_virtualKeyMap;
 	QHash<qint64, int>                  g_acceleratorCommands;
 	int                                 g_acceleratorExecutionCount{0};
@@ -248,6 +249,7 @@ namespace
 		g_connected                       = false;
 		g_nawsNegotiated                  = false;
 		g_useFakeAppController            = false;
+		g_hasMushReaderLiveSpeechOwner    = false;
 		g_virtualKeyMap.clear();
 		g_acceleratorCommands.clear();
 		g_acceleratorExecutionCount      = 0;
@@ -996,6 +998,11 @@ void WorldRuntime::notifyWorldOutputResized()
 	++g_worldOutputResizedNotifyCount;
 }
 
+bool WorldRuntime::hasMushReaderLiveSpeechOwner() const
+{
+	return g_hasMushReaderLiveSpeechOwner;
+}
+
 void WorldRuntime::refreshNawsWindowSize()
 {
 }
@@ -1583,6 +1590,44 @@ class tst_WorldView_Basic : public QObject
 			QCOMPARE(g_accessibleTextInsertRecords.size(), 2);
 			QCOMPARE(g_accessibleAnnouncementRecords.size(), 2);
 			QCOMPARE(g_accessibleValueChangedCount, 0);
+		}
+
+		void worldOutputAccessibleLiveEventsSuppressedWhenMushReaderOwnsSpeech()
+		{
+			qmudInstallWorldOutputAccessibility();
+			resetTestState();
+			g_hasMushReaderLiveSpeechOwner = true;
+
+			WorldView view;
+			view.resize(640, 360);
+			view.setRuntime(fakeRuntimePointer());
+			view.show();
+			QVERIFY(QTest::qWaitForWindowExposed(&view));
+			QWidget *canvas = findNativeOutputCanvas(view);
+			QVERIFY(canvas);
+			QAccessibleInterface *accessible = QAccessible::queryAccessibleInterface(canvas);
+			QVERIFY(accessible);
+			QAccessibleTextInterface *textInterface = accessible->textInterface();
+			QVERIFY(textInterface);
+			QCOMPARE(textInterface->characterCount(), 0);
+
+			ScopedAccessibleUpdateCapture capture;
+
+			appendFakeRuntimeOutputText(view, QStringLiteral("alpha"), {}, false, true);
+			QCoreApplication::processEvents();
+			QCOMPARE(g_accessibleTextInsertRecords.size(), 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.size(), 0);
+			QCOMPARE(g_accessibleAnnouncementRecords.size(), 0);
+			QCOMPARE(g_accessibleValueChangedCount, 0);
+			QCOMPARE(textInterface->text(0, textInterface->characterCount()), QStringLiteral("alpha"));
+
+			appendFakeRuntimeOutputText(view, QStringLiteral("beta"), {}, false, true);
+			QCoreApplication::processEvents();
+			QCOMPARE(g_accessibleTextInsertRecords.size(), 0);
+			QCOMPARE(g_accessibleTextUpdateRecords.size(), 0);
+			QCOMPARE(g_accessibleAnnouncementRecords.size(), 0);
+			QCOMPARE(g_accessibleValueChangedCount, 0);
+			QCOMPARE(textInterface->text(0, textInterface->characterCount()), QStringLiteral("alpha\nbeta"));
 		}
 
 		void worldOutputAccessibleNonAppendMutationsUseContentChangedFallback()

--- a/tests/gui/tst_WorldView_Basic.cpp
+++ b/tests/gui/tst_WorldView_Basic.cpp
@@ -64,6 +64,7 @@ namespace
 	QMap<QString, QString>              g_worldMultilineAttrs;
 	QMap<QString, QVariant>             g_globalOptions;
 	QVector<WorldRuntime::LineEntry>    g_runtimeLines;
+	QList<WorldRuntime::Macro>          g_testMacros;
 	WorldRuntime::TextRectangleSettings g_textRectangle;
 	int                                 g_outputFontHeight{0};
 	int                                 g_drawOutputNotifyCount{0};
@@ -93,6 +94,11 @@ namespace
 	QHash<qint64, int>                  g_acceleratorCommands;
 	int                                 g_acceleratorExecutionCount{0};
 	int                                 g_lastExecutedAcceleratorCommand{-1};
+	int                                 g_sendCommandCount{0};
+	int                                 g_executeCommandCount{0};
+	QString                             g_lastExecutedCommand;
+	bool                                g_lastUserMacroHistory{false};
+	unsigned short                      g_actionSourceDuringExecute{WorldRuntime::eUnknownActionSource};
 
 	struct AccessibleTextInsertRecord
 	{
@@ -209,8 +215,7 @@ namespace
 
 	const QList<WorldRuntime::Macro> &macroStorage()
 	{
-		static const QList<WorldRuntime::Macro> macros;
-		return macros;
+		return g_testMacros;
 	}
 
 	const QList<WorldRuntime::Keypad> &keypadStorage()
@@ -225,6 +230,7 @@ namespace
 		g_worldMultilineAttrs.clear();
 		g_globalOptions.clear();
 		g_runtimeLines.clear();
+		g_testMacros.clear();
 		g_textRectangle                 = {};
 		g_outputFontHeight              = 0;
 		g_drawOutputNotifyCount         = 0;
@@ -254,6 +260,11 @@ namespace
 		g_acceleratorCommands.clear();
 		g_acceleratorExecutionCount      = 0;
 		g_lastExecutedAcceleratorCommand = -1;
+		g_sendCommandCount               = 0;
+		g_executeCommandCount            = 0;
+		g_lastExecutedCommand.clear();
+		g_lastUserMacroHistory      = false;
+		g_actionSourceDuringExecute = WorldRuntime::eUnknownActionSource;
 		g_accessibleTextInsertRecords.clear();
 		g_accessibleTextUpdateRecords.clear();
 		g_accessibleAnnouncementRecords.clear();
@@ -395,6 +406,15 @@ namespace
 		if (!bestBrowser)
 			bestBrowser = topBrowser ? topBrowser : bottomBrowser;
 		return bestBrowser;
+	}
+
+	WorldRuntime::Macro makeMacro(const QString &name, const QString &type, const QString &send)
+	{
+		WorldRuntime::Macro macro;
+		macro.attributes.insert(QStringLiteral("name"), name);
+		macro.attributes.insert(QStringLiteral("type"), type);
+		macro.children.insert(QStringLiteral("send"), send);
+		return macro;
 	}
 
 	QWidget *findNativeOutputCanvas(const WorldView &view)
@@ -1161,7 +1181,25 @@ void WorldRuntime::prepareInputEchoForDisplay(QString &, QVector<StyleSpan> &, b
 
 int WorldRuntime::sendCommand(const QString &, bool, bool, bool, bool, bool) const
 {
-	return 0;
+	++g_sendCommandCount;
+	return eOK;
+}
+
+int WorldRuntime::executeCommand(const QString &text) const
+{
+	++g_executeCommandCount;
+	g_lastExecutedCommand       = text;
+	g_actionSourceDuringExecute = g_currentActionSource;
+	return eOK;
+}
+
+int WorldRuntime::executeUserMacroSendNow(const QString &text, bool history) const
+{
+	++g_executeCommandCount;
+	g_lastExecutedCommand       = text;
+	g_lastUserMacroHistory      = history;
+	g_actionSourceDuringExecute = g_currentActionSource;
+	return eOK;
 }
 
 int WorldRuntime::acceleratorCommandForKey(qint64 key) const
@@ -2303,6 +2341,89 @@ class tst_WorldView_Basic : public QObject
 			QCOMPARE(g_acceleratorExecutionCount, 1);
 			QCOMPARE(g_lastExecutedAcceleratorCommand, commandId);
 			QCOMPARE(shortcutTriggerCount, 0);
+
+			resetTestState();
+		}
+
+		void replaceMacroClearsChangedStateAndMovesCaretToEnd()
+		{
+			resetTestState();
+			g_worldAttrs.insert(QStringLiteral("confirm_before_replacing_typing"), QStringLiteral("1"));
+			g_testMacros.push_back(
+			    makeMacro(QStringLiteral("F2"), QStringLiteral("replace"), QStringLiteral("look")));
+			g_testMacros.push_back(
+			    makeMacro(QStringLiteral("F3"), QStringLiteral("replace"), QStringLiteral("say")));
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.setAllTypingToCommandWindow(true);
+			view.applyRuntimeSettings();
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			input->setFocus(Qt::OtherFocusReason);
+			QTRY_VERIFY(input->hasFocus());
+
+			QTest::keyClick(input, Qt::Key_F2);
+			QCoreApplication::processEvents();
+
+			QCOMPARE(view.inputText(), QStringLiteral("look"));
+			QCOMPARE(input->textCursor().position(), view.inputText().size());
+
+			const auto sawDialog = std::make_shared<bool>(false);
+			scheduleDialogInteraction(
+			    [](const QDialog *dialog)
+			    {
+				    const auto *messageBox = qobject_cast<const QMessageBox *>(dialog);
+				    return messageBox &&
+				           messageBox->text().contains(QStringLiteral("Replace your typing of"));
+			    },
+			    [sawDialog](const QDialog *dialog)
+			    {
+				    *sawDialog = true;
+				    const_cast<QDialog *>(dialog)->reject();
+			    });
+
+			QTest::keyClick(input, Qt::Key_F3);
+			QCoreApplication::processEvents();
+
+			QVERIFY(!*sawDialog);
+			QCOMPARE(view.inputText(), QStringLiteral("say"));
+			QCOMPARE(input->textCursor().position(), view.inputText().size());
+
+			resetTestState();
+		}
+
+		void sendNowMacroUsesCommandEvaluationPath()
+		{
+			resetTestState();
+			g_testMacros.push_back(
+			    makeMacro(QStringLiteral("F2"), QStringLiteral("send_now"), QStringLiteral("north")));
+
+			WorldView view;
+			view.resize(900, 640);
+			view.show();
+			view.setRuntimeObserver(fakeRuntimePointer());
+			view.setAllTypingToCommandWindow(true);
+			QCoreApplication::processEvents();
+
+			QPlainTextEdit *input = view.inputEditor();
+			QVERIFY(input);
+			input->setFocus(Qt::OtherFocusReason);
+			QTRY_VERIFY(input->hasFocus());
+
+			QTest::keyClick(input, Qt::Key_F2);
+			QCoreApplication::processEvents();
+
+			QCOMPARE(g_executeCommandCount, 1);
+			QCOMPARE(g_lastExecutedCommand, QStringLiteral("north"));
+			QVERIFY(g_lastUserMacroHistory);
+			QCOMPARE(g_actionSourceDuringExecute, WorldRuntime::eUserMacro);
+			QCOMPARE(g_currentActionSource, WorldRuntime::eUnknownActionSource);
+			QCOMPARE(g_sendCommandCount, 0);
 
 			resetTestState();
 		}

--- a/tests/integration/tst_MushclientImportUtils.cpp
+++ b/tests/integration/tst_MushclientImportUtils.cpp
@@ -1,0 +1,473 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_MushclientImportUtils.cpp
+ * Role: Integration coverage for explicit MUSHclient directory import behavior.
+ */
+
+#include "../../src/FileExtensions.h"
+#include "../../src/helpers/MushclientImportUtils.h"
+
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QSettings>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QTemporaryDir>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlError>
+#include <QtSql/QSqlQuery>
+#include <QtTest/QtTest>
+#include <filesystem>
+
+class tst_MushclientImportUtils final : public QObject
+{
+		Q_OBJECT
+
+	private slots:
+		static void importsDirectoryReadOnlyWithFiltersAndNoOverwrite();
+#ifndef Q_OS_WIN
+		static void rejectsDestinationSymlinkEscape();
+		static void rejectsReferencedLegacyWorldSymlinkButMigratesReference();
+		static void rejectsTopLevelConfigAndPrefsSymlinks();
+#endif
+};
+
+namespace
+{
+	void writeFile(const QString &path, const QByteArray &data)
+	{
+		QVERIFY2(QDir().mkpath(QFileInfo(path).absolutePath()),
+		         qPrintable(QStringLiteral("Unable to create parent for %1").arg(path)));
+		QFile file(path);
+		QVERIFY2(file.open(QIODevice::WriteOnly | QIODevice::Truncate),
+		         qPrintable(QStringLiteral("Unable to write %1").arg(path)));
+		QCOMPARE(file.write(data), data.size());
+	}
+
+	QByteArray pluginXml(const QString &name, const QString &id, const QString &language)
+	{
+		return QStringLiteral(
+		           R"(<?xml version="1.0" encoding="utf-8"?>
+<muclient>
+<plugin name="%1" author="QMudTest" id="%2" language="%3" purpose="Import test">
+<script>print("ok")</script>
+</plugin>
+</muclient>
+)")
+		    .arg(name, id, language)
+		    .toUtf8();
+	}
+
+	void openTestDatabase(const QString &path, const QString &connectionName, QSqlDatabase &db)
+	{
+		db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), connectionName);
+		db.setDatabaseName(path);
+		QVERIFY2(db.open(),
+		         qPrintable(
+		             QStringLiteral("Unable to open test database %1: %2").arg(path, db.lastError().text())));
+	}
+
+	void execSql(const QSqlDatabase &db, const QString &sql)
+	{
+		QSqlQuery query(db);
+		QVERIFY2(query.exec(sql),
+		         qPrintable(QStringLiteral("SQL failed: %1\n%2").arg(sql, query.lastError().text())));
+	}
+} // namespace
+
+void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrite()
+{
+	QTemporaryDir temp;
+	QVERIFY(temp.isValid());
+
+	const QDir    root(temp.path());
+	const QString mush = root.filePath(QStringLiteral("mush"));
+	const QString home = root.filePath(QStringLiteral("home"));
+	QVERIFY(QDir().mkpath(mush));
+	QVERIFY(QDir().mkpath(home));
+	const QString externalWorld       = root.filePath(QStringLiteral("outside.mcl"));
+	const QString iniOnlyWorld        = root.filePath(QStringLiteral("ini-only.mcl"));
+	const QString missingWorld        = root.filePath(QStringLiteral("missing.mcl"));
+	const QString iniMissingWorld     = root.filePath(QStringLiteral("ini-missing.mcl"));
+	const QString ansiIniWorld        = QDir(mush).filePath(QStringLiteral("caf\u00e9.mcl"));
+	const QString win1252IniWorld     = QDir(mush).filePath(QStringLiteral("price\u20ac.mcl"));
+	const QString fallbackWorld       = root.filePath(QStringLiteral("fallback.qdl"));
+	const QString externalLog         = root.filePath(QStringLiteral("external.log"));
+	const QString externalPlugin      = root.filePath(QStringLiteral("ExternalPlugin.xml"));
+	const QString rootSharedWorld     = QDir(mush).filePath(QStringLiteral("shared.mcl"));
+	const QString relativeSharedWorld = QDir(mush).filePath(QStringLiteral("shared/relative.mcl"));
+	writeFile(externalWorld, QByteArrayLiteral(R"(<?xml version="1.0" encoding="ISO-8859-1"?>
+<muclient>
+<world name="caf)") + QByteArray(1, static_cast<char>(0xE9)) +
+	                             QByteArrayLiteral(R"(" log_file_name=")") + externalLog.toLatin1() +
+	                             QByteArrayLiteral(R"(" />
+</muclient>
+)"));
+	writeFile(iniOnlyWorld, QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                                          "name=\"ini-only\" /></muclient>"));
+	writeFile(ansiIniWorld, QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                                          "name=\"caf\xc3\xa9\" /></muclient>"));
+	writeFile(win1252IniWorld, QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                                             "name=\"price\xe2\x82\xac\" /></muclient>"));
+	writeFile(
+	    QMudFileExtensions::replaceOrAppendExtension(fallbackWorld, QStringLiteral("mcl")),
+	    QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world name=\"fallback\" "
+	                      "/></muclient>"));
+	writeFile(rootSharedWorld, QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                                             "name=\"root-shared\" /></muclient>"));
+	writeFile(relativeSharedWorld,
+	          QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                            "name=\"relative-shared\" /></muclient>"));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/nested/child.mcl")),
+	          QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                            "name=\"nested-child\" /></muclient>"));
+
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/main.mcl")),
+	          QStringLiteral(
+	              R"(<?xml version="1.0" encoding="utf-8"?>
+<muclient>
+<world script_file="lua/module.lua" log_file_name="%1" world_file="%2" missing_file="%3" fallback_file="%4" root_file="%5" relative_root_file="../shared/relative.mcl" nested_file="%6" />
+<include name="plugins/Good.xml" plugin="y" />
+<plugin source="%7" />
+<plugin source="lua/module.lua" />
+<variables>
+<variable name="db_path">%8</variable>
+</variables>
+</muclient>
+)")
+	              .arg(QDir(mush).filePath(QStringLiteral("logs/main.log")), externalWorld, missingWorld,
+	                   fallbackWorld, rootSharedWorld,
+	                   QDir(mush).filePath(QStringLiteral("worlds/nested/child.mcl")), externalPlugin,
+	                   QDir(mush).filePath(QStringLiteral("map.DB")))
+	              .toUtf8());
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/already.mcl")), QByteArrayLiteral("new legacy"));
+	writeFile(QDir(home).filePath(QStringLiteral("worlds/already.qdl")), QByteArrayLiteral("existing qdl"));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/support.txt")), QByteArrayLiteral("support"));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/existing.txt")), QByteArrayLiteral("source"));
+	writeFile(QDir(home).filePath(QStringLiteral("worlds/existing.txt")), QByteArrayLiteral("destination"));
+
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/Good.xml")),
+	          pluginXml(QStringLiteral("GoodPlugin"), QStringLiteral("0123456789abcdef01234567"),
+	                    QStringLiteral("Lua")));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/NotAPlugin.xml")),
+	          QByteArrayLiteral("<muclient><world name=\"x\"/></muclient>"));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/VbPlugin.xml")),
+	          pluginXml(QStringLiteral("VbPlugin"), QStringLiteral("1123456789abcdef01234567"),
+	                    QStringLiteral("VBscript")));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/AutoSave.xml")),
+	          pluginXml(QStringLiteral("AutoSave"), QStringLiteral("8238deec7c06bade8ebc3819"),
+	                    QStringLiteral("Lua")));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/helper.vbs")),
+	          QByteArrayLiteral("' legacy script"));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/data.dat")), QByteArrayLiteral("data"));
+
+	writeFile(QDir(mush).filePath(QStringLiteral("lua/module.lua")), QByteArrayLiteral("return {}"));
+	writeFile(QDir(mush).filePath(QStringLiteral("lua/socket.dll")), QByteArrayLiteral("dll"));
+	writeFile(QDir(mush).filePath(QStringLiteral("scripts/run.lua")), QByteArrayLiteral("print('run')"));
+	writeFile(QDir(mush).filePath(QStringLiteral("logs/main.log")), QByteArrayLiteral("imported log"));
+	writeFile(QDir(mush).filePath(QStringLiteral("logs/existing.log")), QByteArrayLiteral("source log"));
+	writeFile(QDir(home).filePath(QStringLiteral("logs/existing.log")), QByteArrayLiteral("destination log"));
+	writeFile(QDir(mush).filePath(QStringLiteral("map.DB")), QByteArrayLiteral("db"));
+	{
+		const QString sourcePrefsPath      = QDir(mush).filePath(QStringLiteral("MUSHCLIENT_PREFS.SQLITE"));
+		const QString sourceConnectionName = QStringLiteral("tst_mushclient_import_source_prefs");
+		QSqlDatabase  sourceDb;
+		openTestDatabase(sourcePrefsPath, sourceConnectionName, sourceDb);
+		execSql(sourceDb, QStringLiteral("CREATE TABLE prefs (name TEXT PRIMARY KEY, value TEXT NOT NULL)"));
+		execSql(sourceDb, QStringLiteral("INSERT INTO prefs (name, value) VALUES ('ImportedPref', 'yes')"));
+		execSql(sourceDb, QStringLiteral("CREATE TABLE worlds (name TEXT PRIMARY KEY, value TEXT NOT NULL)"));
+		execSql(sourceDb, QStringLiteral("INSERT INTO worlds (name, value) VALUES ('ImportedWorld', '42')"));
+		execSql(sourceDb, QStringLiteral("CREATE INDEX prefs_value_idx ON prefs(value)"));
+		execSql(sourceDb, QStringLiteral("CREATE VIEW prefs_view AS SELECT name, value FROM prefs"));
+		execSql(sourceDb, QStringLiteral("CREATE TRIGGER prefs_insert_trigger AFTER INSERT ON prefs "
+		                                 "BEGIN UPDATE worlds SET value = value WHERE name = "
+		                                 "'ImportedWorld'; END"));
+		sourceDb.close();
+		sourceDb = QSqlDatabase();
+		QSqlDatabase::removeDatabase(sourceConnectionName);
+	}
+	const QString destinationPrefsPath      = QDir(home).filePath(QStringLiteral("QMud.sqlite"));
+	const QString destinationConnectionName = QStringLiteral("tst_mushclient_import_destination_prefs");
+	QSqlDatabase  destinationPreferencesDb;
+	openTestDatabase(destinationPrefsPath, destinationConnectionName, destinationPreferencesDb);
+	execSql(destinationPreferencesDb,
+	        QStringLiteral("CREATE TABLE prefs (name TEXT PRIMARY KEY, value TEXT NOT NULL)"));
+	execSql(destinationPreferencesDb,
+	        QStringLiteral("INSERT INTO prefs (name, value) VALUES ('ExistingPref', 'old')"));
+	execSql(destinationPreferencesDb, QStringLiteral("CREATE VIEW prefs_view AS SELECT name FROM prefs"));
+	execSql(destinationPreferencesDb, QStringLiteral("CREATE VIEW stale_view AS SELECT name FROM prefs"));
+	writeFile(QDir(mush).filePath(QStringLiteral("mUsHcLiEnT.InI")),
+	          QStringLiteral("CtrlBars-Bar0=x\nCtrlBars-Summary=x\n[Global prefs]\nWorldList=%1*%2*")
+	                  .arg(QDir(mush).filePath(QStringLiteral("worlds/main.mcl")), iniOnlyWorld)
+	                  .toUtf8() +
+	              QByteArrayLiteral("caf") + QByteArray(1, static_cast<char>(0xE9)) +
+	              QByteArrayLiteral(".mcl*price") + QByteArray(1, static_cast<char>(0x80)) +
+	              QStringLiteral(".mcl*%1\nPluginList=%2*%3\n")
+	                  .arg(iniMissingWorld, QDir(mush).filePath(QStringLiteral("worlds/plugins/Good.xml")),
+	                       externalPlugin)
+	                  .toUtf8());
+
+	QMudMushclientImportUtils::ImportStats stats = QMudMushclientImportUtils::importDirectory(mush, home);
+	QMudMushclientImportUtils::importPreferencesDatabase(mush, destinationPreferencesDb, stats);
+
+	QCOMPARE(stats.errors, 0);
+	QCOMPARE(stats.warnings, 2);
+	const QString warningText = stats.warningDetails.join(QLatin1Char('\n'));
+	QVERIFY(warningText.contains(QStringLiteral("missing.mcl")));
+	QVERIFY(warningText.contains(QStringLiteral("ini-missing.mcl")));
+	QCOMPARE(stats.worldsConverted, 9);
+	QCOMPARE(stats.configsImported, 1);
+	QCOMPARE(stats.preferenceDatabasesImported, 1);
+	QVERIFY(stats.filesSkippedExisting >= 2);
+	QVERIFY(stats.filesSkippedFiltered >= 5);
+
+	QCOMPARE(QFileInfo(QDir(mush).filePath(QStringLiteral("worlds/main.mcl"))).exists(), true);
+	QCOMPARE(QFileInfo(QDir(mush).filePath(QStringLiteral("mUsHcLiEnT.InI"))).exists(), true);
+	QVERIFY(!QFileInfo(QDir(mush).filePath(QStringLiteral("migrated/MUSHclient.ini"))).exists());
+
+	QFile converted(QDir(home).filePath(QStringLiteral("worlds/main.qdl")));
+	QVERIFY(converted.open(QIODevice::ReadOnly));
+	const QByteArray convertedData = converted.readAll();
+	QVERIFY(convertedData.contains(R"(script_file="./lua/module.lua")"));
+	QVERIFY(convertedData.contains(R"(log_file_name="./logs/main.log")"));
+	QVERIFY(convertedData.contains(R"(world_file="./worlds/outside.qdl")"));
+	QVERIFY(convertedData.contains(R"(missing_file="./worlds/missing.qdl")"));
+	QVERIFY(convertedData.contains(R"(fallback_file="./worlds/fallback.qdl")"));
+	QVERIFY(convertedData.contains(R"(root_file="./worlds/shared.qdl")"));
+	QVERIFY(convertedData.contains(R"(relative_root_file="./worlds/relative.qdl")"));
+	QVERIFY(convertedData.contains(R"(nested_file="./worlds/nested/child.qdl")"));
+	QVERIFY(convertedData.contains(R"(name="./worlds/plugins/Good.xml")"));
+	QVERIFY(convertedData.contains(R"(source="./worlds/plugins/ExternalPlugin.xml")"));
+	QVERIFY(convertedData.contains(R"(source="./worlds/plugins/module.lua")"));
+	QVERIFY(convertedData.contains(QByteArrayLiteral(">./map.DB<")));
+	QVERIFY(!convertedData.contains(externalWorld.toUtf8()));
+	QVERIFY(!convertedData.contains(missingWorld.toUtf8()));
+	QVERIFY(!convertedData.contains(fallbackWorld.toUtf8()));
+	QVERIFY(!convertedData.contains(rootSharedWorld.toUtf8()));
+	QVERIFY(!convertedData.contains(relativeSharedWorld.toUtf8()));
+	QVERIFY(!convertedData.contains(externalPlugin.toUtf8()));
+	QVERIFY(!QFileInfo(QDir(mush).filePath(QStringLiteral("worlds/main.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/outside.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/shared.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("shared.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/relative.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("shared/relative.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/nested/child.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/ini-only.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/caf\u00e9.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/price\u20ac.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/ini-missing.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/missing.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/fallback.qdl"))).exists());
+	QFile recursivelyConverted(QDir(home).filePath(QStringLiteral("worlds/outside.qdl")));
+	QVERIFY(recursivelyConverted.open(QIODevice::ReadOnly));
+	const QByteArray recursivelyConvertedData = recursivelyConverted.readAll();
+	QVERIFY(recursivelyConvertedData.contains(R"(encoding="UTF-8")"));
+	QVERIFY(recursivelyConvertedData.contains(QByteArrayLiteral("caf\xc3\xa9")));
+	QVERIFY(recursivelyConvertedData.contains(R"(log_file_name="./external.log")"));
+	QVERIFY(!recursivelyConvertedData.contains(externalLog.toUtf8()));
+
+	QFile fallbackConverted(QDir(home).filePath(QStringLiteral("worlds/fallback.qdl")));
+	QVERIFY(fallbackConverted.open(QIODevice::ReadOnly));
+	QVERIFY(fallbackConverted.readAll().contains(R"(name="fallback")"));
+
+	QFile alreadyConverted(QDir(home).filePath(QStringLiteral("worlds/already.qdl")));
+	QVERIFY(alreadyConverted.open(QIODevice::ReadOnly));
+	QCOMPARE(alreadyConverted.readAll(), QByteArrayLiteral("existing qdl"));
+
+	QFile existing(QDir(home).filePath(QStringLiteral("worlds/existing.txt")));
+	QVERIFY(existing.open(QIODevice::ReadOnly));
+	QCOMPARE(existing.readAll(), QByteArrayLiteral("destination"));
+
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/Good.xml"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/data.dat"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/NotAPlugin.xml"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/VbPlugin.xml"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/AutoSave.xml"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/helper.vbs"))).exists());
+
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("lua/module.lua"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("lua/socket.dll"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("scripts/run.lua"))).exists());
+	QFile importedLog(QDir(home).filePath(QStringLiteral("logs/main.log")));
+	QVERIFY(importedLog.open(QIODevice::ReadOnly));
+	QCOMPARE(importedLog.readAll(), QByteArrayLiteral("imported log"));
+	QFile existingLog(QDir(home).filePath(QStringLiteral("logs/existing.log")));
+	QVERIFY(existingLog.open(QIODevice::ReadOnly));
+	QCOMPARE(existingLog.readAll(), QByteArrayLiteral("destination log"));
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("map.DB"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("QMud.sqlite"))).exists());
+	{
+		QSqlQuery importedPrefs(destinationPreferencesDb);
+		QVERIFY(importedPrefs.exec(QStringLiteral("SELECT value FROM prefs WHERE name = 'ExistingPref'")));
+		QVERIFY(!importedPrefs.next());
+		QVERIFY(importedPrefs.exec(QStringLiteral("SELECT value FROM prefs WHERE name = 'ImportedPref'")));
+		QVERIFY(importedPrefs.next());
+		QCOMPARE(importedPrefs.value(0).toString(), QStringLiteral("yes"));
+		QVERIFY(importedPrefs.exec(QStringLiteral("SELECT value FROM worlds WHERE name = 'ImportedWorld'")));
+		QVERIFY(importedPrefs.next());
+		QCOMPARE(importedPrefs.value(0).toString(), QStringLiteral("42"));
+		QVERIFY(importedPrefs.exec(QStringLiteral("SELECT COUNT(*) FROM sqlite_master WHERE name = "
+		                                          "'stale_view'")));
+		QVERIFY(importedPrefs.next());
+		QCOMPARE(importedPrefs.value(0).toInt(), 0);
+		QVERIFY(importedPrefs.exec(QStringLiteral("SELECT COUNT(*) FROM sqlite_master WHERE name IN "
+		                                          "('prefs_value_idx', 'prefs_view', "
+		                                          "'prefs_insert_trigger')")));
+		QVERIFY(importedPrefs.next());
+		QCOMPARE(importedPrefs.value(0).toInt(), 3);
+	}
+	destinationPreferencesDb.close();
+	destinationPreferencesDb = QSqlDatabase();
+	QSqlDatabase::removeDatabase(destinationConnectionName);
+
+	QSettings imported(QDir(home).filePath(QStringLiteral("QMud.conf")), QSettings::IniFormat);
+	QCOMPARE(imported.value(QStringLiteral("Global prefs/WorldList")).toString(),
+	         QStringLiteral("./worlds/main.qdl*./worlds/ini-only.qdl*./worlds/caf\u00e9.qdl*./worlds/"
+	                        "price\u20ac.qdl*./worlds/ini-missing.qdl"));
+	QCOMPARE(imported.value(QStringLiteral("Global prefs/PluginList")).toString(),
+	         QStringLiteral("./worlds/plugins/Good.xml*./worlds/plugins/ExternalPlugin.xml"));
+	QVERIFY(imported.value(QStringLiteral("CtrlBars-Bar0")).toString().isEmpty());
+	QVERIFY(imported.value(QStringLiteral("CtrlBars-Summary")).toString().isEmpty());
+}
+
+#ifndef Q_OS_WIN
+void tst_MushclientImportUtils::rejectsDestinationSymlinkEscape()
+{
+	QTemporaryDir temp;
+	QVERIFY(temp.isValid());
+
+	const QDir    root(temp.path());
+	const QString mush    = root.filePath(QStringLiteral("mush"));
+	const QString home    = root.filePath(QStringLiteral("home"));
+	const QString outside = root.filePath(QStringLiteral("outside"));
+	QVERIFY(QDir().mkpath(QDir(mush).filePath(QStringLiteral("worlds"))));
+	QVERIFY(QDir().mkpath(home));
+	QVERIFY(QDir().mkpath(outside));
+
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/support.txt")), QByteArrayLiteral("support"));
+	writeFile(QDir(mush).filePath(QStringLiteral("MUSHclient.ini")),
+	          QByteArrayLiteral("[Global prefs]\nWorldList=worlds/support.txt\n"));
+
+	std::error_code error;
+	std::filesystem::create_directory_symlink(
+	    outside.toStdString(), QDir(home).filePath(QStringLiteral("worlds")).toStdString(), error);
+	if (error)
+		QSKIP(qPrintable(QStringLiteral("Directory symlinks unavailable: %1")
+		                     .arg(QString::fromStdString(error.message()))));
+
+	std::filesystem::create_symlink(QDir(outside).filePath(QStringLiteral("QMud.conf")).toStdString(),
+	                                QDir(home).filePath(QStringLiteral("QMud.conf")).toStdString(), error);
+	if (error)
+		QSKIP(qPrintable(
+		    QStringLiteral("File symlinks unavailable: %1").arg(QString::fromStdString(error.message()))));
+
+	const QMudMushclientImportUtils::ImportStats stats =
+	    QMudMushclientImportUtils::importDirectory(mush, home);
+
+	QVERIFY(stats.errors >= 2);
+	QVERIFY(!QFileInfo(QDir(outside).filePath(QStringLiteral("support.txt"))).exists());
+	QVERIFY(!QFileInfo(QDir(outside).filePath(QStringLiteral("QMud.conf"))).exists());
+}
+
+void tst_MushclientImportUtils::rejectsReferencedLegacyWorldSymlinkButMigratesReference()
+{
+	QTemporaryDir temp;
+	QVERIFY(temp.isValid());
+
+	const QDir    root(temp.path());
+	const QString mush    = root.filePath(QStringLiteral("mush"));
+	const QString home    = root.filePath(QStringLiteral("home"));
+	const QString outside = root.filePath(QStringLiteral("outside"));
+	QVERIFY(QDir().mkpath(QDir(mush).filePath(QStringLiteral("worlds"))));
+	QVERIFY(QDir().mkpath(home));
+	QVERIFY(QDir().mkpath(outside));
+
+	const QString targetPath = QDir(outside).filePath(QStringLiteral("linked-target.mcl"));
+	writeFile(targetPath, QByteArrayLiteral("not xml"));
+
+	std::error_code error;
+	std::filesystem::create_symlink(targetPath.toStdString(),
+	                                QDir(mush).filePath(QStringLiteral("worlds/link.mcl")).toStdString(),
+	                                error);
+	if (error)
+		QSKIP(qPrintable(
+		    QStringLiteral("File symlinks unavailable: %1").arg(QString::fromStdString(error.message()))));
+
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/main.mcl")),
+	          QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                            "world_file=\"link.mcl\" /></muclient>"));
+
+	const QMudMushclientImportUtils::ImportStats stats =
+	    QMudMushclientImportUtils::importDirectory(mush, home);
+
+	QCOMPARE(stats.errors, 0);
+	QCOMPARE(stats.warnings, 1);
+	QVERIFY(stats.warningDetails.join(QLatin1Char('\n')).contains(QStringLiteral("link.mcl")));
+
+	QFile converted(QDir(home).filePath(QStringLiteral("worlds/main.qdl")));
+	QVERIFY(converted.open(QIODevice::ReadOnly));
+	QVERIFY(converted.readAll().contains(R"(world_file="./worlds/link.qdl")"));
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/link.qdl"))).exists());
+}
+
+void tst_MushclientImportUtils::rejectsTopLevelConfigAndPrefsSymlinks()
+{
+	QTemporaryDir temp;
+	QVERIFY(temp.isValid());
+
+	const QDir    root(temp.path());
+	const QString mush    = root.filePath(QStringLiteral("mush"));
+	const QString home    = root.filePath(QStringLiteral("home"));
+	const QString outside = root.filePath(QStringLiteral("outside"));
+	QVERIFY(QDir().mkpath(mush));
+	QVERIFY(QDir().mkpath(home));
+	QVERIFY(QDir().mkpath(outside));
+
+	const QString externalIni = QDir(outside).filePath(QStringLiteral("MUSHclient.ini"));
+	const QString externalDb  = QDir(outside).filePath(QStringLiteral("mushclient_prefs.sqlite"));
+	writeFile(externalIni, QByteArrayLiteral("[Global prefs]\nWorldList=outside.mcl\n"));
+	writeFile(externalDb, QByteArrayLiteral("external prefs"));
+
+	const QString destinationConnectionName =
+	    QStringLiteral("tst_mushclient_import_symlink_destination_prefs");
+	QSqlDatabase destinationPreferencesDb;
+	openTestDatabase(QDir(home).filePath(QStringLiteral("QMud.sqlite")), destinationConnectionName,
+	                 destinationPreferencesDb);
+
+	std::error_code error;
+	std::filesystem::create_symlink(externalIni.toStdString(),
+	                                QDir(mush).filePath(QStringLiteral("MUSHclient.ini")).toStdString(),
+	                                error);
+	if (error)
+		QSKIP(qPrintable(
+		    QStringLiteral("File symlinks unavailable: %1").arg(QString::fromStdString(error.message()))));
+
+	std::filesystem::create_symlink(
+	    externalDb.toStdString(),
+	    QDir(mush).filePath(QStringLiteral("mushclient_prefs.sqlite")).toStdString(), error);
+	if (error)
+		QSKIP(qPrintable(
+		    QStringLiteral("File symlinks unavailable: %1").arg(QString::fromStdString(error.message()))));
+
+	QMudMushclientImportUtils::ImportStats stats = QMudMushclientImportUtils::importDirectory(mush, home);
+	QMudMushclientImportUtils::importPreferencesDatabase(mush, destinationPreferencesDb, stats);
+	destinationPreferencesDb.close();
+	destinationPreferencesDb = QSqlDatabase();
+	QSqlDatabase::removeDatabase(destinationConnectionName);
+
+	QCOMPARE(stats.configsImported, 0);
+	QCOMPARE(stats.preferenceDatabasesImported, 0);
+	QVERIFY(stats.errors >= 1);
+	QVERIFY(stats.filesSkippedFiltered >= 1);
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("QMud.conf"))).exists());
+}
+#endif
+
+QTEST_MAIN(tst_MushclientImportUtils)
+#include "tst_MushclientImportUtils.moc"

--- a/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
+++ b/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
@@ -10,6 +10,7 @@
 
 #include "WorldCommandProcessorUtils.h"
 #include "WorldOptions.h"
+#include "scripting/ScriptingErrors.h"
 
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QHostAddress>
@@ -280,6 +281,36 @@ class tst_WorldCommandProcessor_Trigger : public QObject
 			                      QStringLiteral("qcmd-priority-c83"), QStringLiteral("qcmd-priority-e05"),
 			                      QStringLiteral("qcmd-tail-9f31"), QStringLiteral("qcmd-normal-d64")}));
 			QCOMPARE(queuedTypes(processor), (QList<bool>{false, false, false, false, true, false}));
+		}
+
+		static void userMacroCommandSuppressesAutoSayDuringEvaluation()
+		{
+			QTcpServer server;
+			if (!server.listen(QHostAddress::LocalHost, 0))
+				QSKIP("Local TCP listen is unavailable in this environment.");
+
+			WorldRuntime runtime;
+			runtime.setWorldAttribute(QStringLiteral("enable_auto_say"), QStringLiteral("1"));
+			runtime.setWorldAttribute(QStringLiteral("auto_say_string"), QStringLiteral("say "));
+			runtime.setCurrentActionSource(WorldRuntime::eUserMacro);
+
+			WorldCommandProcessor processor;
+			processor.setRuntime(&runtime);
+
+			QSignalSpy connectedSpy(&runtime, &WorldRuntime::connected);
+			QVERIFY(connectedSpy.isValid());
+			QSignalSpy serverAcceptedSpy(&server, &QTcpServer::newConnection);
+			QVERIFY(serverAcceptedSpy.isValid());
+
+			QVERIFY(runtime.connectToWorld(QStringLiteral("127.0.0.1"), server.serverPort()));
+			QVERIFY(connectedSpy.wait(5000));
+			QTRY_VERIFY_WITH_TIMEOUT(server.hasPendingConnections() || serverAcceptedSpy.count() > 0, 5000);
+			QScopedPointer<QTcpSocket> acceptedSocket(server.nextPendingConnection());
+			QVERIFY(!acceptedSocket.isNull());
+
+			QCOMPARE(processor.executeUserMacroSendNow(QStringLiteral("hello"), false), eOK);
+			QVERIFY(acceptedSocket->waitForReadyRead(5000));
+			QCOMPARE(QString::fromUtf8(acceptedSocket->readAll()), QStringLiteral("hello\r\n"));
 		}
 };
 

--- a/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
+++ b/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
@@ -315,9 +315,10 @@ class tst_WorldCommandProcessor_Trigger : public QObject
 				if (acceptedSocket->bytesAvailable() == 0)
 					acceptedSocket->waitForReadyRead(10);
 				received += acceptedSocket->readAll();
-				return received;
+				return received.contains("hello\r\n");
 			};
-			QTRY_COMPARE_WITH_TIMEOUT(receivedMacroCommand(), QByteArrayLiteral("hello\r\n"), 5000);
+			QTRY_VERIFY_WITH_TIMEOUT(receivedMacroCommand(), 5000);
+			QVERIFY(!received.contains("say hello\r\n"));
 		}
 };
 

--- a/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
+++ b/tests/integration/tst_WorldCommandProcessor_Trigger.cpp
@@ -309,8 +309,15 @@ class tst_WorldCommandProcessor_Trigger : public QObject
 			QVERIFY(!acceptedSocket.isNull());
 
 			QCOMPARE(processor.executeUserMacroSendNow(QStringLiteral("hello"), false), eOK);
-			QVERIFY(acceptedSocket->waitForReadyRead(5000));
-			QCOMPARE(QString::fromUtf8(acceptedSocket->readAll()), QStringLiteral("hello\r\n"));
+			QByteArray received;
+			auto       receivedMacroCommand = [&acceptedSocket, &received]
+			{
+				if (acceptedSocket->bytesAvailable() == 0)
+					acceptedSocket->waitForReadyRead(10);
+				received += acceptedSocket->readAll();
+				return received;
+			};
+			QTRY_COMPARE_WITH_TIMEOUT(receivedMacroCommand(), QByteArrayLiteral("hello\r\n"), 5000);
 		}
 };
 

--- a/tests/unit/tst_IndexedRingBuffer.cpp
+++ b/tests/unit/tst_IndexedRingBuffer.cpp
@@ -117,6 +117,102 @@ class tst_IndexedRingBuffer : public QObject
 			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 5, 8, 9}));
 		}
 
+		void wrappedReplaceGrowthNearFrontShiftsPrefixOnce()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 8, 9}));
+			buffer.remove(0, 2);
+			buffer.push_back(10);
+			buffer.push_back(11);
+
+			buffer.replace(1, 1, 3, 7);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 7, 7, 7, 8, 9, 10, 11}));
+		}
+
+		void wrappedReplaceGrowthNearBackShiftsSuffixOnce()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 5, 9}));
+			buffer.remove(0, 2);
+			buffer.push_back(10);
+			buffer.push_back(11);
+
+			buffer.replace(3, 1, 3, 8);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 5, 8, 8, 8, 10, 11}));
+		}
+
+		void wrappedReplaceShrinkNearFrontShiftsPrefixOnce()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 5, 6, 7, 8}));
+			buffer.remove(0, 2);
+			buffer.push_back(9);
+			buffer.push_back(10);
+
+			buffer.replace(1, 3, 1, 11);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 11, 7, 8, 9, 10}));
+		}
+
+		void wrappedReplaceShrinkNearBackShiftsSuffixOnce()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 5, 6, 7, 8}));
+			buffer.remove(0, 2);
+			buffer.push_back(9);
+			buffer.push_back(10);
+
+			buffer.replace(4, 3, 1, 11);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 5, 6, 11, 10}));
+		}
+
+		void replaceInsertOnlyAtFront()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4}));
+			buffer.remove(0, 2);
+			buffer.push_back(5);
+			buffer.push_back(6);
+
+			buffer.replace(0, 0, 2, 9);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({9, 9, 3, 4, 5, 6}));
+		}
+
+		void replaceAppendOnlyAtBack()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4}));
+			buffer.remove(0, 2);
+			buffer.push_back(5);
+			buffer.push_back(6);
+
+			buffer.replace(buffer.size(), 0, 2, 9);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 5, 6, 9, 9}));
+		}
+
+		void replaceEqualSizeKeepsUnchangedSides()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 5, 6}));
+			buffer.remove(0, 2);
+			buffer.push_back(7);
+			buffer.push_back(8);
+
+			buffer.replace(2, 2, 2, 9);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 9, 9, 7, 8}));
+		}
+
+		void replaceRemoveOnlyInMiddle()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 5, 6, 7}));
+			buffer.remove(0, 2);
+			buffer.push_back(8);
+			buffer.push_back(9);
+
+			buffer.replace(2, 3, 0, 0);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 8, 9}));
+		}
+
 		void iteratorsSupportAlgorithmsInLogicalOrder()
 		{
 			IndexedRingBuffer<int> buffer(QVector<int>({1, 3, 5, 7, 9}));

--- a/tests/unit/tst_IndexedRingBuffer.cpp
+++ b/tests/unit/tst_IndexedRingBuffer.cpp
@@ -1,0 +1,142 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_IndexedRingBuffer.cpp
+ * Role: QTest coverage for IndexedRingBuffer logical indexing and head-trim behavior.
+ */
+
+#include "IndexedRingBuffer.h"
+
+#include <QtTest/QTest>
+
+#include <algorithm>
+#include <ranges>
+
+static_assert(std::random_access_iterator<IndexedRingBuffer<int>::iterator>);
+static_assert(std::random_access_iterator<IndexedRingBuffer<int>::const_iterator>);
+static_assert(std::ranges::random_access_range<IndexedRingBuffer<int>>);
+static_assert(std::ranges::random_access_range<const IndexedRingBuffer<int>>);
+
+/**
+ * @brief QTest fixture covering IndexedRingBuffer container behavior.
+ */
+class tst_IndexedRingBuffer : public QObject
+{
+		Q_OBJECT
+
+		// NOLINTBEGIN(readability-convert-member-functions-to-static)
+	private slots:
+		void headRemovalPreservesLogicalOrder()
+		{
+			IndexedRingBuffer<int> buffer;
+			for (int value = 1; value <= 6; ++value)
+				buffer.push_back(value);
+
+			buffer.remove(0, 3);
+			buffer.push_back(7);
+			buffer.push_back(8);
+
+			QCOMPARE(buffer.size(), 5);
+			QCOMPARE(buffer.at(0), 4);
+			QCOMPARE(buffer.at(1), 5);
+			QCOMPARE(buffer.at(2), 6);
+			QCOMPARE(buffer.at(3), 7);
+			QCOMPARE(buffer.at(4), 8);
+			QCOMPARE(buffer.toVector(), QVector<int>({4, 5, 6, 7, 8}));
+		}
+
+		void resizeAfterHeadRemovalKeepsIndexingContiguous()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({10, 20, 30, 40, 50}));
+
+			buffer.removeFirst();
+			buffer.removeFirst();
+			buffer.resize(5);
+			buffer[3] = 60;
+			buffer[4] = 70;
+
+			QCOMPARE(buffer.toVector(), QVector<int>({30, 40, 50, 60, 70}));
+		}
+
+		void middleInsertAndEraseMaintainLogicalSequence()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 4, 5}));
+			buffer.removeFirst();
+			buffer.insert(1, 3);
+			buffer.erase(buffer.begin() + 2);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({2, 3, 5}));
+		}
+
+		void wrappedInsertNearFrontShiftsPrefixOnly()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 4, 5, 6, 7}));
+			buffer.remove(0, 2);
+			buffer.push_back(8);
+			buffer.push_back(9);
+
+			buffer.insert(1, 3);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({4, 3, 5, 6, 7, 8, 9}));
+		}
+
+		void wrappedInsertNearBackShiftsSuffixOnly()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 6, 7}));
+			buffer.remove(0, 2);
+			buffer.push_back(8);
+			buffer.push_back(9);
+
+			buffer.insert(3, 5);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 6, 5, 7, 8, 9}));
+		}
+
+		void wrappedRemoveNearFrontShiftsPrefixOnly()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 5, 6, 7}));
+			buffer.remove(0, 2);
+			buffer.push_back(8);
+			buffer.push_back(9);
+
+			buffer.remove(2, 2);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 7, 8, 9}));
+		}
+
+		void wrappedRemoveNearBackShiftsSuffixOnly()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 2, 3, 4, 5, 6, 7}));
+			buffer.remove(0, 2);
+			buffer.push_back(8);
+			buffer.push_back(9);
+
+			buffer.remove(3, 2);
+
+			QCOMPARE(buffer.toVector(), QVector<int>({3, 4, 5, 8, 9}));
+		}
+
+		void iteratorsSupportAlgorithmsInLogicalOrder()
+		{
+			IndexedRingBuffer<int> buffer(QVector<int>({1, 3, 5, 7, 9}));
+			buffer.remove(0, 2);
+			buffer.push_back(11);
+			buffer.push_back(13);
+
+			const IndexedRingBuffer<int> &constBuffer = buffer;
+			const auto                    found       = std::ranges::upper_bound(constBuffer, 10);
+			QVERIFY(found != constBuffer.cend());
+			QCOMPARE(*found, 11);
+
+			std::ranges::fill(buffer, 4);
+			QCOMPARE(buffer.toVector(), QVector<int>({4, 4, 4, 4, 4}));
+		}
+		// NOLINTEND(readability-convert-member-functions-to-static)
+};
+
+QTEST_APPLESS_MAIN(tst_IndexedRingBuffer)
+
+#if __has_include("tst_IndexedRingBuffer.moc")
+#include "tst_IndexedRingBuffer.moc"
+#endif

--- a/tests/unit/tst_LuaCallbackEngine.cpp
+++ b/tests/unit/tst_LuaCallbackEngine.cpp
@@ -122,7 +122,7 @@ namespace
 		return size > kMaxInt ? std::numeric_limits<int>::max() : static_cast<int>(size);
 	}
 
-	QStringList logicalOutputLinesFromEntries(const QVector<WorldRuntime::LineEntry> &entries)
+	template <typename Entries> QStringList logicalOutputLinesFromEntries(const Entries &entries)
 	{
 		QStringList lines;
 		QString     currentLine;
@@ -2061,7 +2061,7 @@ end
 	QVERIFY(!result.deferredRuntimeMutationBatches.isEmpty());
 	executeDeferredMutations(result);
 
-	const QVector<WorldRuntime::LineEntry> &lines = runtime.lines();
+	const auto &lines = runtime.lines();
 	QCOMPARE(logicalOutputLinesFromEntries(lines), QStringList({QStringLiteral("[435, 1226]"), prompt}));
 	teardownWorkerEngine(executor, engine);
 }

--- a/tests/unit/tst_NativePluginRegistry.cpp
+++ b/tests/unit/tst_NativePluginRegistry.cpp
@@ -783,7 +783,7 @@ class tst_NativePluginRegistry : public QObject
 
 			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), true));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
-			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 
 			events.clear();
 			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
@@ -793,7 +793,7 @@ class tst_NativePluginRegistry : public QObject
 
 			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
-			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 			QVERIFY(events.size() >= 3);
 			QVERIFY(events.at(events.size() - 2).stop);
 			QCOMPARE(events.constLast().text, QStringLiteral("speech off"));
@@ -805,14 +805,14 @@ class tst_NativePluginRegistry : public QObject
 
 			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), true));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
-			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
 			                                                     QStringLiteral("still muted line"));
 			QVERIFY(events.isEmpty());
 
 			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
-			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 
 			events.clear();
 			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
@@ -822,8 +822,16 @@ class tst_NativePluginRegistry : public QObject
 
 			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), false));
 			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
-			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 
+			events.clear();
+			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
+			                                                     QStringLiteral("passive disabled line"));
+			QVERIFY(events.isEmpty());
+
+			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts")));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
+			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 			events.clear();
 			QMudNativePluginRegistry::handleMushReaderScreenDraw(&runtime, 1, 0,
 			                                                     QStringLiteral("passive line"));
@@ -832,13 +840,13 @@ class tst_NativePluginRegistry : public QObject
 
 			QVERIFY(runtime.enablePlugin(QMudNativePluginRegistry::mushReaderPluginId(), true));
 			QVERIFY(QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
-			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 
 			QString unloadError;
 			QVERIFY(runtime.unloadPlugin(QMudNativePluginRegistry::mushReaderPluginId(), &unloadError));
 			QVERIFY(unloadError.isEmpty());
 			QVERIFY(!QMudNativePluginRegistry::isMushReaderPluginEnabled(&runtime));
-			QVERIFY(QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
+			QVERIFY(!QMudNativePluginRegistry::isMushReaderPassiveSpeechEnabled(&runtime));
 		}
 
 		void blacklistAndProtectedPluginXmlClassification()

--- a/tests/unit/tst_NativePluginRegistry.cpp
+++ b/tests/unit/tst_NativePluginRegistry.cpp
@@ -728,6 +728,21 @@ class tst_NativePluginRegistry : public QObject
 			QCOMPARE(events.size(), 6);
 		}
 
+		void silentStopPathsDoNotInitializeSpeechBackends()
+		{
+			WorldRuntime runtime;
+			QCOMPARE(QMudNativePluginRegistry::mushReaderTestBackendCount(&runtime), std::size_t{0});
+
+			QMudNativePluginRegistry::setMushReaderPluginEnabled(&runtime, false);
+			QCOMPARE(QMudNativePluginRegistry::mushReaderTestBackendCount(&runtime), std::size_t{0});
+
+			QMudNativePluginRegistry::setMushReaderPassiveSpeechEnabled(&runtime, false);
+			QCOMPARE(QMudNativePluginRegistry::mushReaderTestBackendCount(&runtime), std::size_t{0});
+
+			QVERIFY(QMudNativePluginRegistry::handleMushReaderCommand(&runtime, QStringLiteral("tts_stop")));
+			QCOMPARE(QMudNativePluginRegistry::mushReaderTestBackendCount(&runtime), std::size_t{0});
+		}
+
 		void runtimeSetupRegistersNativeAccelerator()
 		{
 			WorldRuntime runtime;

--- a/tests/unit/tst_SoundFileRoutingUtils.cpp
+++ b/tests/unit/tst_SoundFileRoutingUtils.cpp
@@ -1,0 +1,186 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_SoundFileRoutingUtils.cpp
+ * Role: Unit coverage for sound file backend routing helpers.
+ */
+
+#include "SoundFileRoutingUtils.h"
+
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QDir>
+#include <QFile>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <QTemporaryDir>
+
+#include <QtTest/QTest>
+
+namespace
+{
+	/**
+	 * @brief Appends a 16-bit little-endian value to byte data.
+	 * @param data Mutable destination data.
+	 * @param value Value to append.
+	 */
+	void appendLe16(QByteArray &data, const quint16 value)
+	{
+		data.append(static_cast<char>(value & 0xFFU));
+		data.append(static_cast<char>((value >> 8U) & 0xFFU));
+	}
+
+	/**
+	 * @brief Appends a 32-bit little-endian value to byte data.
+	 * @param data Mutable destination data.
+	 * @param value Value to append.
+	 */
+	void appendLe32(QByteArray &data, const quint32 value)
+	{
+		data.append(static_cast<char>(value & 0xFFU));
+		data.append(static_cast<char>((value >> 8U) & 0xFFU));
+		data.append(static_cast<char>((value >> 16U) & 0xFFU));
+		data.append(static_cast<char>((value >> 24U) & 0xFFU));
+	}
+
+	/**
+	 * @brief Builds a minimal RIFF/WAVE file payload.
+	 * @param formatTag WAVE format tag.
+	 * @param extensiblePcm Whether to include an extensible PCM subformat GUID.
+	 * @return Encoded WAVE file bytes.
+	 */
+	QByteArray waveBytes(const quint16 formatTag, const bool extensiblePcm = false)
+	{
+		QByteArray formatChunk;
+		appendLe16(formatChunk, formatTag);
+		appendLe16(formatChunk, 1);
+		appendLe32(formatChunk, 44100);
+		appendLe32(formatChunk, 88200);
+		appendLe16(formatChunk, 2);
+		appendLe16(formatChunk, 16);
+		if (extensiblePcm)
+		{
+			appendLe16(formatChunk, 22);
+			appendLe16(formatChunk, 16);
+			appendLe32(formatChunk, 3);
+			formatChunk.append(QByteArray::fromHex("0100000000001000800000AA00389B71"));
+		}
+
+		QByteArray data;
+		data.append("RIFF", 4);
+		appendLe32(data, static_cast<quint32>(4 + 8 + formatChunk.size() + 8));
+		data.append("WAVE", 4);
+		data.append("fmt ", 4);
+		appendLe32(data, static_cast<quint32>(formatChunk.size()));
+		data.append(formatChunk);
+		if ((formatChunk.size() % 2) != 0)
+			data.append('\0');
+		data.append("data", 4);
+		appendLe32(data, 0);
+		return data;
+	}
+
+	/**
+	 * @brief Writes a temporary sound file for routing tests.
+	 * @param dir Temporary directory.
+	 * @param fileName File name below the temporary directory.
+	 * @param bytes File bytes.
+	 * @return Absolute file path.
+	 */
+	QString writeSoundFile(const QTemporaryDir &dir, const QString &fileName, const QByteArray &bytes)
+	{
+		const QString path = QDir(dir.path()).filePath(fileName);
+		QFile         file(path);
+		if (!file.open(QIODevice::WriteOnly))
+			return {};
+		if (file.write(bytes) != static_cast<qint64>(bytes.size()))
+			return {};
+		return file.fileName();
+	}
+} // namespace
+
+/**
+ * @brief QTest fixture for sound file playback backend routing.
+ */
+class tst_SoundFileRoutingUtils : public QObject
+{
+		Q_OBJECT
+
+	private slots:
+		/**
+		 * @brief Verifies ordinary PCM WAV files are routed to QSoundEffect.
+		 */
+		static void pcmWaveUsesSoundEffect()
+		{
+			QTemporaryDir dir;
+			QVERIFY(dir.isValid());
+
+			const QString path = writeSoundFile(dir, QStringLiteral("plain.wav"), waveBytes(0x0001));
+			QVERIFY(!path.isEmpty());
+
+			QCOMPARE(soundFilePlaybackBackendForFile(path), SoundFilePlaybackBackend::QSoundEffect);
+		}
+
+		/**
+		 * @brief Verifies extensible PCM WAV files are routed to QSoundEffect.
+		 */
+		static void extensiblePcmWaveUsesSoundEffect()
+		{
+			QTemporaryDir dir;
+			QVERIFY(dir.isValid());
+
+			const QString path =
+			    writeSoundFile(dir, QStringLiteral("extensible.wave"), waveBytes(0xFFFE, true));
+			QVERIFY(!path.isEmpty());
+
+			QCOMPARE(soundFilePlaybackBackendForFile(path), SoundFilePlaybackBackend::QSoundEffect);
+		}
+
+		/**
+		 * @brief Verifies compressed WAV containers are routed to QMediaPlayer.
+		 */
+		static void compressedWaveUsesMediaPlayer()
+		{
+			QTemporaryDir dir;
+			QVERIFY(dir.isValid());
+
+			const QString path = writeSoundFile(dir, QStringLiteral("compressed.wav"), waveBytes(0x0055));
+			QVERIFY(!path.isEmpty());
+
+			QCOMPARE(soundFilePlaybackBackendForFile(path), SoundFilePlaybackBackend::QMediaPlayer);
+		}
+
+		/**
+		 * @brief Verifies malformed WAV files are routed away from QSoundEffect.
+		 */
+		static void malformedWaveUsesMediaPlayer()
+		{
+			QTemporaryDir dir;
+			QVERIFY(dir.isValid());
+
+			const QString path =
+			    writeSoundFile(dir, QStringLiteral("broken.wav"), QByteArrayLiteral("not wave"));
+			QVERIFY(!path.isEmpty());
+
+			QCOMPARE(soundFilePlaybackBackendForFile(path), SoundFilePlaybackBackend::QMediaPlayer);
+		}
+
+		/**
+		 * @brief Verifies non-WAV file names use QMediaPlayer.
+		 */
+		static void nonWaveUsesMediaPlayer()
+		{
+			QTemporaryDir dir;
+			QVERIFY(dir.isValid());
+
+			const QString path = writeSoundFile(dir, QStringLiteral("music.ogg"), QByteArrayLiteral("OggS"));
+			QVERIFY(!path.isEmpty());
+
+			QCOMPARE(soundFilePlaybackBackendForFile(path), SoundFilePlaybackBackend::QMediaPlayer);
+		}
+};
+
+QTEST_APPLESS_MAIN(tst_SoundFileRoutingUtils)
+
+#if __has_include("tst_SoundFileRoutingUtils.moc")
+#include "tst_SoundFileRoutingUtils.moc"
+#endif

--- a/tests/unit/tst_UpdateCheckUtils.cpp
+++ b/tests/unit/tst_UpdateCheckUtils.cpp
@@ -99,7 +99,7 @@ class tst_UpdateCheckUtils : public QObject
 		{
 			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.08-ci"), QJsonArray());
 			const auto       result  = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
+			    payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::NoStableRelease);
 		}
 
@@ -110,8 +110,26 @@ class tst_UpdateCheckUtils : public QObject
 		{
 			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.04"), QJsonArray());
 			const auto       result  = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
+			    payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::UpToDate);
+		}
+
+		/**
+		 * @brief Verifies stable same-version release replaces a running CI build.
+		 */
+		void evaluateLatestReleasePayloadOffersStableReleaseForEqualCiVersion()
+		{
+			QJsonArray assets;
+			assets.push_back(makeAsset(QStringLiteral("QMud-10.04-x86_64.AppImage"),
+			                           QStringLiteral("https://example.invalid/qmud.appimage"),
+			                           QStringLiteral("sha256:%1").arg(sampleSha256())));
+			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.04"), assets);
+			const auto       result =
+			    QMudUpdateCheck::evaluateLatestReleasePayload(payload, QStringLiteral("10.04-ci"), QString(),
+			                                                  QMudUpdateCheck::InstallTarget::LinuxAppImage);
+			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::UpdateAvailable);
+			QCOMPARE(result.releaseVersion, QStringLiteral("10.04"));
+			QCOMPARE(result.asset.name, QStringLiteral("QMud-10.04-x86_64.AppImage"));
 		}
 
 		/**
@@ -127,8 +145,8 @@ class tst_UpdateCheckUtils : public QObject
 			                                                    QStringLiteral("fixes and features"));
 
 			const auto       result = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QStringLiteral("10.06"),
-                QMudUpdateCheck::InstallTarget::LinuxAppImage);
+			    payload, QStringLiteral("10.04"), QStringLiteral("10.06"),
+			    QMudUpdateCheck::InstallTarget::LinuxAppImage);
 
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::UpdateAvailable);
 			QCOMPARE(result.releaseVersion, QStringLiteral("10.07"));
@@ -152,8 +170,8 @@ class tst_UpdateCheckUtils : public QObject
 			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.07"), assets);
 
 			const auto       result = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QStringLiteral("10.07"),
-                QMudUpdateCheck::InstallTarget::LinuxAppImage);
+			    payload, QStringLiteral("10.04"), QStringLiteral("10.07"),
+			    QMudUpdateCheck::InstallTarget::LinuxAppImage);
 
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::UpdateAvailable);
 			QVERIFY(!result.clearSkipVersion);
@@ -171,7 +189,7 @@ class tst_UpdateCheckUtils : public QObject
 			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.07"), assets);
 
 			const auto       result = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
+			    payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
 
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::NoCompatibleAsset);
 			QCOMPARE(result.releaseVersion, QStringLiteral("10.07"));
@@ -205,7 +223,7 @@ class tst_UpdateCheckUtils : public QObject
 			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.07"), assets);
 
 			const auto       result = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
+			    payload, QStringLiteral("10.04"), QString(), QMudUpdateCheck::InstallTarget::LinuxAppImage);
 
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::NoCompatibleAsset);
 		}
@@ -225,8 +243,8 @@ class tst_UpdateCheckUtils : public QObject
 
 			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.07"), assets);
 			const auto       result  = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QString(),
-                QMudUpdateCheck::InstallTarget::WindowsInstaller);
+			    payload, QStringLiteral("10.04"), QString(),
+			    QMudUpdateCheck::InstallTarget::WindowsInstaller);
 
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::UpdateAvailable);
 			QCOMPARE(result.asset.name, QStringLiteral("QMud-10.07-win-setup.exe"));
@@ -245,8 +263,8 @@ class tst_UpdateCheckUtils : public QObject
 
 			const QByteArray payload = makeLatestReleasePayload(QStringLiteral("v10.07"), assets);
 			const auto       result  = QMudUpdateCheck::evaluateLatestReleasePayload(
-                payload, QStringLiteral("10.04"), QString(),
-                QMudUpdateCheck::InstallTarget::WindowsInstaller);
+			    payload, QStringLiteral("10.04"), QString(),
+			    QMudUpdateCheck::InstallTarget::WindowsInstaller);
 
 			QCOMPARE(result.status, QMudUpdateCheck::ReleaseEvaluationStatus::NoCompatibleAsset);
 		}
@@ -254,7 +272,6 @@ class tst_UpdateCheckUtils : public QObject
 };
 
 QTEST_MAIN(tst_UpdateCheckUtils)
-
 
 #if __has_include("tst_UpdateCheckUtils.moc")
 #include "tst_UpdateCheckUtils.moc"

--- a/tests/unit/tst_WorldRuntime_OutputBufferSeal.cpp
+++ b/tests/unit/tst_WorldRuntime_OutputBufferSeal.cpp
@@ -1,0 +1,190 @@
+/*
+ * QMud Project
+ * Copyright (c) 2026 Panagiotis Kalogiratos (Nodens)
+ *
+ * File: tst_WorldRuntime_OutputBufferSeal.cpp
+ * Role: Unit coverage for WorldRuntime session-state output-buffer sealing.
+ */
+
+#include "WorldRuntime.h"
+
+#include <QDateTime>
+#include <QtTest/QTest>
+
+namespace
+{
+	/**
+	 * @brief Builds a deterministic output line for replacement assertions.
+	 * @param text Line text.
+	 * @param lineNumber Absolute runtime line number.
+	 * @return Runtime line entry.
+	 */
+	WorldRuntime::LineEntry makeLine(const QString &text, const qint64 lineNumber)
+	{
+		WorldRuntime::LineEntry line;
+		line.text       = text;
+		line.flags      = WorldRuntime::LineOutput;
+		line.hardReturn = true;
+		line.time       = QDateTime::fromMSecsSinceEpoch(1710000000000 + lineNumber);
+		line.lineNumber = lineNumber;
+		line.ticks      = static_cast<double>(lineNumber);
+		line.elapsed    = static_cast<double>(lineNumber);
+		return line;
+	}
+} // namespace
+
+/**
+ * @brief QTest fixture covering the runtime output-buffer save seal.
+ */
+class tst_WorldRuntime_OutputBufferSeal : public QObject
+{
+		Q_OBJECT
+
+		// NOLINTBEGIN(readability-convert-member-functions-to-static)
+	private slots:
+		void sealBlocksAppendReplaceBookmarkAndDelete()
+		{
+			WorldRuntime::StyleSpan span;
+			span.length = 14;
+			span.fore   = QColor(QStringLiteral("#112233"));
+
+			WorldRuntime runtime;
+			runtime.addLine(QStringLiteral("base"), WorldRuntime::LineOutput);
+			QCOMPARE(runtime.lines().size(), 1);
+			QCOMPARE(runtime.lines().at(0).text, QStringLiteral("base"));
+
+			runtime.setSessionStateOutputBufferSealed(true);
+			QVERIFY(runtime.isSessionStateOutputBufferSealed());
+			runtime.addLine(QStringLiteral("blocked-append"), WorldRuntime::LineOutput);
+			runtime.addLine(QStringLiteral("blocked-styled"), WorldRuntime::LineOutput,
+			                QVector<WorldRuntime::StyleSpan>{span});
+			runtime.replaceOutputLines(
+			    QVector<WorldRuntime::LineEntry>{makeLine(QStringLiteral("blocked-replace"), 50)});
+			runtime.bookmarkLine(1, true);
+			runtime.deleteLines(1);
+			runtime.deleteOutput();
+
+			QCOMPARE(runtime.lines().size(), 1);
+			QCOMPARE(runtime.lines().at(0).text, QStringLiteral("base"));
+			QVERIFY((runtime.lines().at(0).flags & WorldRuntime::LineBookmark) == 0);
+
+			runtime.setSessionStateOutputBufferSealed(false);
+			QVERIFY(!runtime.isSessionStateOutputBufferSealed());
+			runtime.addLine(QStringLiteral("after-unseal"), WorldRuntime::LineOutput);
+			QCOMPARE(runtime.lines().size(), 2);
+			QCOMPARE(runtime.lines().at(1).text, QStringLiteral("after-unseal"));
+			runtime.addLine(QStringLiteral("styled-after-unseal"), WorldRuntime::LineOutput,
+			                QVector<WorldRuntime::StyleSpan>{span});
+			QCOMPARE(runtime.lines().size(), 3);
+			QCOMPARE(runtime.lines().at(2).text, QStringLiteral("styled-after-unseal"));
+			QCOMPARE(runtime.lines().at(2).spans.size(), 1);
+
+			runtime.replaceOutputLines(
+			    QVector<WorldRuntime::LineEntry>{makeLine(QStringLiteral("replacement"), 80)});
+			QCOMPARE(runtime.lines().size(), 1);
+			QCOMPARE(runtime.lines().at(0).text, QStringLiteral("replacement"));
+
+			runtime.bookmarkLine(1, true);
+			QVERIFY((runtime.lines().at(0).flags & WorldRuntime::LineBookmark) != 0);
+
+			runtime.deleteLines(1);
+			QCOMPARE(runtime.lines().size(), 0);
+
+			runtime.addLine(QStringLiteral("clearable"), WorldRuntime::LineOutput);
+			QCOMPARE(runtime.lines().size(), 1);
+			runtime.deleteOutput();
+			QCOMPARE(runtime.lines().size(), 0);
+		}
+
+		void sealBlocksHardReturnMutations()
+		{
+			WorldRuntime runtime;
+			runtime.addLine(QStringLiteral("input"), WorldRuntime::LineInput, false);
+			QCOMPARE(runtime.lines().size(), 1);
+			QVERIFY(!runtime.lines().at(0).hardReturn);
+
+			runtime.setSessionStateOutputBufferSealed(true);
+			runtime.finalizePendingInputLineHardReturn();
+			QVERIFY(!runtime.lines().at(0).hardReturn);
+
+			runtime.setSessionStateOutputBufferSealed(false);
+			runtime.finalizePendingInputLineHardReturn();
+			QVERIFY(runtime.lines().at(0).hardReturn);
+
+			runtime.setSessionStateOutputBufferSealed(true);
+			runtime.clearLastLineHardReturn();
+			QVERIFY(runtime.lines().at(0).hardReturn);
+
+			runtime.setSessionStateOutputBufferSealed(false);
+			runtime.clearLastLineHardReturn();
+			QVERIFY(!runtime.lines().at(0).hardReturn);
+		}
+
+		void sealBlocksLuaContextLineMutations()
+		{
+			WorldRuntime runtime;
+			runtime.beginIncomingLineLuaContext(QStringLiteral("incoming"), WorldRuntime::LineOutput, {});
+
+			runtime.setSessionStateOutputBufferSealed(true);
+			QVERIFY(!runtime.reserveIncomingLineLuaContextInBuffer());
+			QCOMPARE(runtime.lines().size(), 0);
+
+			runtime.setSessionStateOutputBufferSealed(false);
+			QVERIFY(runtime.reserveIncomingLineLuaContextInBuffer());
+			QCOMPARE(runtime.lines().size(), 1);
+			QCOMPARE(runtime.lines().at(0).text, QStringLiteral("incoming"));
+
+			runtime.setSessionStateOutputBufferSealed(true);
+			QVERIFY(!runtime.updateBufferedIncomingLineLuaContext(QStringLiteral("blocked-update"),
+			                                                      WorldRuntime::LineOutput, {}));
+			QVERIFY(!runtime.hideBufferedIncomingLineLuaContextForReplacement());
+			QVERIFY(!runtime.removeBufferedIncomingLineLuaContext());
+			QCOMPARE(runtime.lines().size(), 1);
+			QCOMPARE(runtime.lines().at(0).text, QStringLiteral("incoming"));
+			QVERIFY((runtime.lines().at(0).flags & WorldRuntime::LineHidden) == 0);
+
+			runtime.setSessionStateOutputBufferSealed(false);
+			QVERIFY(runtime.updateBufferedIncomingLineLuaContext(QStringLiteral("updated"),
+			                                                     WorldRuntime::LineOutput, {}));
+			QCOMPARE(runtime.lines().at(0).text, QStringLiteral("updated"));
+			QVERIFY(runtime.hideBufferedIncomingLineLuaContextForReplacement());
+			QVERIFY((runtime.lines().at(0).flags & WorldRuntime::LineHidden) != 0);
+
+			const qint64 hiddenLineNumber = runtime.lines().at(0).lineNumber;
+			runtime.setSessionStateOutputBufferSealed(true);
+			QVERIFY(!runtime.removeHiddenLuaContextLineByAbsoluteNumber(hiddenLineNumber));
+			QCOMPARE(runtime.lines().size(), 1);
+
+			runtime.setSessionStateOutputBufferSealed(false);
+			QVERIFY(runtime.removeHiddenLuaContextLineByAbsoluteNumber(hiddenLineNumber));
+			QCOMPARE(runtime.lines().size(), 0);
+		}
+
+		void sealBlocksLuaCallbackAnchorWrites()
+		{
+			WorldRuntime runtime;
+			runtime.addLine(QStringLiteral("anchor"), WorldRuntime::LineOutput);
+			QCOMPARE(runtime.lines().size(), 1);
+			const qint64 anchorLineNumber = runtime.lines().at(0).lineNumber;
+
+			runtime.setSessionStateOutputBufferSealed(true);
+			QVERIFY(!runtime.writeLuaCallbackOutputAtLineAnchor(anchorLineNumber, 1, false,
+			                                                    QStringLiteral("blocked-anchor"),
+			                                                    WorldRuntime::LineOutput, {}, true));
+			QCOMPARE(runtime.lines().size(), 1);
+			QCOMPARE(runtime.lines().at(0).text, QStringLiteral("anchor"));
+
+			runtime.setSessionStateOutputBufferSealed(false);
+			QVERIFY(runtime.writeLuaCallbackOutputAtLineAnchor(
+			    anchorLineNumber, 1, false, QStringLiteral("inserted"), WorldRuntime::LineOutput, {}, true));
+			QCOMPARE(runtime.lines().size(), 2);
+			QCOMPARE(runtime.lines().at(1).text, QStringLiteral("inserted"));
+		}
+		// NOLINTEND(readability-convert-member-functions-to-static)
+};
+
+QTEST_MAIN(tst_WorldRuntime_OutputBufferSeal)
+
+#if __has_include("tst_WorldRuntime_OutputBufferSeal.moc")
+#include "tst_WorldRuntime_OutputBufferSeal.moc"
+#endif


### PR DESCRIPTION
## Summary

- Properly support compressed audio formats.
- Fix MushReader and passive TTS engine layering.
- Refactor TTS engine teardown.
- Implement Import from MUSHclient functionality. This largely simplifies importing from MUSHcleint. Help -> Import from MUSHclient.
- Allow update from CI build to stable if same version.
- Fix Macro Send now and Replace parity. Send now in particular was not going through the command input.
- Adjust tab focus. A few widgets were consuming tab presses internally, making it hard for VI users to cycle to all available widgets.
- Increase max command input history size to 50k.
- Refactor view caches. Huge performance optimizations here as now now nothing rebuilds caches from 0. That only happens as a fallback that should normally be reachable only if there's an edge case bub with deltas handling.
- Update README.
- Implement custom indexed ring-buffer. QVector was very inefficient when operating at the max buffer size as head trim of a line was actually 0(n-1). For eg max size buffers like 500k lines the cost was really really bad. MUSHclient dealt with this by using a linked list, plus a sparse position table so indexed access did not require walking from head every time, a nice solution but still not the best as random indexed access was still costly. The proper solution here is a custom indexed ring-buffer that brings the cost of trimming a line at head to O(1) while still having very fast random indexed access.


## Scope

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- Macro Send now and Replace now work identical to MUSHclient.
- Tab now allows navigation focus of all widgets in every congiration menu/panel.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

