### PR TITLE
Importer hotfix for plugins directory portable paths case. Tighten importer world in world references handling.

### DIFF
--- a/src/helpers/MushclientImportUtils.cpp
+++ b/src/helpers/MushclientImportUtils.cpp
@@ -207,11 +207,26 @@ namespace
 		QString normalizedRelative = normalized;
 		while (normalizedRelative.startsWith(QStringLiteral("./")))
 			normalizedRelative = normalizedRelative.mid(2);
-		if (!QFileInfo(normalizedRelative).isAbsolute() && !hasWindowsDrivePath(normalizedRelative) &&
-		    normalizedRelative.startsWith(QStringLiteral("worlds/"), Qt::CaseInsensitive))
+		const bool isAbsolute =
+		    QFileInfo(normalizedRelative).isAbsolute() || hasWindowsDrivePath(normalizedRelative);
+		QString portableRelative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(normalizedRelative);
+		if (portableRelative.startsWith(QStringLiteral("worlds/"), Qt::CaseInsensitive))
 		{
-			return dotRelativeStoragePath(destinationBaseDir,
-			                              QDir(destinationBaseDir).filePath(normalizedRelative));
+			const QString relativeWorld =
+			    QMudFileExtensions::canonicalizePathExtension(portableRelative.mid(7));
+			return dotRelativeStoragePath(
+			    destinationBaseDir,
+			    QDir(destinationBaseDir).filePath(QStringLiteral("worlds/") + relativeWorld));
+		}
+
+		if (!isAbsolute && !portableRelative.isEmpty() &&
+		    !portableRelative.startsWith(QStringLiteral("../")) && !QDir::isAbsolutePath(portableRelative))
+		{
+			return dotRelativeStoragePath(
+			    destinationBaseDir,
+			    QDir(destinationBaseDir)
+			        .filePath(QStringLiteral("worlds/") +
+			                  QMudFileExtensions::canonicalizePathExtension(portableRelative)));
 		}
 
 		const QString fileName = QFileInfo(normalized).fileName();
