### PR TITLE
Add support for MUSHclient %y, %a, and %Z logfile time format, fix % escaping edge case

### DIFF
--- a/src/helpers/TimeFormatUtils.cpp
+++ b/src/helpers/TimeFormatUtils.cpp
@@ -14,20 +14,23 @@
 
 namespace
 {
-	QString escapePercent(const QString &value)
+	QString fixupOrIdentity(const QString &value, const bool fixHtml,
+	                        const TimeFormatUtils::HtmlFixupFn fixupHtml)
 	{
-		auto result = value;
-		result.replace(QStringLiteral("%"), QStringLiteral("%%"));
-		return result;
+		if (!fixHtml || !fixupHtml)
+			return value;
+		return fixupHtml(value);
 	}
 
-	QString toQtDateFormat(const QString &format)
+	QString toQtDateFormat(const QString &format, const TimeFormatUtils::WorldTimeFormatContext &context,
+	                       const bool fixHtml, const TimeFormatUtils::HtmlFixupFn fixupHtml)
 	{
 		QString result;
 		result.reserve(format.size() + 16);
 
 		QString literal;
 		literal.reserve(format.size());
+		// Single-quote accumulated literal text so QLocale::toString renders it verbatim rather than as format codes.
 		const auto flushLiteral = [&]
 		{
 			if (literal.isEmpty())
@@ -69,6 +72,24 @@ namespace
 			case '%':
 				literal += QLatin1Char('%');
 				break;
+			case 'E':
+				literal += fixupOrIdentity(context.workingDir, fixHtml, fixupHtml);
+				break;
+			case 'N':
+				literal += fixupOrIdentity(context.worldName, fixHtml, fixupHtml);
+				break;
+			case 'P':
+				literal += fixupOrIdentity(context.playerName, fixHtml, fixupHtml);
+				break;
+			case 'F':
+				literal += fixupOrIdentity(context.worldDir, fixHtml, fixupHtml);
+				break;
+			case 'L':
+				literal += fixupOrIdentity(context.logDir, fixHtml, fixupHtml);
+				break;
+			case 'a':
+				token = QStringLiteral("ddd");
+				break;
 			case 'A':
 				token = QStringLiteral("dddd");
 				break;
@@ -87,6 +108,9 @@ namespace
 			case 'Y':
 				token = QStringLiteral("yyyy");
 				break;
+			case 'y':
+				token = QStringLiteral("yy");
+				break;
 			case 'H':
 				token = noPad ? QStringLiteral("H") : QStringLiteral("HH");
 				break;
@@ -101,6 +125,9 @@ namespace
 				break;
 			case 'p':
 				token = QStringLiteral("AP");
+				break;
+			case 'Z':
+				token = QStringLiteral("t");
 				break;
 			default:
 				literal += QLatin1Char('%');
@@ -175,21 +202,6 @@ QString TimeFormatUtils::formatWorldTime(const QDateTime &time, const QString &f
                                          const WorldTimeFormatContext &context, const bool fixHtml,
                                          HtmlFixupFn fixupHtml)
 {
-	auto       strFormat = format;
-
-	const auto fixupOrIdentity = [&](const QString &value)
-	{
-		if (!fixHtml || !fixupHtml)
-			return value;
-		return fixupHtml(value);
-	};
-
-	strFormat.replace(QStringLiteral("%E"), escapePercent(fixupOrIdentity(context.workingDir)));
-	strFormat.replace(QStringLiteral("%N"), escapePercent(fixupOrIdentity(context.worldName)));
-	strFormat.replace(QStringLiteral("%P"), escapePercent(fixupOrIdentity(context.playerName)));
-	strFormat.replace(QStringLiteral("%F"), escapePercent(fixupOrIdentity(context.worldDir)));
-	strFormat.replace(QStringLiteral("%L"), escapePercent(fixupOrIdentity(context.logDir)));
-
-	const auto qtFormat = toQtDateFormat(strFormat);
+	const auto qtFormat = toQtDateFormat(format, context, fixHtml, fixupHtml);
 	return QLocale::system().toString(time, qtFormat);
 }

--- a/src/helpers/TimeFormatUtils.cpp
+++ b/src/helpers/TimeFormatUtils.cpp
@@ -14,15 +14,15 @@
 
 namespace
 {
-	QString fixupOrIdentity(const QString &value, const bool fixHtml,
+	QString contextLiteral(const QString &value, const bool htmlFixupEnabled,
 	                        const TimeFormatUtils::HtmlFixupFn fixupHtml)
 	{
-		if (!fixHtml || !fixupHtml)
+		if (!htmlFixupEnabled || !fixupHtml)
 			return value;
 		return fixupHtml(value);
 	}
 
-	QString toQtDateFormat(const QString &format, const TimeFormatUtils::WorldTimeFormatContext &context,
+	QString toQtDateTimeFormat(const QString &format, const TimeFormatUtils::WorldTimeFormatContext &context,
 	                       const bool fixHtml, const TimeFormatUtils::HtmlFixupFn fixupHtml)
 	{
 		QString result;
@@ -73,19 +73,19 @@ namespace
 				literal += QLatin1Char('%');
 				break;
 			case 'E':
-				literal += fixupOrIdentity(context.workingDir, fixHtml, fixupHtml);
+				literal += contextLiteral(context.workingDir, fixHtml, fixupHtml);
 				break;
 			case 'N':
-				literal += fixupOrIdentity(context.worldName, fixHtml, fixupHtml);
+				literal += contextLiteral(context.worldName, fixHtml, fixupHtml);
 				break;
 			case 'P':
-				literal += fixupOrIdentity(context.playerName, fixHtml, fixupHtml);
+				literal += contextLiteral(context.playerName, fixHtml, fixupHtml);
 				break;
 			case 'F':
-				literal += fixupOrIdentity(context.worldDir, fixHtml, fixupHtml);
+				literal += contextLiteral(context.worldDir, fixHtml, fixupHtml);
 				break;
 			case 'L':
-				literal += fixupOrIdentity(context.logDir, fixHtml, fixupHtml);
+				literal += contextLiteral(context.logDir, fixHtml, fixupHtml);
 				break;
 			case 'a':
 				token = QStringLiteral("ddd");
@@ -202,6 +202,6 @@ QString TimeFormatUtils::formatWorldTime(const QDateTime &time, const QString &f
                                          const WorldTimeFormatContext &context, const bool fixHtml,
                                          HtmlFixupFn fixupHtml)
 {
-	const auto qtFormat = toQtDateFormat(format, context, fixHtml, fixupHtml);
+	const auto qtFormat = toQtDateTimeFormat(format, context, fixHtml, fixupHtml);
 	return QLocale::system().toString(time, qtFormat);
 }

--- a/tests/unit/tst_TimeFormatUtils.cpp
+++ b/tests/unit/tst_TimeFormatUtils.cpp
@@ -57,6 +57,22 @@ class tst_TimeFormatUtils : public QObject
 			const QString formatted = TimeFormatUtils::formatWorldTime(
 			    time, QStringLiteral("%E|%N|%P|%F|%L|%%"), context, false, nullptr);
 			QCOMPARE(formatted, QStringLiteral("work%dir|world%name|player%name|worlds%dir|logs%dir|%"));
+
+			const QString escapedDirective =
+			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%%E"), context, false, nullptr);
+			QCOMPARE(escapedDirective, QStringLiteral("%E"));
+
+			context.workingDir = QStringLiteral("~/QMudWorkingDir/");
+			const QString workingDirExpansion =
+			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%E"), context, false, nullptr);
+
+			QCOMPARE(workingDirExpansion, QStringLiteral("~/QMudWorkingDir/"));
+
+			context.worldName = QStringLiteral("Lara's mud");
+			const QString literalName =
+			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%N"), context, false, nullptr);
+			QCOMPARE(literalName, QStringLiteral("Lara's mud"));
+
 		}
 
 		void formatWorldTimeFixHtmlUsesProvidedCallback()
@@ -80,12 +96,24 @@ class tst_TimeFormatUtils : public QObject
 
 		void formatWorldTimeNoPadTokensAndUnknownTokenFallback()
 		{
-			const QDateTime time = QDateTime::fromString(QStringLiteral("2026-03-04T05:06:07"), Qt::ISODate);
+			const QDateTime time = QDateTime::fromString(QStringLiteral("2026-03-04T05:06:07Z"), Qt::ISODate);
 			QVERIFY(time.isValid());
 
 			const QString noPad = TimeFormatUtils::formatWorldTime(
 			    time, QStringLiteral("%#d-%#m-%Y %#H:%#M:%#S %#I"), {}, false, nullptr);
 			QCOMPARE(noPad, QStringLiteral("4-3-2026 5:6:7 5"));
+
+			const QString twoDigitYear =
+			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%y-%m-%d"), {}, false, nullptr);
+			QCOMPARE(twoDigitYear, QStringLiteral("26-03-04"));
+
+			const QString abbrevWeekday =
+			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%a"), {}, false, nullptr);
+			QCOMPARE(abbrevWeekday, QStringLiteral("Wed"));
+
+			const QString zoneName =
+			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%Z"), {}, false, nullptr);
+			QCOMPARE(zoneName, QStringLiteral("UTC"));
 
 			const QString unknown =
 			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%q %Y"), {}, false, nullptr);

--- a/tests/unit/tst_TimeFormatUtils.cpp
+++ b/tests/unit/tst_TimeFormatUtils.cpp
@@ -62,11 +62,11 @@ class tst_TimeFormatUtils : public QObject
 			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%%E"), context, false, nullptr);
 			QCOMPARE(escapedDirective, QStringLiteral("%E"));
 
-			context.workingDir = QStringLiteral("~/QMudWorkingDir/");
+			context.workingDir = QStringLiteral("work'dir%value");
 			const QString workingDirExpansion =
 			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%E"), context, false, nullptr);
 
-			QCOMPARE(workingDirExpansion, QStringLiteral("~/QMudWorkingDir/"));
+			QCOMPARE(workingDirExpansion, QStringLiteral("work'dir%value"));
 
 			context.worldName = QStringLiteral("Lara's mud");
 			const QString literalName =
@@ -109,11 +109,11 @@ class tst_TimeFormatUtils : public QObject
 
 			const QString abbrevWeekday =
 			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%a"), {}, false, nullptr);
-			QCOMPARE(abbrevWeekday, QStringLiteral("Wed"));
+			QCOMPARE(abbrevWeekday, QLocale::system().toString(time, "ddd"));
 
 			const QString zoneName =
 			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%Z"), {}, false, nullptr);
-			QCOMPARE(zoneName, QStringLiteral("UTC"));
+			QCOMPARE(zoneName, QLocale::system().toString(time, "t"));
 
 			const QString unknown =
 			    TimeFormatUtils::formatWorldTime(time, QStringLiteral("%q %Y"), {}, false, nullptr);


### PR DESCRIPTION
## Summary

Partially addresses #119, adding support for %y, %a, and %Z and fixes the %% escaping edge case.

Whether the rest of #119 is an issue depends on whether you want to completely clone strftime to get the rest of the format specifiers (of uncertain usefulness in a MU* client context, IMO), and is a judgment call I won't try to make.

Fixes #119 

## Scope

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Compatibility impact

Allows %a, %y, and %Z to be used for log filename format strings

## Validation

I have manually validated and also added unit test asserts.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