@@ -690,16 +705,16 @@ namespace
 	}
 
 	QString mappedSourcePluginStoragePath(const QString &sourceBaseDir, const QString &destinationBaseDir,
-	                                      const QString &relativeBaseDir, const QString &path)
+	                                      const QString &path)
 	{
 		QString normalized = stripOptionalQuotes(normalizePathString(path).trimmed());
 		if (normalized.isEmpty())
 			return normalized;
 
-		QStringList bases;
-		if (!relativeBaseDir.trimmed().isEmpty())
-			bases.push_back(relativeBaseDir);
-		bases.push_back(sourceBaseDir);
+		QStringList   bases;
+		const QString sourcePluginsDir = QDir(sourceBaseDir).filePath(QStringLiteral("worlds/plugins"));
+		if (!sourcePluginsDir.trimmed().isEmpty())
+			bases.push_back(sourcePluginsDir);
 
 		for (const QString &base : bases)
 		{
@@ -734,7 +749,7 @@ namespace
 		bool anyChanged = false;
 		for (const QString &item : items)
 		{
-			const QString value = mappedSourcePluginStoragePath(sourceBaseDir, destinationBaseDir, {}, item);
+			const QString value = mappedSourcePluginStoragePath(sourceBaseDir, destinationBaseDir, item);
 			if (value != item)
 				anyChanged = true;
 			migrated.push_back(value);
@@ -754,19 +769,63 @@ namespace
 		if (relativeBaseDir.trimmed().isEmpty())
 			return normalized;
 
-		const QString relativeBaseAbsolute = absolutePathFromBase(relativeBaseDir, normalized);
-		if (const QString relative = relativePathUnderBase(sourceBaseDir, relativeBaseAbsolute);
-		    !relative.isEmpty())
+		QString normalizedRelative = normalized;
+		while (normalizedRelative.startsWith(QStringLiteral("./")))
+			normalizedRelative = normalizedRelative.mid(2);
+		const bool hasLeadingSlashWindowsDrive =
+		    normalizedRelative.size() > 2 && normalizedRelative.at(0) == QLatin1Char('/') &&
+		    normalizedRelative.at(1).isLetter() && normalizedRelative.at(2) == QLatin1Char(':');
+		const bool isWindowsAbsolute = hasWindowsDrivePath(normalizedRelative) || hasLeadingSlashWindowsDrive;
+		const bool isNativeAbsolute  = QFileInfo(normalizedRelative).isAbsolute() && !isWindowsAbsolute;
+		const bool isAbsolute        = isNativeAbsolute || isWindowsAbsolute;
+		const QString sourceWorlds   = QDir(sourceBaseDir).filePath(QStringLiteral("worlds"));
+		if (isNativeAbsolute)
 		{
-			return relative;
+			const QString absolutePath = absolutePathFromBase(relativeBaseDir, normalized);
+			if (const QString relativeWorld = relativePathUnderBase(sourceWorlds, absolutePath);
+			    !relativeWorld.isEmpty())
+			{
+				return QStringLiteral("worlds/") + relativeWorld;
+			}
 		}
+
+		QString portableRelative = QMudPluginPathUtils::legacyPathRelativeToQmudHome(normalizedRelative);
+		if (portableRelative.startsWith(QStringLiteral("worlds/"), Qt::CaseInsensitive))
+			return portableRelative;
+		if (!isAbsolute && !portableRelative.isEmpty() &&
+		    !portableRelative.startsWith(QStringLiteral("../")) && !QDir::isAbsolutePath(portableRelative))
+		{
+			const QString baseRelative = relativePathUnderBase(sourceWorlds, relativeBaseDir);
+			if (!baseRelative.isEmpty() || QDir::cleanPath(relativeBaseDir) == QDir::cleanPath(sourceWorlds))
+			{
+				const QString combined =
+				    QDir::cleanPath(QDir(baseRelative.isEmpty() ? QStringLiteral(".") : baseRelative)
+				                        .filePath(portableRelative));
+				if (combined != QStringLiteral("..") && !combined.startsWith(QStringLiteral("../")) &&
+				    !QDir::isAbsolutePath(combined))
+				{
+					return QStringLiteral("worlds/") + combined;
+				}
+			}
+		}
+
+		if (!isAbsolute)
+		{
+			const QString relativeBaseAbsolute = absolutePathFromBase(relativeBaseDir, normalized);
+			if (const QString relativeWorld = relativePathUnderBase(sourceWorlds, relativeBaseAbsolute);
+			    !relativeWorld.isEmpty())
+			{
+				return QStringLiteral("worlds/") + relativeWorld;
+			}
+		}
+
 		return normalized;
 	}
 
 	QString migrateLegacyXmlPluginPathValue(const QString &sourceBaseDir, const QString &destinationBaseDir,
-	                                        const QString &relativeBaseDir, const QString &value)
+	                                        const QString &value)
 	{
-		return mappedSourcePluginStoragePath(sourceBaseDir, destinationBaseDir, relativeBaseDir, value);
+		return mappedSourcePluginStoragePath(sourceBaseDir, destinationBaseDir, value);
 	}
 
 	struct LegacyWorldMigrationResult
@@ -815,8 +874,7 @@ namespace
 			QStringList       migrated;
 			migrated.reserve(items.size());
 			for (const QString &item : items)
-				migrated.push_back(migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir,
-				                                                   relativeBaseDir, item));
+				migrated.push_back(migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir, item));
 			return migrated.join(QLatin1Char('*'));
 		}
 
@@ -954,19 +1012,18 @@ namespace
 					if (elementName.compare(QStringLiteral("include"), Qt::CaseInsensitive) == 0 &&
 					    attributeName.compare(QStringLiteral("name"), Qt::CaseInsensitive) == 0)
 					{
-						value = isPluginInclude
-						            ? migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir,
-						                                              relativeBaseDir, value)
-						            : migrateLegacyXmlPathValue(sourceBaseDir, destinationBaseDir,
-						                                        relativeBaseDir, QStringLiteral("File"),
-						                                        value, archiveLegacySource, activeConversions,
-						                                        warnings, convertedWorlds);
+						value =
+						    isPluginInclude
+						        ? migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir, value)
+						        : migrateLegacyXmlPathValue(sourceBaseDir, destinationBaseDir,
+						                                    relativeBaseDir, QStringLiteral("File"), value,
+						                                    archiveLegacySource, activeConversions, warnings,
+						                                    convertedWorlds);
 					}
 					else if (elementName.compare(QStringLiteral("plugin"), Qt::CaseInsensitive) == 0 &&
 					         attributeName.compare(QStringLiteral("source"), Qt::CaseInsensitive) == 0)
 					{
-						value = migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir,
-						                                        relativeBaseDir, value);
+						value = migrateLegacyXmlPluginPathValue(sourceBaseDir, destinationBaseDir, value);
 					}
 					else if (isPathListKey(attributeName) || shouldNormalizePathKey(attributeName))
 					{

--- a/tests/integration/tst_MushclientImportUtils.cpp
+++ b/tests/integration/tst_MushclientImportUtils.cpp
@@ -126,13 +126,19 @@ void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrit
 	writeFile(QDir(mush).filePath(QStringLiteral("worlds/nested/child.mcl")),
 	          QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
 	                            "name=\"nested-child\" /></muclient>"));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/TestSubdir/existing.mcl")),
+	          QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"utf-8\"?><muclient><world "
+	                            "name=\"mm-existing\" /></muclient>"));
 
 	writeFile(QDir(mush).filePath(QStringLiteral("worlds/main.mcl")),
 	          QStringLiteral(
 	              R"(<?xml version="1.0" encoding="utf-8"?>
 <muclient>
-<world script_file="lua/module.lua" log_file_name="%1" world_file="%2" missing_file="%3" fallback_file="%4" root_file="%5" relative_root_file="../shared/relative.mcl" nested_file="%6" />
+<world script_file="scripts/run.lua" module_file="lua/module.lua" log_file_name="%1" world_file="%2" missing_file="%3" fallback_file="%4" root_file="%5" relative_root_file="../shared/relative.mcl" nested_file="%6" fixture_existing_file="TestSubdir\existing.mcl" fixture_missing_file="TestSubdir\missing.mcl" fixture_absolute_missing_file="C:\MUSHclient\worlds\TestSubdir\missing_abs.mcl" fixture_portable_missing_file=".\worlds\TestSubdir\missing_portable.mcl" flat_missing_file="flat_missing.mcl" />
 <include name="plugins/Good.xml" plugin="y" />
+<include name="TestSubdir\fixture-plugin.xml" plugin="y" />
+<include name="C:\MUSHclient\worlds\plugins\TestSubdir\Absolute.xml" plugin="y" />
+<include name=".\worlds\plugins\TestSubdir\Portable.xml" plugin="y" />
 <plugin source="%7" />
 <plugin source="lua/module.lua" />
 <variables>
@@ -153,6 +159,15 @@ void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrit
 
 	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/Good.xml")),
 	          pluginXml(QStringLiteral("GoodPlugin"), QStringLiteral("0123456789abcdef01234567"),
+	                    QStringLiteral("Lua")));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/TestSubdir/fixture-plugin.xml")),
+	          pluginXml(QStringLiteral("AcceleratorsPlugin"), QStringLiteral("2123456789abcdef01234567"),
+	                    QStringLiteral("Lua")));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/TestSubdir/Absolute.xml")),
+	          pluginXml(QStringLiteral("AbsolutePlugin"), QStringLiteral("3123456789abcdef01234567"),
+	                    QStringLiteral("Lua")));
+	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/TestSubdir/Portable.xml")),
+	          pluginXml(QStringLiteral("PortablePlugin"), QStringLiteral("4123456789abcdef01234567"),
 	                    QStringLiteral("Lua")));
 	writeFile(QDir(mush).filePath(QStringLiteral("worlds/plugins/NotAPlugin.xml")),
 	          QByteArrayLiteral("<muclient><world name=\"x\"/></muclient>"));
@@ -216,10 +231,15 @@ void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrit
 	QMudMushclientImportUtils::importPreferencesDatabase(mush, destinationPreferencesDb, stats);
 
 	QCOMPARE(stats.errors, 0);
-	QCOMPARE(stats.warnings, 2);
+	QCOMPARE(stats.warnings, 7);
 	const QString warningText = stats.warningDetails.join(QLatin1Char('\n'));
 	QVERIFY(warningText.contains(QStringLiteral("missing.mcl")));
+	QVERIFY(warningText.contains(QStringLiteral("../shared/relative.mcl")));
 	QVERIFY(warningText.contains(QStringLiteral("ini-missing.mcl")));
+	QVERIFY(warningText.contains(QStringLiteral("TestSubdir/missing.mcl")));
+	QVERIFY(warningText.contains(QStringLiteral("TestSubdir/missing_abs.mcl")));
+	QVERIFY(warningText.contains(QStringLiteral("TestSubdir/missing_portable.mcl")));
+	QVERIFY(warningText.contains(QStringLiteral("flat_missing.mcl")));
 	QCOMPARE(stats.worldsConverted, 9);
 	QCOMPARE(stats.configsImported, 1);
 	QCOMPARE(stats.preferenceDatabasesImported, 1);
@@ -233,7 +253,8 @@ void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrit
 	QFile converted(QDir(home).filePath(QStringLiteral("worlds/main.qdl")));
 	QVERIFY(converted.open(QIODevice::ReadOnly));
 	const QByteArray convertedData = converted.readAll();
-	QVERIFY(convertedData.contains(R"(script_file="./lua/module.lua")"));
+	QVERIFY(convertedData.contains(R"(script_file="./scripts/run.lua")"));
+	QVERIFY(convertedData.contains(R"(module_file="./lua/module.lua")"));
 	QVERIFY(convertedData.contains(R"(log_file_name="./logs/main.log")"));
 	QVERIFY(convertedData.contains(R"(world_file="./worlds/outside.qdl")"));
 	QVERIFY(convertedData.contains(R"(missing_file="./worlds/missing.qdl")"));
@@ -241,7 +262,16 @@ void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrit
 	QVERIFY(convertedData.contains(R"(root_file="./worlds/shared.qdl")"));
 	QVERIFY(convertedData.contains(R"(relative_root_file="./worlds/relative.qdl")"));
 	QVERIFY(convertedData.contains(R"(nested_file="./worlds/nested/child.qdl")"));
+	QVERIFY(convertedData.contains(R"(fixture_existing_file="./worlds/TestSubdir/existing.qdl")"));
+	QVERIFY(convertedData.contains(R"(fixture_missing_file="./worlds/TestSubdir/missing.qdl")"));
+	QVERIFY(convertedData.contains(R"(fixture_absolute_missing_file="./worlds/TestSubdir/missing_abs.qdl")"));
+	QVERIFY(convertedData.contains(
+	    R"(fixture_portable_missing_file="./worlds/TestSubdir/missing_portable.qdl")"));
+	QVERIFY(convertedData.contains(R"(flat_missing_file="./worlds/flat_missing.qdl")"));
 	QVERIFY(convertedData.contains(R"(name="./worlds/plugins/Good.xml")"));
+	QVERIFY(convertedData.contains(R"(name="./worlds/plugins/TestSubdir/fixture-plugin.xml")"));
+	QVERIFY(convertedData.contains(R"(name="./worlds/plugins/TestSubdir/Absolute.xml")"));
+	QVERIFY(convertedData.contains(R"(name="./worlds/plugins/TestSubdir/Portable.xml")"));
 	QVERIFY(convertedData.contains(R"(source="./worlds/plugins/ExternalPlugin.xml")"));
 	QVERIFY(convertedData.contains(R"(source="./worlds/plugins/module.lua")"));
 	QVERIFY(convertedData.contains(QByteArrayLiteral(">./map.DB<")));
@@ -255,9 +285,15 @@ void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrit
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/outside.qdl"))).exists());
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/shared.qdl"))).exists());
 	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("shared.qdl"))).exists());
-	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/relative.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/relative.qdl"))).exists());
 	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("shared/relative.qdl"))).exists());
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/nested/child.qdl"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/TestSubdir/existing.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/TestSubdir/missing.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/TestSubdir/missing_abs.qdl"))).exists());
+	QVERIFY(
+	    !QFileInfo(QDir(home).filePath(QStringLiteral("worlds/TestSubdir/missing_portable.qdl"))).exists());
+	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/flat_missing.qdl"))).exists());
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/ini-only.qdl"))).exists());
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/caf\u00e9.qdl"))).exists());
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/price\u20ac.qdl"))).exists());
@@ -285,6 +321,12 @@ void tst_MushclientImportUtils::importsDirectoryReadOnlyWithFiltersAndNoOverwrit
 	QCOMPARE(existing.readAll(), QByteArrayLiteral("destination"));
 
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/Good.xml"))).exists());
+	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/TestSubdir/fixture-plugin.xml")))
+	            .exists());
+	QVERIFY(
+	    QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/TestSubdir/Absolute.xml"))).exists());
+	QVERIFY(
+	    QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/TestSubdir/Portable.xml"))).exists());
 	QVERIFY(QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/data.dat"))).exists());
 	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/NotAPlugin.xml"))).exists());
 	QVERIFY(!QFileInfo(QDir(home).filePath(QStringLiteral("worlds/plugins/VbPlugin.xml"))).exists());


### PR DESCRIPTION
Tighten importer world in world references handling.

## Summary

The new importer was failing to write the plugin paths properly if they were originally in the MC portable form, relating to plugins directory eg `subdir\plugin.xml` referring to `C:\MUSHclient\worlds\plugins\subdir\plugin.xml` and was falling back to loosing `subdir` in the written path. This also tightens the migration of world files referenced in other world files.

## Scope

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Compatibility impact

Describe impact on:

- MUSHclient streamlined migration.

## Validation

- Tests.
- Manual tests.

## Checklist

- [x] I verified behavior manually or with tests.
- [x] I updated docs when relevant.
- [x] I did not introduce unrelated changes.

